### PR TITLE
Delete one of 5 confusing 'git's in a single line

### DIFF
--- a/app/views/downloads/index.html.haml
+++ b/app/views/downloads/index.html.haml
@@ -51,7 +51,7 @@
     If you already have Git installed, you can get the latest development version via Git itself:
 
   %code
-    git clone https://github.com/git/git.git
+    git clone https://github.com/git/git
 
   %p
     You can also always browse the current contents of the git repository using the <a href="https://github.com/git/git">web interface</a>.


### PR DESCRIPTION
Cloning github links works even without the .git extension.
