### PR TITLE
fix failures in links in book sections

### DIFF
--- a/lib/tasks/book.rake
+++ b/lib/tasks/book.rake
@@ -60,7 +60,7 @@ def generate_pages(lang, chapter, content)
 
     html += sec
 
-    nav = "<div id='nav'><a href='[[nav-prev]]'>prev</a> | <a href='[[nav-next]]'>next</a></div>"
+    nav = '<div id="nav"><a href="[[nav-prev]]">prev</a> | <a href="[[nav-next]]">next</a></div>'
     html += nav
 
     data = {


### PR DESCRIPTION
In french, some chapters have a single quote in their title. The
present generation of previous/next links between sections is also
using single quotes for attributes, which leads to improper html.

Just swap single and double quotes, so that attributes now use
double quotes and single quotes are now part of the url.

This fixe addresses github/gitscm-next#101
