### PR TITLE
search now works when JS is disabled

### DIFF
--- a/app/views/shared/_header.html.haml
+++ b/app/views/shared/_header.html.haml
@@ -3,7 +3,7 @@
   %span#tagline
     =raw random_tagline
 
-  %form#search
-    <input id="search-text" placeholder="Search entire site..." autocomplete="off" type="text" />
+  %form#search{:action => '/search/results'}
+    <input id="search-text" name="search" placeholder="Search entire site..." autocomplete="off" type="text" />
 
   %div#search-results


### PR DESCRIPTION
I couldn't get elasticsearch configured locally, but it looks like the
GET string is the same with and without JS now. This was mentioned by
@encukou in #29 and should close that issue once this fix is verified.
