### PR TITLE
added links to ebook formats in sidebar

### DIFF
--- a/app/assets/stylesheets/book.css.scss
+++ b/app/assets/stylesheets/book.css.scss
@@ -114,12 +114,12 @@
 
 #about-book {
   display: none;
-  text-indent: 85px;
+  text-indent: 40px;
   text-align: center;
   font-size: 12px;
   color: $light-font-color;
   padding-left: 22px;
-  background: transparent url(/images/icons/info.png) 85px 0 no-repeat;
+  background: transparent url(/images/icons/info.png) 40px 0 no-repeat;
   &.visible {
     @include inline-block;
   }

--- a/app/views/doc/_ebooks.html.erb
+++ b/app/views/doc/_ebooks.html.erb
@@ -1,0 +1,1 @@
+<p>Download this book in <a href="https://github.s3.amazonaws.com/media/progit.en.pdf">PDF</a>, <a href="https://github.s3.amazonaws.com/media/pro-git.en.mobi">mobi</a>, or <a href="https://github.s3.amazonaws.com/media/progit.epub">ePub</a> form for free.</p>

--- a/app/views/doc/_translations.html.erb
+++ b/app/views/doc/_translations.html.erb
@@ -4,7 +4,7 @@ This book is translated into
   <a href="/book/zh">Chinese</a>, 
   <a href="/book/fr">French</a>,
   <a href="/book/ja">Japanese</a> and 
-  <a href="/book/nl">Dutch</a>
+  <a href="/book/nl">Dutch</a>.
 </p>
 
 <p>
@@ -17,7 +17,7 @@ Partial translations available in
   <a href="/book/mk">Macedonian</a>,
   <a href="/book/pl">Polish</a>,
   <a href="/book/th">Thai</a> and
-  <a href="/book/ru">Russian</a>
+  <a href="/book/ru">Russian</a>.
 </p>
 
 <hr class="sidebar"/>

--- a/app/views/doc/book.html.erb
+++ b/app/views/doc/book.html.erb
@@ -3,6 +3,7 @@
 <%- @page_title = "Git - Book" %>
 
 <% content_for :sidebar do %>
+  <%= render 'ebooks' %>
   <%= render 'translations' %>
 <% end %>
 

--- a/app/views/doc/book_section.html.erb
+++ b/app/views/doc/book_section.html.erb
@@ -2,6 +2,7 @@
 <% @subsection = 'book' %>
 
 <% content_for :sidebar do %>
+  <%= render 'ebooks' %>
   <%= render 'translations' %>
   <%= render 'shared/related' %>
 <% end %>

--- a/app/views/doc/index.html.haml
+++ b/app/views/doc/index.html.haml
@@ -57,7 +57,7 @@
                 %h2
                   = chapter.number.to_s + '.'
                   %a{:href=>"/book/#{@book.code}/#{chapter.sections.first.slug}"}= chapter.title
-          <a href="#" id="about-book">About this book</a>
+          <a href="#" id="about-book">Book information and downloads</a>
 
 
   %h2 Videos

--- a/app/views/shared/_book.html.erb
+++ b/app/views/shared/_book.html.erb
@@ -1,5 +1,6 @@
 <div class="callout">
   <p>The entire <strong><a href="/book">Pro Git book</a></strong> written
   by Scott Chacon is available to <a href="/book">read online for free</a>.
-  Dead tree versions are available on <a href="http://www.amazon.com/gp/product/1430218339?ie=UTF8&tag=prgi-20&linkCode=as2&camp=1789&creative=390957&creativeASIN=1430218339">Amazon.com</a>.</>
+  Dead tree versions are available on <a href="http://www.amazon.com/gp/product/1430218339?ie=UTF8&tag=prgi-20&linkCode=as2&camp=1789&creative=390957&creativeASIN=1430218339">Amazon.com</a>. 
+  </p>
 </div>


### PR DESCRIPTION
Carlos pointed out that it's not very easy to find links to the electronic versions of the Pro Git book. Previously, the only place to find the links were behind the flippy book cover on the top level Documentation page. Now every book page will have the three download links in the sidebar.
