### PR TITLE
Fix Downloads table layout

### DIFF
--- a/app/assets/stylesheets/lists.css.scss
+++ b/app/assets/stylesheets/lists.css.scss
@@ -148,6 +148,7 @@ table.binaries {
   td {
     padding: 8px 20px 6px 0;
     position: relative;
+    width: auto;
   }
   a {
     font-weight: bold;


### PR DESCRIPTION
The fixes the layout of the first table in the [Downloads](http://git-scm.com/downloads) page.

Before:

![screen shot 2014-01-31 at 12 34 13](https://f.cloud.github.com/assets/65057/2050000/a5b11ff4-8a6b-11e3-9caf-81d169980464.png)

After:

![screen shot 2014-01-31 at 12 34 45](https://f.cloud.github.com/assets/65057/2050010/baa23fc4-8a6b-11e3-8f03-75252bab4c77.png)

/cc @jasonlong
