### PR TITLE
Fix delicious.com links

### DIFF
--- a/app/views/downloads/guis/index.html.haml
+++ b/app/views/downloads/guis/index.html.haml
@@ -86,5 +86,5 @@
 
   %div.callout
     %p
-      There are other great GUI tools available as well. Matthew McCullough maintains a great list of <a href="http://delicious.com/matthew.mccullough/git+gui">Git GUIs</a> organized by OS (<a href="http://delicious.com/matthew.mccullough/git+gui+windows">Windows</a>, <a href="http://delicious.com/matthew.mccullough/git+gui+macosx">Mac</a>, and <a href="http://delicious.com/matthew.mccullough/git+gui+linux">Linux</a>).
+      There are other great GUI tools available as well. Matthew McCullough maintains a great list of <a href="http://delicious.com/matthew.mccullough/gui,git">Git GUIs</a> organized by OS (<a href="http://delicious.com/matthew.mccullough/git,gui,windows">Windows</a>, <a href="http://delicious.com/matthew.mccullough/git,gui,macosx">Mac</a>, and <a href="http://delicious.com/matthew.mccullough/git,gui,linux">Linux</a>).
 


### PR DESCRIPTION
Links didn't work, so I fixed them.

**Example**
Before: http://delicious.com/matthew.mccullough/gui+git
After: http://delicious.com/matthew.mccullough/gui,git
