### PR TITLE
update text for references to Software Freedom Conservancy

### DIFF
--- a/app/views/shared/_footer.html.haml
+++ b/app/views/shared/_footer.html.haml
@@ -4,6 +4,6 @@
     Patches, suggestions, and comments are welcome.
 
   %div.sfc-member
-    Git is a member of the <a href="/sfc">Software Freedom Conservancy</a>
+    Git is a member of <a href="/sfc">Software Freedom Conservancy</a>
 
 = javascript_include_tag "jquery-1.7.1.min.js", "jquery-ui-1.8.18.custom.min.js", "jquery.defaultvalue.js", "session.min.js", "site.js"

--- a/app/views/site/sfc.html.erb
+++ b/app/views/site/sfc.html.erb
@@ -1,19 +1,19 @@
 <div id="main">
-  <h1 id="sfc">Git and The Software Freedom Conservancy</h1>
+  <h1 id="sfc">Git and Software Freedom Conservancy</h1>
 
-  <p>Git is a member project of the <a href="http://sfconservancy.org/">Software
-  Freedom Conservancy</a>.  The SFC is a not-for-profit organization that
+  <p>Git is a member project of <a href="http://sfconservancy.org/">Software
+  Freedom Conservancy</a>.  Conservancy is a not-for-profit organization that
   provides financial and administrative assistance to open source projects.
 
   <h2 class="section-start">Donation</h2>
 
-  <p>The SFC accepts donations on git's behalf. In the past, project money has
+  <p>Conservancy accepts donations on git's behalf. In the past, project money has
   typically gone to defraying travel costs for developers to come to our annual
   <a href="https://git.wiki.kernel.org/index.php/GitTogether">GitTogether</a>
-  mini-conference.  A portion of the money goes to the SFC to cover their
+  mini-conference.  A portion of the money goes to Conservancy to cover their
   operating expenses. You can also donate <a
-  href="http://sfconservancy.org/donate">directly</a> to the Conservancy's
-  general fund.
+  href="http://sfconservancy.org/donate">directly</a> to Software
+  Freedom Conservancy's general fund.
 
   <table class="data-table software">
     <tr><td valign="top">
@@ -33,7 +33,7 @@
       </script>
       <form action="https://checkout.google.com/cws/v2/Donations/622836985124940/checkoutForm" id="BB_BuyButtonForm" method="post" name="BB_BuyButtonForm" onSubmit="return validateAmount(this.item_price_1)" target="_top">
           <input name="item_name_1" type="hidden" value="Git Donation via Software Freedom Conservancy"/>
-          <input name="item_description_1" type="hidden" value="Donation to the Git Project via the Software Freedom Conservancy."/>
+          <input name="item_description_1" type="hidden" value="Donation to the Git Project via Software Freedom Conservancy."/>
           <input name="item_quantity_1" type="hidden" value="1"/>
           <input name="item_currency_1" type="hidden" value="USD"/>
           <input name="item_is_modifiable_1" type="hidden" value="true"/>
@@ -83,7 +83,7 @@
   </pre>
   </div>
 
-  <p>The SFC can accept wire donations, but the instructions vary
+  <p>Conservancy can accept wire donations, but the instructions vary
   depending on the country of origin. Please contact <a
     href="mailto:accounting@sfconservancy.org">accounting@sfconservancy.org</a>
   for instructions.


### PR DESCRIPTION
Software Freedom Conservancy is attempting to normalize
style guidelines for references to the organization. From
their guidelines sent to project heads:
- please do not add a "the" in front of "Software Freedom
  Conservancy" or "Conservancy" in any written context.
  We've admittedly used a "the" intermittently in the
  past, but we'd like to be consistent going forward.  So,
  instead of "Project X is a member of the Conservancy,"
  just say "Project X is a member of Conservancy."
- please use "Conservancy" as the abbreviation for
  "Software Freedom Conservancy."  We're discontinuing the
  use of the acronym "SFC," and we ask your help in doing
  the same.

This commit updates all references across git-scm.com to
match the new guidelines.
