### PR TITLE
Use clearer rerere option of 'true' instead of '1'

### DIFF
--- a/app/views/blog/progit/2010-03-08-rerere.markdown
+++ b/app/views/blog/progit/2010-03-08-rerere.markdown
@@ -36,7 +36,7 @@ tests fail without having to re-resolve the conflicts again.
 
 To enable the rerere functionality, you simply have to run this config setting:
 
-	$ git config --global rerere.enabled 1
+	$ git config --global rerere.enabled true
 
 You can also turn it on by creating the `.git/rr-cache` directory in a specific
 repository, but I think the config setting is clearer, and it can be done globally.


### PR DESCRIPTION
This is better than `1` for folks coming from languages that have word-literals for boolean options. The parser in Git treats this equivalently, so I think this helps make the use (enabling) of the feature much clearer to newcomers.
