### PR TITLE
The original GitX is not actively maintained and needs a replacement.

### DIFF
--- a/app/views/downloads/guis/index.html.haml
+++ b/app/views/downloads/guis/index.html.haml
@@ -33,9 +33,9 @@
           %p.description
             <strong>Platforms:</strong> Windows</br>
             <strong>Price:</strong> Free
-        %li.mac
-          =link_to(image_tag('guis/gitx@2x.png', {:width => '294', :height => '166'}), "http://gitx.laullon.com/")
-          %h4= link_to "GitX (L)", "http://gitx.laullon.com/"
+       %li.mac
+          =link_to(image_tag('guis/gitx@2x.png', {:width => '294', :height => '166'}), "http://rowanj.github.io/gitx/")
+          %h4= link_to "GitX-dev ", "http://rowanj.github.io/gitx/"
           %p.description
             <strong>Platforms:</strong> Mac</br>
             <strong>Price:</strong> Free


### PR DESCRIPTION
The original GitX (L) hasn't received any update in the past two years, while [GitX-dev](http://rowanj.github.io/gitx/) is active and has gained some really nice updates to the overall functionality.

> GitX-dev is a fork (variant) of GitX, a long-defunct GUI for the git version-control system. It has been maintained and enhanced with productivity and friendliness oriented changes, with effort focused on making a first-class, maintainable tool for today's active developers.
