### PR TITLE
Skip nils when filtering tags

### DIFF
--- a/lib/tasks/index.rake
+++ b/lib/tasks/index.rake
@@ -20,7 +20,7 @@ task :preindex => :environment do
   end
 
   # find all tags
-  tags = @octokit.tags( repo ).select { |tag| tag.name =~ /^v1[\d\.]+$/ }  # just get release tags
+  tags = @octokit.tags( repo ).select { |tag| !tag.nil? && tag.name =~ /^v1[\d\.]+$/ }  # just get release tags
 
   if rebuild
     tags = tags.select { |t| t.name == rebuild }


### PR DESCRIPTION
The tag filtering block can get a nil value, so we need to catch it.

I've no idea why this happens, but this is what I need to get it to run locally. Since the version in the frontpage is still wrong, I'm guessing the heroku cronjobs are hitting the same issue.
