### PR TITLE
user-manual.html truncated after the first section

### DIFF
--- a/lib/asciidoc.rb
+++ b/lib/asciidoc.rb
@@ -909,11 +909,12 @@ module Asciidoc
       def section_level(line)
         char = line.strip.chars.to_a.uniq
         case char
-        when ['=']; 0
-        when ['-']; 1
-        when ['~']; 2
-        when ['^']; 3
-        when ['+']; 4
+        when ['_']; 0
+        when ['=']; 1
+        when ['-']; 2
+        when ['~']; 3
+        when ['^']; 4
+        when ['+']; 5
         end
       end
 


### PR DESCRIPTION
I pointed this out [on the mailing list](http://thread.gmane.org/gmane.comp.version-control.git/223901) last week:

On Fri, May 10, 2013 at 03:02:29PM -0400, W. Trevor King wrote:

> There's also a version on git-scm.com [2], but this cuts out after the first section (before “Exploring Git history”).  I'm not sure who's in charge of maintaining either location, or which (if either) is considered “canonical”.

This repository is upstream, so I'll attach a PR here if I figure out what's going wrong ;).  I would expect this problem has to do with `lib/asciidoc.rb`, but I haven't poked around much yet.
