### PR TITLE
drop fees text from sfc donation page

### DIFF
--- a/app/views/site/sfc.html.erb
+++ b/app/views/site/sfc.html.erb
@@ -52,9 +52,7 @@
       </form>
     </td><td valign="top">
       <h3 class="title">Paypal</h3>
-      <p>We can also accept PayPal donations, but note that the fees are
-      higher for Paypal than other options, so less of your money makes it to
-      the project.
+      <p>To donate to Git via PayPal:
       <div class="center">
       <form action="https://www.paypal.com/cgi-bin/webscr" method="post">
         <input type="hidden" name="cmd" value="_s-xclick">


### PR DESCRIPTION
It used to be the case that Google Checkout would process
donations for free, whereas PayPal charged fees, and so we
pointed people to Google. As of July, Google now charges
approximately the same fees. There's no reason to prefer one
over the other.
