### PR TITLE
Updated Git GUI clients - SourceTree for Windows

### DIFF
--- a/app/views/downloads/guis/index.html.haml
+++ b/app/views/downloads/guis/index.html.haml
@@ -39,11 +39,11 @@
           %p.description
             <strong>Platforms:</strong> Mac</br>
             <strong>Price:</strong> Free
-        %li.mac
+        %li.mac.windows
           =link_to(image_tag('guis/sourcetree@2x.png', {:width => '294', :height => '166'}), "http://www.sourcetreeapp.com/")
           %h4= link_to "SourceTree", "http://www.sourcetreeapp.com/"
           %p.description
-            <strong>Platforms:</strong> Mac</br>
+            <strong>Platforms:</strong> Mac, Windows</br>
             <strong>Price:</strong> Free
         %li.mac.windows.linux
           =link_to(image_tag('guis/smartgit@2x.png', {:width => '294', :height => '166'}), "http://www.syntevo.com/smartgit/index.html")


### PR DESCRIPTION
Per http://blogs.atlassian.com/2013/03/introducing-sourcetree-git-client-microsoft-windows/, added Windows as supported platform.
