### PR TITLE
Mention the Google Groups git-user list

### DIFF
--- a/app/views/community/index.html.haml
+++ b/app/views/community/index.html.haml
@@ -34,6 +34,9 @@
   %p
     The <a href="http://dir.gmane.org/gmane.comp.version-control.git">archive of the Git mailing list</a> can be found on Gmane. 
 
+  %p
+    There is also <a href="https://groups.google.com/forum/?fromgroups#!forum/git-users">Git user mailing list</a> on Google Groups which is a nice place for beginners to ask about anything.
+
   %h2 IRC Channel
 
   %p


### PR DESCRIPTION
The old website mentioned the Google Group. Can't the new one too?
