### PR TITLE
Tweak how <tt> blocks in manpages are rendered

### DIFF
--- a/app/assets/stylesheets/man-pages.css.scss
+++ b/app/assets/stylesheets/man-pages.css.scss
@@ -7,11 +7,12 @@
       font-style: normal;
     }
     tt {
-      background-color: #eee0b5;
-      padding: 2px;
-      font-family: $fixed-width-font-family !important;
+      @extend code;
+      display: inline;
+      padding: 1px;
     }
   }
+
   p.nutshell {
     background-color: #e8e7dd;
     padding: 1em;


### PR DESCRIPTION
See issue #243. This is an attempt to make the manpages render somewhat nicer. It's not great, but with this minimal change, I find that my reading experience is already greatly improved compared to the current state. Here is an example taken from the git-fast-import manpage. Before:

![Screen Shot 2013-01-30 at 15 18 38](https://f.cloud.github.com/assets/241512/111096/10b00dc8-6ae8-11e2-80cd-d497305e1fab.png)

After:

![Screen Shot 2013-01-30 at 15 19 10](https://f.cloud.github.com/assets/241512/111097/16af07ce-6ae8-11e2-83af-0f112f0f7be7.png)

Perhaps the red should be changed, though, to perhaps something a bit darker, or even the same color as the rest of the text. I also experimented with just changing this to use typewriter, but no other effects. But I found the result a bit too bland:

![Screen Shot 2013-01-30 at 15 21 19](https://f.cloud.github.com/assets/241512/111103/6c525b72-6ae8-11e2-9b9b-ff62fa0bc926.png)

However, tastes differ. If you want this to go into a somewhat different direction, please give me some hints as to how, and I can make some more variants and screenshots thereof. Of course to really see the full effect, one should consider much more of the reference pages than just that tiny snippet I am showing here.
