### PR TITLE
url-encode book section titles

### DIFF
--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -37,12 +37,12 @@ class Section < ActiveRecord::Base
     lang = self.book.code
     prev_number = self.number - 1
     if section = self.sections.where(:number => prev_number).first
-      return "/book/#{lang}/#{section.slug}"
+      return "/book/#{lang}/#{ERB::Util.url_encode(section.slug)}"
     else
       # find previous chapter
       if ch = self.chapter.prev
         if section = ch.last_section
-          return "/book/#{lang}/#{section.slug}"
+          return "/book/#{lang}/#{ERB::Util.url_encode(section.slug)}"
         end
       end
     end
@@ -53,11 +53,11 @@ class Section < ActiveRecord::Base
     lang = self.book.code
     next_number = self.number + 1
     if section = self.sections.where(:number => next_number).first
-      return "/book/#{lang}/#{section.slug}"
+      return "/book/#{lang}/#{ERB::Util.url_encode(section.slug)}"
     else
       if ch = self.chapter.next
         if section = ch.first_section
-          return "/book/#{lang}/#{section.slug}"
+          return "/book/#{lang}/#{ERB::Util.url_encode(section.slug)}"
         end
       end
       # find next chapter

--- a/app/views/books/_chapter_listings.html.erb
+++ b/app/views/books/_chapter_listings.html.erb
@@ -4,7 +4,7 @@
   <% stop       = start + (per_column - 1)        -%>
   <% @book.chapters[start..stop].each do |chapter| %>
   <li class='chapter'>
-  <h2><%= chapter.number %>. <a href="/book/<%= @book.code %>/<%= chapter.sections.first.slug %>"><%=raw chapter.title %></a></h2>
+  <h2><%= chapter.number %>. <a href="/book/<%= @book.code %>/<%=u chapter.sections.first.slug %>"><%=raw chapter.title %></a></h2>
     <ol>
       <% chapter.sections.each do |section| %>
         <% if !section.title.empty? %>

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -16,7 +16,7 @@
   <ol class='book-toc'>
     <% @book.chapters.each do |chapter| %>
     <li class='chapter'>
-    <h2><%= chapter.number %>. <a href="/book/<%= @book.code %>/<%= chapter.sections.first.slug %>"><%=raw chapter.title %></a></h2>
+    <h2><%= chapter.number %>. <a href="/book/<%= @book.code %>/<%=u chapter.sections.first.slug %>"><%=raw chapter.title %></a></h2>
       <ol>
         <% chapter.sections.each do |section| %>
           <% if !section.title.empty? %>

--- a/app/views/doc/book.html.erb
+++ b/app/views/doc/book.html.erb
@@ -16,7 +16,7 @@
   <ol class='book-toc'>
     <% @book.chapters.each do |chapter| %>
     <li class='chapter'>
-    <h2><%= chapter.number %>. <a href="/book/<%= @book.code %>/<%= chapter.sections.first.slug %>"><%=raw chapter.title %></a></h2>
+    <h2><%= chapter.number %>. <a href="/book/<%= @book.code %>/<%=u chapter.sections.first.slug %>"><%=raw chapter.title %></a></h2>
       <ol>
         <% chapter.sections.each do |section| %>
           <% if !section.title.empty? %>


### PR DESCRIPTION
Some of the translated section titles end in question marks.
When these are placed directly into a link without quoting,
the trailing "?" is parsed as a parameter separator, leading
to a broken link.

The same problem was fixed in #149, but only for the actual
section listing. This commit fixes the prev/next links, as
well as any direct chapter links.
