### PR TITLE
Fix broken image on Search section.

### DIFF
--- a/app/views/shared/_masthead.html.erb
+++ b/app/views/shared/_masthead.html.erb
@@ -19,6 +19,6 @@
       <img src="https://d1ffx7ull4987f.cloudfront.net/images/achievements/large_badge/121/completed-try-git-1d5111823aae2bb9d14fbcb663998353.png" height="42" width="42" style="float: left; margin: -2px 4px 0 0;"/> Learn Git in your browser for free with <a href="http://try.github.com">Try Git</a>.
     </p>
 
-    <img class="illustration" src="images/branching-illustration@2x.png" width="389" height="251" />
+    <img class="illustration" src="/images/branching-illustration@2x.png" width="389" height="251" />
   </div> <!-- .inner -->
 </div> <!-- #masthead -->


### PR DESCRIPTION
On the Search section after issuing a search the main image ("branching illustration") is broken because the src path is relative.
