### PR TITLE
Fix Windows Icon when viewing page on a Mac

### DIFF
--- a/app/assets/javascripts/site.js
+++ b/app/assets/javascripts/site.js
@@ -33,7 +33,6 @@ var DownloadBox = {
       $(".monitor").removeClass("linux");
       $(".monitor").addClass("mac");
       $("#download-link").text("Download for Mac").attr("href", "/download/mac");
-      $("#alt-link").removeClass("windows").addClass("mac");
       $("#alt-link").text("Windows Build").attr("href", "/download/win");
       $("#gui-os-filter").attr('data-os', 'mac');
       $("#gui-os-filter").text("Only show GUIs for my OS (Mac)")


### PR DESCRIPTION
The page was showing an Apple logo for the Windows download when viewing the site on OS X.

![Wrong Icon on OS X](http://i.imgur.com/5GCZ1.png)

This patch fixes that.
