### PR TITLE
donloads: show the installer/package release date

### DIFF
--- a/app/models/download.rb
+++ b/app/models/download.rb
@@ -2,11 +2,12 @@
 # t.string :filename
 # t.string :platform
 # t.references :version
+# t.timestamp :release_date
 # t.timestamps
 class Download < ActiveRecord::Base
   belongs_to :version
 
   def self.latest_for(platform)
-    includes(:version).where('platform=?', platform).order('versions.vorder DESC').order('downloads.filename DESC').first
+    includes(:version).where('platform=?', platform).order('versions.vorder DESC').order('downloads.release_date DESC').first
   end
 end

--- a/app/views/downloads/downloading.html.haml
+++ b/app/views/downloads/downloading.html.haml
@@ -11,7 +11,7 @@
   %div.callout.downloading
     %h3 Your download is starting...
 
-    %p=raw "You are downloading version <strong>#{@download.version.name}</strong> of Git for the <strong>#{@platform.capitalize}</strong> platform. This is the most recent <a href='#{@project_url}'>maintained build</a> for this platform. It was released <strong>#{time_ago_in_words @download.version.committed} ago</strong>, on #{@download.version.committed.strftime("%Y-%m-%d")}."
+    %p=raw "You are downloading version <strong>#{@download.version.name}</strong> of Git for the <strong>#{@platform.capitalize}</strong> platform. This is the most recent <a href='#{@project_url}'>maintained build</a> for this platform. It was released <strong>#{time_ago_in_words @download.release_date} ago</strong>, on #{@download.release_date.strftime("%Y-%m-%d")}."
 
     %p=raw "<strong>If your download hasn't started, <a href=\"#{@download.url}\">click here to download manually</a>.</strong>"
 

--- a/db/migrate/20120925124736_add_release_date_to_downloads.rb
+++ b/db/migrate/20120925124736_add_release_date_to_downloads.rb
@@ -1,0 +1,17 @@
+class AddReleaseDateToDownloads < ActiveRecord::Migration
+  def change
+    add_column :downloads, :release_date, :timestamp
+
+    Download.all.each do |d|
+      time = d.version.committed # best guess
+
+      if d.platform == 'windows' # for Windows, take it from the filename
+        d.filename =~ /Git-(.*?)-(.*?)(\d{4})(\d{2})(\d{2})\.exe/
+        time = Time.utc($3, $4, $5)
+      end
+
+      d.release_date = time
+      d.save
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20120423150252) do
+ActiveRecord::Schema.define(:version => 20120925124736) do
 
   create_table "books", :force => true do |t|
     t.string   "code"
@@ -64,6 +64,7 @@ ActiveRecord::Schema.define(:version => 20120423150252) do
     t.integer  "version_id"
     t.datetime "created_at", :null => false
     t.datetime "updated_at", :null => false
+    t.datetime "release_date"
   end
 
   create_table "related_items", :force => true do |t|

--- a/lib/tasks/downloads.rake
+++ b/lib/tasks/downloads.rake
@@ -5,7 +5,7 @@ task :downloads => :environment do
   # find latest windows version
   win_downloads = Octokit.downloads("msysgit/git")
   win_downloads.each do |down|
-    if m = /^Git-(.*?)-(.*).exe/.match(down.name)
+    if m = /^Git-(.*?)-(.*?)(\d{4})(\d{2})(\d{2})\.exe/.match(down.name)
       version = m[1]
       puts version = version
       puts url = down.html_url
@@ -14,6 +14,7 @@ task :downloads => :environment do
         d = v.downloads.where(:url => url).first_or_create
         d.filename = down.name
         d.platform = 'windows'
+        d.release_date = Time.utc(m[3], m[4], m[5])
         d.save
       end
     end
@@ -31,6 +32,7 @@ task :downloads => :environment do
         d = v.downloads.where(:url => url).first_or_create
         d.filename = down.name
         d.platform = 'mac'
+        d.release_date = down.created_at
         d.save
       end
     end


### PR DESCRIPTION
Yet Another Msygit Fix. Store the installer's release date as a
separate field, as it's not always the date that the version was
tagged.

This allows us to report the correct release date in the /download/win
page. Unfortunately the msysgit downloads aren't always uploaded to
github on the date that the installer has, so we need to parse it to
get the release date.

---

After the migration, the Mac page will still show the wrong date until the next `rake downloads` run, but the date issue for Mac is much less important than for Windows, which will have the right date from the start.

@sschuberth what do you think? as long as the filename format doesn't change, this should keep working. If the downloads on the github repo start getting the right timestamp, we can simplify this so we take it instead of parsing the filename.
