### PR TITLE
Fix broken link to Git Pro book on download pages

### DIFF
--- a/app/views/downloads/downloading.html.haml
+++ b/app/views/downloads/downloading.html.haml
@@ -26,7 +26,7 @@
 
   %ul#download-next-steps
     %li
-      <a href="/documentation/book">
+      <a href="/book">
       <img src="/images/icons/nav-read-book.png" />
       <h3>Read the Book</h3>
       <p>Dive into the Pro Git book and learn at your own pace.</p>


### PR DESCRIPTION
The link to the Git Pro book on download pages for all platforms (eg. http://git-scm.com/download/mac) is broken. 
It links to http://git-scm.com/documentation/book, which gives a 500 Internal server error, when it should be linking to http://git-scm.com/book.
