### PR TITLE
Update tarball download links to the official URL

### DIFF
--- a/app/views/shared/_monitor.html.haml
+++ b/app/views/shared/_monitor.html.haml
@@ -5,4 +5,4 @@
   =link_to "Release Notes", latest_relnote_url
   %span.release-date= latest_release_date
 
-  =link_to "Download Source Code", "https://github.com/git/git/tags", {:class => 'button', :id => 'download-link'}
+  =link_to "Download Source Code", "http://code.google.com/p/git-core/downloads/list", {:class => 'button', :id => 'download-link'}

--- a/app/views/site/index.html.haml
+++ b/app/views/site/index.html.haml
@@ -43,7 +43,7 @@
     %table
       %tr
         %td{:nowrap => true}= link_to "Graphical UIs", "/downloads/guis", {:class => 'icon gui', :id => 'gui-link'}
-        %td{:nowrap => true}= link_to "Tarballs", "https://github.com/git/git/tags", {:class => 'icon older-releases'}
+        %td{:nowrap => true}= link_to "Tarballs", "http://code.google.com/p/git-core/downloads/list", {:class => 'icon older-releases'}
       %tr
         %td{:nowrap => true}= link_to "Windows Build", "/download/win", {:class => 'icon windows', :id => 'alt-link'}
         %td{:nowrap => true}= link_to "Source Code", "https://github.com/git/git", {:class => 'icon source'}


### PR DESCRIPTION
As discussed on the mailing list, Junio's release process is more than
just running a git archive command or equivalent. The official tarballs
contain a pregenerated configure script and adds a correct version file.

The link has been updated to point to the official URL for downloading
the git tarballs, as specified by the git [ANNOUNCE] messages on the
## mailing list.

See the discussion at http://marc.info/?l=git&m=134125992426641&w=2
for the discussion behind this pull request.
