### PR TITLE
Update Debian/Ubuntu installation instructions

### DIFF
--- a/app/views/downloads/download_linux.html.erb
+++ b/app/views/downloads/download_linux.html.erb
@@ -6,7 +6,7 @@
   <p>It is easiest to install Git on Linux using the preferred package manager of your Linux distribution.</p>
 
   <h3>Debian/Ubuntu</h3>
-  <code>$ apt-get install git-core</code>
+  <code>$ apt-get install git</code>
 
   <h3>Fedora</h3>
   <code>$ yum install git</code>


### PR DESCRIPTION
The current instructions say to use "apt-get install git-core," however git-core is an obsolete package. The user should use "apt-get install git."
