### PR TITLE
Miswording: Should be "commit" not "push"

### DIFF
--- a/app/views/about/index.html.haml
+++ b/app/views/about/index.html.haml
@@ -107,7 +107,7 @@
       In some cases the commands don't match up exactly. Here, matching on the lowest
       common denominator was attempted. For example, the 'commit' tests also include
       the time to push for Git, though most of the time you would not actually be pushing
-      to the server immediately after a push where the two commands cannot be separated
+      to the server immediately after a commit where the two commands cannot be separated
       in SVN.
     %p
       All of these times are in seconds.


### PR DESCRIPTION
When explaining that the benchmark numbers for commit include the push time and that you generally don't do one after another it seems the word push beat up the word "commit" for no reason in the last sentence of a paragraph.

This fixes that.
