### PR TITLE
[RFC] Show installer version in the download link

### DIFF
--- a/app/assets/javascripts/site.js
+++ b/app/assets/javascripts/site.js
@@ -32,14 +32,14 @@ var DownloadBox = {
     var os = window.session.browser.os; // Mac, Win, Linux
     if(os == "Mac") {
       $(".monitor").addClass("mac");
-      $("#download-link").text("Download for Mac").attr("href", "/download/mac");
+      $("#download-link").text("Download " + $("#installer-version").attr('data-mac') + " for Mac").attr("href", "/download/mac");
       $("#gui-link").removeClass('mac').addClass('gui');
       $("#gui-link").text("Mac GUIs").attr("href", "/download/gui/mac");
       $("#gui-os-filter").attr('data-os', 'mac');
       $("#gui-os-filter").text("Only show GUIs for my OS (Mac)")
     } else if (os == "Windows") {
       $(".monitor").addClass("windows");
-      $("#download-link").text("Download for Windows").attr("href", "/download/win");
+      $("#download-link").text("Download " + $("#installer-version").attr('data-win') + " for Windows").attr("href", "/download/win");
       $("#gui-link").removeClass('mac').addClass('gui');
       $("#gui-link").text("Windows GUIs").attr("href", "/download/gui/win");
       $("#alt-link").removeClass("windows").addClass("mac");

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -13,6 +13,16 @@ module ApplicationHelper
     @version.name
   end
 
+  def latest_mac_installer
+    @mac_installer ||= Download.latest_for 'mac'
+    @mac_installer.version.name
+  end
+
+  def latest_win_installer
+    @win_installer ||= Download.latest_for 'windows'
+    @win_installer.version.name
+  end
+
   def latest_release_date
     @version ||= Version.latest_version
     '(' + @version.committed.strftime("%Y-%m-%d") + ')'

--- a/app/views/shared/_monitor.html.haml
+++ b/app/views/shared/_monitor.html.haml
@@ -4,5 +4,6 @@
 
   =link_to "Release Notes", latest_relnote_url
   %span.release-date= latest_release_date
+  %span#installer-version{"data-mac" => latest_mac_installer, "data-win" => latest_win_installer}
 
   =link_to "Download Source Code", "http://code.google.com/p/git-core/downloads/list", {:class => 'button', :id => 'download-link'}


### PR DESCRIPTION
Here's something that tries to bring some clarity to what actually gets downloaded with the monitor button. I don't particularly like any of this, but hopefully we can use it as a starting point.

For Mac and Windows, it adds the version number of the latest installer that we know of to the download button. I'm not sure whether it's better or worse to have "latest is 1.7.12, click here to download 1.7.11" be explicitly stated or not, or whether we want to mention the latest packaged version for a particular OS elsewhere.

Msysgit is here again a bit of an issue, as there are multiple installers for one git version, which makes this a bit more complicated to show.
