### PR TITLE
Request to make the Microsoft reference go to the ASP.Net Web Stack product

### DIFF
--- a/app/views/site/index.html.haml
+++ b/app/views/site/index.html.haml
@@ -55,7 +55,7 @@
   %ul
     %li= link_to "Google", "https://github.com/google", {:class => 'google'}
     %li= link_to "Facebook", "https://github.com/facebook", {:class => 'facebook'}
-    %li= link_to "Microsoft", "https://github.com/WindowsAzure", {:class => 'microsoft'}
+    %li= link_to "Microsoft", "http://aspnetwebstack.codeplex.com", {:class => 'microsoft'}
     %li= link_to "Twitter", "https://github.com/twitter", {:class => 'twitter'}
     %li= link_to "LinkedIn", "https://github.com/linkedin", {:class => 'linked-in'}
     %li= link_to "Linux", "http://git.kernel.org/?p=linux/kernel/git/torvalds/linux-2.6.git;a=summary", {:class => 'linux'}


### PR DESCRIPTION
This may be better, the ASP.Net team uses Git everyday on CodePlex:
http://weblogs.asp.net/scottgu/archive/2012/03/27/asp-net-mvc-web-api-razor-and-open-source.aspx
