### PR TITLE
Fix 404 links to old github url (gitscm-next)

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ To run the website for testing purposes, run:
 
 ## Contributing
 
-If you wish to contribute to this website, please [fork it on GitHub](https://github.com/github/gitscm-next), push your
+If you wish to contribute to this website, please [fork it on GitHub](https://github.com/github/git-scm.com), push your
 change to a named branch, then send me a pull request. If it is a big feature,
 you might want to contact me first to make sure it's something that I'll
 accept.  If it involves code, please also write tests for it.

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,6 +1,6 @@
 <footer>
   <div class="site-source">
-    This <a href="https://github.com/git/gitscm-next/blob/master/README.md#license">open sourced</a> site is <a href="https://github.com/git/gitscm-next">hosted on GitHub.</a><br>
+    This <a href="https://github.com/git/git-scm.com/blob/master/README.md#license">open sourced</a> site is <a href="https://github.com/git/git-scm.com">hosted on GitHub.</a><br>
     Patches, suggestions, and comments are welcome.
   </div>
   <div class="sfc-member">


### PR DESCRIPTION
There are couple of 404 links. This is a minor fix for URL's from old github repo (gitscm-nex changed to git-scm.com). 
