### PR TITLE
Make the distinction between source and platform releases clearer

### DIFF
--- a/app/assets/javascripts/site.js
+++ b/app/assets/javascripts/site.js
@@ -32,14 +32,14 @@ var DownloadBox = {
     var os = window.session.browser.os; // Mac, Win, Linux
     if(os == "Mac") {
       $(".monitor").addClass("mac");
-      $("#download-link").text("Download for Mac").attr("href", "/download/mac");
+      $("#download-link").text("Downloads for Mac").attr("href", "/download/mac");
       $("#gui-link").removeClass('mac').addClass('gui');
       $("#gui-link").text("Mac GUIs").attr("href", "/download/gui/mac");
       $("#gui-os-filter").attr('data-os', 'mac');
       $("#gui-os-filter").text("Only show GUIs for my OS (Mac)")
     } else if (os == "Windows") {
       $(".monitor").addClass("windows");
-      $("#download-link").text("Download for Windows").attr("href", "/download/win");
+      $("#download-link").text("Downloads for Windows").attr("href", "/download/win");
       $("#gui-link").removeClass('mac').addClass('gui');
       $("#gui-link").text("Windows GUIs").attr("href", "/download/gui/win");
       $("#alt-link").removeClass("windows").addClass("mac");
@@ -48,7 +48,7 @@ var DownloadBox = {
       $("#gui-os-filter").text("Only show GUIs for my OS (Windows)")
     } else if (os == "Linux") {
       $(".monitor").addClass("linux");
-      $("#download-link").text("Download for Linux").attr("href", "/download/linux");
+      $("#download-link").text("Downloads for Linux").attr("href", "/download/linux");
       $("#gui-link").removeClass('mac').addClass('gui');
       $("#gui-link").text("Linux GUIs").attr("href", "/download/gui/linux");
       $("#alt-link").removeClass("windows").addClass("mac");

--- a/app/views/shared/_monitor.html.haml
+++ b/app/views/shared/_monitor.html.haml
@@ -1,5 +1,5 @@
 %div.monitor
-  %h4 Latest stable release
+  %h4 Latest source release
   %span.version= latest_version
 
   =link_to "Release Notes", latest_relnote_url


### PR DESCRIPTION
The current wording seems to make the difference too subtle for a casual
reader; try to clear this up by:
- naming the latest release "source" instead of "stable" release, to
  make clearer what it is that we're showing the version for.
- reword the button to "Downloads" for a platform, which makes it a noun
  for the available downloads, rather than a verb which can too easily
  be taken to mean "download this version"

This should reduce the incidence of people complaining that the version
in the front is erroneous.

---

Ideas from #268. Possibly not perfect, but it should help.
