### PR TITLE
Search fix for #122

### DIFF
--- a/app/models/doc.rb
+++ b/app/models/doc.rb
@@ -16,7 +16,7 @@ class Doc < ActiveRecord::Base
       }
     }
 
-    terms = term.split(' ')
+    terms = term.split(/\s|-/)
     terms.each do |terma|
       query_options['bool']['should'] << { "prefix" => { "name" => { "value" => terma, "boost" => 12.0 } } }
       query_options['bool']['should'] << { "term" => { "text" => terma } }

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -93,7 +93,7 @@ class Section < ActiveRecord::Base
       }
     }
 
-    terms = term.split(' ')
+    terms = term.split(/\s|-/)
     terms.each do |terma|
       query_options['bool']['should'] << { "prefix" => { "section" => { "value" => terma, "boost" => 12.0 } } }
       query_options['bool']['should'] << { "term" => { "html" => terma } }


### PR DESCRIPTION
The search only works great when user enters any keywords with space, but when entering the keywords with dash will get empty result.

See #122.

This fix should accept space and dash. Not sure about other non-characters, but so far I know the dash is mostly used for documentations and links.
