### PR TITLE
Updated pricing information of Gitbox (http://gitboxapp.com/)

### DIFF
--- a/app/views/downloads/guis/index.html.haml
+++ b/app/views/downloads/guis/index.html.haml
@@ -64,7 +64,7 @@
           %h4= link_to "Gitbox", "http://www.gitboxapp.com/"
           %p.description
             <strong>Platforms:</strong> Mac</br>
-            <strong>Price:</strong> $19.99 / Free for personal use
+            <strong>Price:</strong> $14.99
         %li.windows
           =link_to(image_tag('guis/git-extensions@2x.png', {:width => '294', :height => '166'}), "http://code.google.com/p/gitextensions/")
           %h4= link_to "Git Extensions", "http://code.google.com/p/gitextensions/"


### PR DESCRIPTION
Changed price to $14.99 and removed "Free for personal use" because no references to this could be found on their website.
