### PR TITLE
design tweaks for Try Git promo

### DIFF
--- a/app/assets/stylesheets/layout.css.scss
+++ b/app/assets/stylesheets/layout.css.scss
@@ -80,11 +80,11 @@ aside {
       margin-bottom: 1.2em;
     }
     .promo {
-      background: #d8d7cf;
-      display: inline-block;
-      margin-top: -.5em;
-      padding: 4px 8px 4px 4px;
-      width: auto;
+      font-weight: bold;
+      img {
+        position: relative;
+        top: -6px;
+      }
     }
     img.illustration {
       position: absolute;

--- a/app/views/layouts/layout.html.haml
+++ b/app/views/layouts/layout.html.haml
@@ -5,17 +5,17 @@
       %title= @page_title
     - else
       %title Git
-    %meta{:charset => "utf-8"}    
+    %meta{:charset => "utf-8"}
     %meta{:content => "IE=edge,chrome=1", "http-equiv" => "X-UA-Compatible"}
     %link{:rel => "shortcut icon", "href" => "/favicon.ico", :type => "image/x-icon"}
-    = stylesheet_link_tag "git-scm.css" 
+    = stylesheet_link_tag "git-scm.css"
     = javascript_include_tag "modernizr.js", "modernizr-tests.js"
     /[if (gte IE 6)&(lte IE 8)]
       %script{:src => "/javascripts/selectivizr-min.js", :type => "text/javascript"}
     = javascript_include_tag "http://use.typekit.com/jsq2fql.js"
     :javascript
       try{Typekit.load();}catch(e){}
-    
+
   %body{:id => @section}
     %div.inner
       = partial 'shared/header'
@@ -30,12 +30,12 @@
             Git is <a href="/documentation">easy to learn</a> and has a <a href="/about/small-and-fast">tiny footprint with lightning fast performance</a>. It outclasses SCM tools like Subversion, CVS, Perforce, and ClearCase with features like <a href="/about/branching-and-merging">cheap local branching</a>, convenient <a href="/about/staging-area">staging areas</a>, and <a href="/about/distributed">multiple workflows</a>.
 
           %p.promo
-            <img src="https://d1ffx7ull4987f.cloudfront.net/images/achievements/large_badge/121/completed-try-git-1d5111823aae2bb9d14fbcb663998353.png" height="31px" width="31px" style="float: left; margin: -2px 4px 0 0;"/> Learn Git in your browser for free with <a href="http://try.github.com">Try Git</a>. 
+            <img src="https://d1ffx7ull4987f.cloudfront.net/images/achievements/large_badge/121/completed-try-git-1d5111823aae2bb9d14fbcb663998353.png" height="42" width="42" style="float: left; margin: -2px 4px 0 0;"/> Learn Git in your browser for free with <a href="http://try.github.com">Try Git</a>.
 
           <img class="illustration" src="images/branching-illustration.png" />
 
       %div#conent-wrapper
-        %div.inner 
+        %div.inner
           =yield
           = partial 'shared/footer'
 
@@ -48,14 +48,14 @@
                 %li= link_to "About", "/about", {:class => (@section == 'about') ? 'active' : ''}
                 %li
                   =link_to "Documentation", "/doc", {:class => (@section == 'documentation') ? 'active' : ''}
-                  %ul{:class => (@section == 'documentation') ? 'expanded' : ''} 
+                  %ul{:class => (@section == 'documentation') ? 'expanded' : ''}
                     %li= link_to "Reference", "/docs", {:class => (@subsection == 'reference') ? 'active' : ''}
                     %li= link_to "Book", "/book", {:class => (@subsection == 'book') ? 'active' : ''}
                     %li= link_to "Videos", "/videos", {:class => (@subsection == 'videos') ? 'active' : ''}
                     %li= link_to "External Links", "/doc/ext", {:class => (@subsection == 'external-links') ? 'active' : ''}
                 %li
                   = link_to "Downloads", "/downloads", {:class => (@section == 'downloads') ? 'active' : ''}
-                  %ul{:class => (@section == 'downloads') ? 'expanded' : ''} 
+                  %ul{:class => (@section == 'downloads') ? 'expanded' : ''}
                     %li= link_to "GUI Clients", "/downloads/guis", {:class => (@subsection == 'guis') ? 'active' : ''}
                     %li= link_to "Logos", "/downloads/logos", {:class => (@subsection == 'logos') ? 'active' : ''}
                 %li= link_to "Community", "/community", {:class => (@section == 'community') ? 'active' : ''}


### PR DESCRIPTION
A small tweak for the Try Git promo on the front page. I think this matches the overall design a bit better and it allows the badge to be slightly larger.

Before:

![](http://cl.ly/image/1Z1k0P1F0W3S/content)

After:

![](http://cl.ly/image/2K2u1I1x1I0d/content)

cc @schacon @dandenney @matthewmccullough 
