### PR TITLE
The `<tt>` tag is obsolete

### DIFF
--- a/templates/section_listing.html.erb
+++ b/templates/section_listing.html.erb
@@ -1,5 +1,5 @@
 <div class="listingblock">
   <div class="content">
-    <pre><tt><%= content %></tt></pre>
+    <pre><%= content %></pre>
   </div>
 </div>


### PR DESCRIPTION
At least, according to https://developer.mozilla.org/en/HTML/Element/tt
