### PR TITLE
Use platform name instead of Mac for "Download a GUI"

### DIFF
--- a/app/views/downloads/downloading.html.haml
+++ b/app/views/downloads/downloading.html.haml
@@ -35,7 +35,7 @@
       <a href="/downloads/guis">
       <img src="/images/icons/nav-download-gui.png" />
       <h3>Download a GUI</h3>
-      <p>Several free and commercial GUI tools are available for the Mac platform.</p>
+      <p>Several free and commercial GUI tools are available for the #{@platform.capitalize} platform.</p>
       </a>
     %li
       <a href="/community">


### PR DESCRIPTION
fixes #17
