### PR TITLE
Replace GitX(L) with actively maintained GitX-dev.

### DIFF
--- a/app/views/downloads/guis/index.html.haml
+++ b/app/views/downloads/guis/index.html.haml
@@ -34,8 +34,8 @@
             <strong>Platforms:</strong> Windows</br>
             <strong>Price:</strong> Free
         %li.mac
-          =link_to(image_tag('guis/gitx@2x.png', {:width => '294', :height => '166'}), "http://gitx.laullon.com/")
-          %h4= link_to "GitX (L)", "http://gitx.laullon.com/"
+          =link_to(image_tag('guis/gitx@2x.png', {:width => '294', :height => '166'}), "http://rowanj.github.io/gitx/")
+          %h4= link_to "GitX-dev ", "http://rowanj.github.io/gitx/"
           %p.description
             <strong>Platforms:</strong> Mac</br>
             <strong>Price:</strong> Free


### PR DESCRIPTION
This is a manual update of #287, without the Travis-killing whitespace issue.
