### PR TITLE
Community: no subscription necessary for git@vger.kernel.org

### DIFF
--- a/app/views/community/index.html.haml
+++ b/app/views/community/index.html.haml
@@ -12,6 +12,9 @@
 
   %p
     Questions or comments for the Git community can be sent to the mailing list by using the email address <a href="mailto:git@vger.kernel.org">git@vger.kernel.org</a>. <strong>Bug reports should be sent to this mailing list.</strong> 
+
+  %p
+    You do not need to subscribe: you will be Cc&apos;d in replies. Please keep the Cc list intact when replying (use &quot;Reply to all&quot;). Greylisting may delay your first post for a few hours.
     
   %p
     The <a href="http://dir.gmane.org/gmane.comp.version-control.git">archive</a> can be found on Gmane.  Click <a href="mailto:majordomo@vger.kernel.org?body=subscribe git">here</a> to subscribe.  


### PR DESCRIPTION
Add a paragraph about the Cc policy and subscription (non)requirements for
git@vger.kernel.org, to reassure our bug reporters.
