### PR TITLE
Fix two variable names for DocsController#related_update

### DIFF
--- a/app/controllers/doc_controller.rb
+++ b/app/controllers/doc_controller.rb
@@ -124,7 +124,7 @@ class DocController < ApplicationController
 
     fromc = params[:from_content]
     toc = params[:to_content]
-    RelatedItem.create_both(from, to)
+    RelatedItem.create_both(fromc, toc)
     render :text => 'ok'
   end
 


### PR DESCRIPTION
When to generate related items via `UPDATE_TOKEN=something rake related`, but got 500 error about undefined variable name.

``` ruby
NameError (undefined local variable or method `from' for #<DocController:0x007fae9b52a390>):
  app/controllers/doc_controller.rb:127:in `related_update'
```

I fixed two variable names.
