### PR TITLE
added git-draw to documentation/external-links

### DIFF
--- a/app/views/doc/ext.html.erb
+++ b/app/views/doc/ext.html.erb
@@ -59,6 +59,12 @@
           </p>
         </li>
         <li>
+          <h4><a href="https://github.com/sensorflo/git-draw/wiki">git-draw</a></h4>
+          <p class='description'>
+            git-draw is a small tool that draws nearly the full content of a tiny git repository as a graph. It helps people with an engineering background learning Git's internals.
+          </p>
+        </li>
+        <li>
           <h4><a href="http://www-cs-students.stanford.edu/~blynn/gitmagic/">Git Magic</a></h4>
           <p class='description'>
             An alternative book with the source <a href="http://github.com/blynn/gitmagic/tree/master">online</a>.


### PR DESCRIPTION
git-draw is a small tool that draws nearly the full content of a tiny git repository as a graph. It helps people with an engineer background learning Git's internals.

If you like, you can add a reference to git-draw on GitHub to the git-scm page 'external links'. I.e. that is what this commit does.

Cheers

Flo
