### PR TITLE
drop Google Checkout link from SFC donation page

### DIFF
--- a/app/views/site/sfc.html.erb
+++ b/app/views/site/sfc.html.erb
@@ -15,59 +15,20 @@
   href="http://sfconservancy.org/donate">directly</a> to Software
   Freedom Conservancy's general fund.
 
-  <table class="data-table software">
-    <tr><td valign="top">
-      <h3 class="title">Google Checkout</h3>
-      <p>To donate to git via Google Checkout:
-
-      <script type="text/javascript">
-      function validateAmount(amount){
-              if(amount.value.match( /^[0-9]+(\.([0-9]+))?$/)){
-                      return true;
-              }else{
-                      alert('You must enter a valid donation.');
-                      amount.focus();
-                      return false;
-              }
-      }
-      </script>
-      <form action="https://checkout.google.com/cws/v2/Donations/622836985124940/checkoutForm" id="BB_BuyButtonForm" method="post" name="BB_BuyButtonForm" onSubmit="return validateAmount(this.item_price_1)" target="_top">
-          <input name="item_name_1" type="hidden" value="Git Donation via Software Freedom Conservancy"/>
-          <input name="item_description_1" type="hidden" value="Donation to the Git Project via Software Freedom Conservancy."/>
-          <input name="item_quantity_1" type="hidden" value="1"/>
-          <input name="item_currency_1" type="hidden" value="USD"/>
-          <input name="item_is_modifiable_1" type="hidden" value="true"/>
-          <input name="item_min_price_1" type="hidden" value="5.0"/>
-          <input name="item_max_price_1" type="hidden" value="25000.0"/>
-          <input name="_charset_" type="hidden" value="utf-8"/>
-          <table cellpadding="5" cellspacing="0" width="1%">
-              <tr>
-                  <td align="right" nowrap="nowrap" width="1%">&#x24; <input id="item_price_1" name="item_price_1" onfocus="this.style.color='black'; this.value='';" size="11" style="color:grey;" type="text" value="Enter Amount"/>
-                  </td>
-                  <td align="left" width="1%">
-                      <input alt="Donate" src="https://checkout.google.com/buttons/donateNow.gif?merchant_id=622836985124940&amp;w=115&amp;h=50&amp;style=white&amp;variant=text&amp;loc=en_US" type="image"/>
-                  </td>
-              </tr>
-          </table>
-      </form>
-    </td><td valign="top">
-      <h3 class="title">Paypal</h3>
-      <p>To donate to Git via PayPal:
-      <div class="center">
-      <form action="https://www.paypal.com/cgi-bin/webscr" method="post">
-        <input type="hidden" name="cmd" value="_s-xclick">
-        <input type="hidden" name="hosted_button_id" value="GXTE9AECX4LAL">
-        <input type="image"
-               src="https://www.paypal.com/en_US/i/btn/btn_donateCC_LG.gif"
-               border="0" name="submit"
-               alt="PayPal - The safer, easier way to pay online!">
-        <img alt="" border="0" height="1" width="1"
-             src="https://www.paypal.com/en_US/i/scr/pixel.gif">
-      </form>
-      </div>
-    </td></tr>
-  </table>
-
+  <h3 class="title">Paypal</h3>
+  <p>To donate to Git via PayPal:
+  <div class="center">
+    <form action="https://www.paypal.com/cgi-bin/webscr" method="post">
+      <input type="hidden" name="cmd" value="_s-xclick">
+      <input type="hidden" name="hosted_button_id" value="GXTE9AECX4LAL">
+      <input type="image"
+             src="https://www.paypal.com/en_US/i/btn/btn_donateCC_LG.gif"
+             border="0" name="submit"
+             alt="PayPal - The safer, easier way to pay online!">
+      <img alt="" border="0" height="1" width="1"
+           src="https://www.paypal.com/en_US/i/scr/pixel.gif">
+    </form>
+  </div>
 
   <h3 class="title">Check or Wire</h3>
   <p>We can also accept donations drawn in USD from banks in the USA


### PR DESCRIPTION
Google is discontinuing Checkout later this month, and SFC
has asked all member projects to drop any links.

Formatting-wise, this means we can drop the side-by-side
table entirely, and "Paypal" becomes just another item in
the list of &lt;h3> sections.
