### PR TITLE
fixed FlippyBook for webkit with no js

### DIFF
--- a/app/assets/javascripts/site.js
+++ b/app/assets/javascripts/site.js
@@ -286,6 +286,7 @@ var FlippyBook = {
       FlippyBook.threeDee = true;
       $('#book-container').addClass('three-dee');
     }
+    $('#about-book').addClass('visible');
   },
 
   observeOpenCloseClicks: function() {

--- a/app/assets/stylesheets/book.css.scss
+++ b/app/assets/stylesheets/book.css.scss
@@ -46,18 +46,18 @@
   position: absolute;
   left: 4px;
   top: 0;
-  @include transform-style(preserve-3d);
-  @include transition-duration(1.2s);
 }
 .webkit #flippy-book #book-cover {
   left: auto;
   right: 6px;    
+  @include transform-style(preserve-3d);
+  @include transition-duration(1.2s);
 }
-#flippy-book #book-cover.open {
+.webkit #flippy-book #book-cover.open {
   @include transform-origin(-1px, 0);
   @include rotateY(-180deg);
 }
-#flippy-book #book-cover.close {
+.webkit #flippy-book #book-cover.close {
   @include transform-origin(0, 0);
 }
 #flippy-book #book-cover-outside {
@@ -113,13 +113,16 @@
 }
 
 #about-book {
-  @include inline-block;
+  display: none;
   text-indent: 85px;
   text-align: center;
   font-size: 12px;
   color: $light-font-color;
   padding-left: 22px;
   background: transparent url(/images/icons/info.png) 85px 0 no-repeat;
+  &.visible {
+    @include inline-block;
+  }
 }
 
 ol.book-toc {


### PR DESCRIPTION
The front cover of the Pro Git book now renders properly when JS is disabled on webkit browsers. Since we can't even do the vanilla transition to show the book info w/o JS, I've hidden the "About this Book" link for all non-JS users. We could always link that to a standalone page about the book if it's an issue.
