### PR TITLE
book: url-encode section slugs

### DIFF
--- a/app/views/doc/book.html.erb
+++ b/app/views/doc/book.html.erb
@@ -22,7 +22,7 @@
           <% if !section.title.empty? %>
             <li>
               <%= chapter.number %>.<%= section.number %> 
-              <a href="/book/<%= @book.code %>/<%= section.slug %>"><%=raw section.title %></a>
+              <a href="/book/<%= @book.code %>/<%= u(section.slug) %>"><%=raw section.title %></a>
             </li>
           <% end %>
         <% end %>


### PR DESCRIPTION
The Spanish version of the book contains a section title that ends in "?", which needs to be URL-encoded.

This fixes #142. My only hesitation is that this fixes just one spot. Is there a plan for how quoting like this should happen in general, or should it just be done on an as-needed basis. I don't actually do web apps, so this is all magical to me.
