### PR TITLE
Fixes #125: makes "Search as you type" work on Firefox

### DIFF
--- a/app/assets/javascripts/site.js
+++ b/app/assets/javascripts/site.js
@@ -133,7 +133,7 @@ var Search = {
       Search.currentSearch = term;
       $.get("/search", {search: term}, function(results) {
         $("#search-results").html(results);
-      });
+      }, 'html');
     };
   },
 


### PR DESCRIPTION
Firefox is stricter about datatype than other browsers. Specified 'html'
(otherwise it was xml) datatype for $.get("/search", ...) explicitly.
