### PR TITLE
Use git/git repository in links

### DIFF
--- a/app/views/downloads/index.html.haml
+++ b/app/views/downloads/index.html.haml
@@ -19,7 +19,7 @@
             %td= link_to "Solaris", "/download/linux", {:class => 'icon solaris'}
 
       %p
-        <a href="http://code.google.com/p/git-core/downloads/list">Older releases</a> are available and the <a href="https://github.com/gitster/git">Git source repository</a> is on GitHub.
+        <a href="http://code.google.com/p/git-core/downloads/list">Older releases</a> are available and the <a href="https://github.com/git/git">Git source repository</a> is on GitHub.
 
 
     %div.column-right
@@ -54,4 +54,4 @@
     git clone https://github.com/git/git.git
 
   %p
-    You can also always browse the current contents of the git repository using the <a href="#">web interface</a>.
+    You can also always browse the current contents of the git repository using the <a href="https://github.com/git/git">web interface</a>.


### PR DESCRIPTION
The clone URL was using `git/git` but one link was using `gitster/git` and the other one was dead.
