### PR TITLE
download_linux: Fedora renamed git-core to git years ago

### DIFF
--- a/app/views/downloads/download_linux.html.erb
+++ b/app/views/downloads/download_linux.html.erb
@@ -9,7 +9,7 @@
   <code>$ apt-get install git-core</code>
 
   <h3>Fedora</h3>
-  <code>$ yum install git-core</code>
+  <code>$ yum install git</code>
 
   <h3>Gentoo</h3>
   <code>$ emerge --ask --verbose dev-vcs/git</code>


### PR DESCRIPTION
While yum install git-core still works, this is only because the Fedora
packages have a virtual git-core provide in the main git package.  The
package was renamed from git-core to git with git-1.5.4.3, in Feb 2008¹.
Use the preferred package name to guard against failures if the git-core
provides should ever be dropped.

It might be worth noting that to get all git packages, there is a
git-all metapackage which pulls in the various git subpackages.  Support
for cvs, emacs, git daemon, git-gui, gitk, gitweb, send-email, and
subversion are in such subpackages.

¹ http://pkgs.fedoraproject.org/gitweb/?p=git.git;a=commit;h=0c4a11ca
