### PR TITLE
Better localized language name for Chinese.

### DIFF
--- a/app/views/blog/progit/2009-08-19-translate-this.markdown
+++ b/app/views/blog/progit/2009-08-19-translate-this.markdown
@@ -11,7 +11,7 @@ and put the code <a href="http://github.com/progit/progit">up on GitHub</a>,
 several people have forked and started translating the book into other
 languages such as 
 <a href="/book/de">German</a>, 
-<a href="/book/zh">Chinese</a>, 
+<a href="/book/zh">中文</a>, 
 <a href="/book/ja">Japanese</a> and
 <a href="/book/ru">Russian</a>.
 

--- a/app/views/books/_translations.html.erb
+++ b/app/views/books/_translations.html.erb
@@ -1,7 +1,7 @@
 <p>
 This book is translated into 
   <a href="/book/de">German</a>,
-  <a href="/book/zh">Chinese</a>,
+  <a href="/book/zh">中文</a>,
   <a href="/book/fr">French</a>,
   <a href="/book/ja">Japanese</a>,
   <a href="/book/nl">Dutch</a>,

--- a/app/views/doc/_translations.html.erb
+++ b/app/views/doc/_translations.html.erb
@@ -1,7 +1,7 @@
 <p>
 This book is translated into 
   <a href="/book/de">German</a>, 
-  <a href="/book/zh">Chinese</a>, 
+  <a href="/book/zh">中文</a>, 
   <a href="/book/fr">French</a>, 
   <a href="/book/ja">Japanese</a>, 
   <a href="/book/nl">Dutch</a>, 


### PR DESCRIPTION
This commit replaces "Chinese" with "中文", which makes it easier to pick up the right localization for Chinese users.
