### PR TITLE
Improve erratic search results

### DIFF
--- a/app/assets/javascripts/site.js
+++ b/app/assets/javascripts/site.js
@@ -97,7 +97,7 @@ var Search = {
 
   observeTextEntry: function() {
     $('form#search input').keyup(function(e) {
-      Search.runSearch(e.which);
+      Search.runSearch();
     });
 
     $('form#search input').keydown(function(e) {
@@ -131,17 +131,28 @@ var Search = {
     });
   },
 
-  runSearch: function(lastLetter) {
-    Search.searching = true;
+  runSearch: function() {
     var term = $('#search-text').val();
     if(term.length < 2) { return false };
 
-    if(term != Search.currentSearch) {
-      Search.currentSearch = term;
-      $.get("/search", {search: term}, function(results) {
-        $("#search-results").html(results);
-      }, 'html');
-    };
+    if(!Search.searching) {
+      Search.searching = true;
+
+      if(term != Search.currentSearch) {
+        Search.currentSearch = term;
+        $.get("/search", {search: term}, function(results) {
+          $("#search-results").html(results);
+          Search.searching = false;
+        }, 'html');
+      };
+    }
+    else {
+      clearTimeout(Search.timeout);
+      Search.timeout = setTimeout(function() {
+        Search.searching = false;
+        Search.runSearch();
+      }, 300);
+    }
   },
 
   selectResultOption: function() {


### PR DESCRIPTION
Sometimes search was showing non-optimal results. This happened because
earlier requests would respond slower. You can reproduce that by quickly
typing 'git push' multiple times into the searchbox. I was able to get
'git push', 'git citool' and 'git-request-pull' as my top result
depending on response times for different requests. This solution
doesn't completely fix this problem, but helps alleviate it quite a bit
while also reducing the number of requests to the server.

Since Search.searching was already declared, you might've been aware of
the problem and might have some other ideas how you'd like to solve it.
