### PR TITLE
Just a simple typo in the error pages.

### DIFF
--- a/app/views/site/404.html.haml
+++ b/app/views/site/404.html.haml
@@ -4,7 +4,7 @@
 %h1 That page doesn't exist.
 
 %p
-  We recently redesigned the site and older URLs may now lead to missing pages. We apologize for the inconvience.
+  We recently redesigned the site and older URLs may now lead to missing pages. We apologize for the inconvenience.
 
 %nav
   %ul

--- a/app/views/site/500.html.haml
+++ b/app/views/site/500.html.haml
@@ -4,7 +4,7 @@
 %h1 Internal server error
 
 %p
-  There was an error processing your request. We have been notified of the error and will investigate ASAP. We apologize for the inconvience.
+  There was an error processing your request. We have been notified of the error and will investigate ASAP. We apologize for the inconvenience.
 
 %nav
   %ul


### PR DESCRIPTION
I've assumed that the html pages under public get reconstructed from the haml counterparts and thus have only fixed the haml ones. Stupidly don't have rake/ror/bundler installed on my workstation at the moment, so I can't verify, but these typos being what they are, I don't think it'll be a major issue.
