### PR TITLE
Fixes #108: makes /about work with javascript disabled

### DIFF
--- a/app/assets/javascripts/site.js
+++ b/app/assets/javascripts/site.js
@@ -228,6 +228,7 @@ var AboutContent = {
 
   init: function() {
     if ($('body#about').length === 0) return;
+    $('section.about').css('display:none');
     AboutContent.observeNav();
     AboutContent.observePopState();
     AboutContent.showSection(AboutContent.getSection());

--- a/app/assets/stylesheets/layout.css.scss
+++ b/app/assets/stylesheets/layout.css.scss
@@ -2,7 +2,7 @@ body {
   font-size: $base-font-size;
   line-height: $base-line-height;
   font-family: $base-font-family;
-  color: $font-color; 
+  color: $font-color;
   background: #f0efe7 url(/images/bg/body.jpg);
 }
 
@@ -54,7 +54,7 @@ aside {
   }
   .callout {
     background-color: $callout-color;
-    @include border-radius(3px);  
+    @include border-radius(3px);
     padding: 8px 14px 4px 14px;
     margin-bottom: 1.4em;
     p {
@@ -120,7 +120,7 @@ aside nav ul {
       display: block;
       color: #413932;
       &.active, &:hover {
-        color: $orange; 
+        color: $orange;
       }
     }
     ul {
@@ -156,7 +156,6 @@ aside nav ul {
 }
 
 section.about {
-  display: none;
   &.current {
     display: block;
   }
@@ -244,7 +243,7 @@ footer {
   padding: 20px 0 40px 0;
   color: $light-font-color;
   font-size: 12px;
-  line-height: $base-line-height * 0.7; 
+  line-height: $base-line-height * 0.7;
   a {
     color: darken($light-font-color, 35%);
     &:hover {
@@ -258,7 +257,7 @@ footer {
   }
   .sfc-member {
     float: right;
-    text-align: right; 
+    text-align: right;
   }
 }
 

--- a/app/views/about/index.html.haml
+++ b/app/views/about/index.html.haml
@@ -9,17 +9,17 @@
 
   %ol#about-nav
     %li
-      <a href="#" class="current three-line" id="nav-branching-and-merging" data-section-id="branching-and-merging">Branching and Merging</a>
+      <a href="#branching-and-merging" class="current three-line" id="nav-branching-and-merging" data-section-id="branching-and-merging">Branching and Merging</a>
     %li
-      <a href="#" class="two-line" id="nav-small-and-fast" data-section-id="small-and-fast">Small and Fast</a>
+      <a href="#small-and-fast" class="two-line" id="nav-small-and-fast" data-section-id="small-and-fast">Small and Fast</a>
     %li
-      <a href="#" class="one-line" id="nav-distributed" data-section-id="distributed">Distributed</a>
+      <a href="#distributed" class="one-line" id="nav-distributed" data-section-id="distributed">Distributed</a>
     %li
-      <a href="#" class="two-line" id="nav-info-assurance" data-section-id="info-assurance">Data Assurance</a>
+      <a href="#info-assurance" class="two-line" id="nav-info-assurance" data-section-id="info-assurance">Data Assurance</a>
     %li
-      <a href="#" class="two-line" id="nav-staging-area" data-section-id="staging-area">Staging Area</a>
+      <a href="#staging-area" class="two-line" id="nav-staging-area" data-section-id="staging-area">Staging Area</a>
     %li
-      <a href="#" class="three-line" id="nav-free-and-open-source" data-section-id="free-and-open-source">Free and Open Source</a>
+      <a href="#free-and-open-source" class="three-line" id="nav-free-and-open-source" data-section-id="free-and-open-source">Free and Open Source</a>
 
   %section.about#branching-and-merging.current
     %h2 Branching and Merging
@@ -53,7 +53,7 @@
       There are ways to accomplish some of this with other systems, but the work involved is much more difficult and error-prone. Git makes this process incredibly easy and it changes the way most developers work when they learn it.
 
     %div.bottom-nav
-      =link_to "Small and Fast →", "#", {:class => 'next', 'data-section-id' => 'small-and-fast'}
+      =link_to "Small and Fast →", "#small-and-fast", {:class => 'next', 'data-section-id' => 'small-and-fast'}
 
 
   %section.about#small-and-fast
@@ -67,7 +67,7 @@
 
     %h3 Benchmarks
 
-    %p 
+    %p
       Let's see how common operations stack up against
       Subversion, a common centralized version control system that is similar
       to CVS or Perforce. <em>Smaller is faster.</em>
@@ -99,7 +99,7 @@
           =raw gchart("Blame", [['git', 1.91], ['svn', 3.04]])
         %td
           =raw gchart("Size", [['git', 181], ['svn', 132]])
-    %p 
+    %p
       For testing, large AWS instances were set up in the same availability zone.
       Git and SVN were installed on both machines, the Ruby repository was copied to
       both Git and SVN servers, and common operations were performed on both.
@@ -139,7 +139,7 @@
       one or two orders of magnitude faster than SVN</strong>, even under ideal conditions
       for SVN.
     %p
-      One place where Git is slower is in the initial clone operation. 
+      One place where Git is slower is in the initial clone operation.
       Here, Git is downloading the entire history rather than only the latest
       version. As seen in the above charts, it's not considerably slower for an operation
       that is only performed once.
@@ -161,8 +161,8 @@
       and storing data on the client side.
 
     %div.bottom-nav
-      =link_to "← Branching and Merging", "#", {:class => 'previous', 'data-section-id' => 'branching-and-merging'}
-      =link_to "Distributed →", "#", {:class => 'next', 'data-section-id' => 'distributed'}
+      =link_to "← Branching and Merging", "#branching-and-merging", {:class => 'previous', 'data-section-id' => 'branching-and-merging'}
+      =link_to "Distributed →", "#distributed", {:class => 'next', 'data-section-id' => 'distributed'}
 
   %section.about#distributed
     %h2 Distributed
@@ -206,8 +206,8 @@
       <img src="/images/about/workflow-c.png" alt="Workflow C" />
 
     %div.bottom-nav
-      =link_to "← Small and Fast", "#", {:class => 'previous', 'data-section-id' => 'small-and-fast'}
-      =link_to "Data Assurance →", "#", {:class => 'next', 'data-section-id' => 'info-assurance'}
+      =link_to "← Small and Fast", "#small-and-fast", {:class => 'previous', 'data-section-id' => 'small-and-fast'}
+      =link_to "Data Assurance →", "#info-assurance", {:class => 'next', 'data-section-id' => 'info-assurance'}
 
   %section.about#info-assurance
     %h2 Data Assurance
@@ -215,7 +215,7 @@
     %p
       The data model that Git uses ensures the cryptographic integrity of every bit
       of your project.  Every file and commit is checksummed and retrieved by its
-      checksum when checked back out. It's impossible to get anything out of Git 
+      checksum when checked back out. It's impossible to get anything out of Git
       other than the <strong>exact bits you put in</strong>.
 
     %img{:src => "/images/assurance.png"}
@@ -224,15 +224,15 @@
       It is also impossible to change any file, date, commit message, or any other
       data in a Git repository without changing the IDs of everything after it.
       This means that if you have a commit ID, you can be assured not only that
-      your project is exactly the same as when it was committed, but 
+      your project is exactly the same as when it was committed, but
       that nothing in its history was changed.
 
     %p
       Most centralized version control systems provide no such integrity by default.
 
     %div.bottom-nav
-      =link_to "← Distributed", "#", {:class => 'previous', 'data-section-id' => 'distributed'}
-      =link_to "Staging Area →", "#", {:class => 'next', 'data-section-id' => 'staging-area'}
+      =link_to "← Distributed", "#distributed", {:class => 'previous', 'data-section-id' => 'distributed'}
+      =link_to "Staging Area →", "#staging-area", {:class => 'next', 'data-section-id' => 'staging-area'}
 
   %section.about#staging-area
     %h2 Staging Area
@@ -256,8 +256,8 @@
       <img src="/images/about/index2.png" alt="Index 2" />
 
     %div.bottom-nav
-      =link_to "← Data Assurance", "#", {:class => 'previous', 'data-section-id' => 'info-assurance'}
-      =link_to "Free and Open Source →", "#", {:class => 'next', 'data-section-id' => 'free-and-open-source'}
+      =link_to "← Data Assurance", "#info-assurance", {:class => 'previous', 'data-section-id' => 'info-assurance'}
+      =link_to "Free and Open Source →", "#free-and-open-source", {:class => 'next', 'data-section-id' => 'free-and-open-source'}
 
 
   %section.about#free-and-open-source
@@ -285,4 +285,4 @@
         %li Use source code from the Git repository in a project under a different license without permission
 
     %div.bottom-nav
-      =link_to "← Staging Area", "#", {:class => 'previous', 'data-section-id' => 'staging-area'}
+      =link_to "← Staging Area", "#staging-area", {:class => 'previous', 'data-section-id' => 'staging-area'}


### PR DESCRIPTION
Make /about work with javascript disabled:
- Remove display:none for about sections from css
- Add display:none for about sections to javascript init of AboutContent
- Make links to sections work when javascript is disabled

Considered, but decided against:
- Hide div.bottom-nav when javascript is disabled
