### PR TITLE
Initial preparations for i18n

### DIFF
--- a/app/views/about/_branching_and_merging.html.erb
+++ b/app/views/about/_branching_and_merging.html.erb
@@ -1,31 +1,31 @@
 <section class="about current" id="branching-and-merging" style="display: block;">
 
-  <h2>Branching and Merging</h2>
+  <h2><%= t(".branching_and_merging") %></h2>
 
   <p>
-    The Git feature that really makes it stand apart from nearly every other SCM out there is its branching model.
+    <%= t(".p1") %>
   </p>
 
   <p>
-    Git allows and encourages you to have multiple local branches that can be entirely independent of each other. The creation, merging, and deletion of those lines of development takes seconds.
+    <%= t(".p2") %>
   </p>
 
   <p>
-    This means that you can do things like:
+    <%= t(".p3") %>
   </p>
 
   <ul class="bullets">
     <li>
-      <strong>Frictionless Context Switching</strong>. Create a branch to try out an idea, commit a few times, switch back to where you branched from, apply a patch, switch back to where you are experimenting, and merge it in.
+      <%= t(".ul_li1_html") %>
     </li>
     <li>
-      <strong>Role-Based Codelines</strong>. Have a branch that always contains only what goes to production, another that you merge work into for testing, and several smaller ones for day to day work.
+      <%= t(".ul_li2_html") %>
     </li>
     <li>
-      <strong>Feature Based Workflow</strong>. Create new branches for each new feature you're working on so you can seamlessly switch back and forth between them, then delete each branch when that feature gets merged into your main line.
+      <%= t(".ul_li3_html") %>
     </li>
     <li>
-      <strong>Disposable Experimentation</strong>. Create a branch to experiment in, realize it's not going to work, and just delete it - abandoning the work—with nobody else ever seeing it (even if you've pushed other branches in the meantime).
+      <%= t(".ul_li4_html") %>
     </li>
   </ul>
 
@@ -34,16 +34,15 @@
   </p>
 
   <p>
-    Notably, when you push to a remote repository, you do not have to push all of your branches. You can choose to share just one of your branches, a few of them, or all of them. This tends to free people to try new ideas without worrying about having to plan how and when they are going to merge it in or share it with others.
+    <%= t(".p4") %>
   </p>
 
   <p>
-    There are ways to accomplish some of this with other systems, but the work involved is much more difficult and error-prone. Git makes this process incredibly easy and it changes the way most developers work when they learn it.
+    <%= t(".p5") %>
   </p>
 
   <div class="bottom-nav" style="display: block;">
-    <a href="#small-and-fast" class="next" data-section-id="small-and-fast">Small and Fast →</a>
+    <a href="#small-and-fast" class="next" data-section-id="small-and-fast"></a>
   </div>
 
 </section>
-

--- a/app/views/about/_data_assurance.html.erb
+++ b/app/views/about/_data_assurance.html.erb
@@ -1,25 +1,18 @@
   <section class="about" id="info-assurance" style="display: none;">
-    <h2>Data Assurance</h2>
+    <h2><%= t(".data_assurance") %></h2>
     <p>
-    The data model that Git uses ensures the cryptographic integrity of every bit
-    of your project.  Every file and commit is checksummed and retrieved by its
-    checksum when checked back out. It's impossible to get anything out of Git
-    other than the <strong>exact bits you put in</strong>.
+      <%= t(".p1_html") %>
     </p>
     <img height="522" src="/images/assurance@2x.png" width="628">
     <p>
-    It is also impossible to change any file, date, commit message, or any other
-    data in a Git repository without changing the IDs of everything after it.
-    This means that if you have a commit ID, you can be assured not only that
-    your project is exactly the same as when it was committed, but
-    that nothing in its history was changed.
+      <%= t(".p2") %>
     </p>
     <p>
-    Most centralized version control systems provide no such integrity by default.
+      <%= t(".p3") %>
     </p>
     <div class="bottom-nav" style="display: block;">
-      <a href="#distributed" class="previous" data-section-id="distributed">← Distributed</a>
-      <a href="#staging-area" class="next" data-section-id="staging-area">Staging Area →</a>
+      <a href="#distributed" class="previous" data-section-id="distributed"><%= t(".distributed") %></a>
+      <a href="#staging-area" class="next" data-section-id="staging-area"><%= t(".staging_area") %></a>
     </div>
   </section>
  

--- a/app/views/about/_distributed.html.erb
+++ b/app/views/about/_distributed.html.erb
@@ -1,42 +1,41 @@
   <section class="about" id="distributed" style="display: none;">
     
-    <h2>Distributed</h2>
+    <h2><%= t('.distributed') %></h2>
     
     <p>
-    One of the nicest features of any Distributed SCM, Git included, is that it's distributed. This means that instead of doing a "checkout" of the current tip of the source code, you do a "clone" of the entire repository.
+      <%= t('.p1') %>
     </p>
-    <h3>Multiple Backups</h3>
+    <h3><%= t('.multiple_backups') %></h3>
     <p>
-    This means that even if you're using a centralized workflow, every user essentially has a full backup of the main server. Each of these copies could be pushed up to replace the main server in the event of a crash or corruption. In effect, there is no single point of failure with Git unless there is only a single copy of the repository.
+    <%= t('.p2') %>
     </p>
-    <h3>Any Workflow</h3>
+    <h3><%= t('.any_workflow') %></h3>
     <p>
-    Because of Git's distributed nature and superb branching system, an almost endless number of workflows can be implemented with relative ease.
+      <%= t('.p3') %>
     </p>
-    <h4>Subversion-Style Workflow</h4>
+    <h4><%= t('.subversion_style') %></h4>
     <p>
-    A centralized workflow is very common, especially from people transitioning from a centralized system. Git will not allow you to push if someone has pushed since the last time you fetched, so a centralized model where all developers push to the same server works just fine.
+      <%= t('.p4') %>
     </p>
     <p class="center">
-    <img src="/images/about/workflow-a@2x.png" width="415" height="209" alt="Workflow A">
+    <img src="/images/about/workflow-a@2x.png" width="415" height="209" alt="<%= t('.img_alt_workflow_a') %>">
     </p>
-    <h4>Integration Manager Workflow</h4>
+    <h4><%= t('.subversion_style') %></h4>
     <p>
-    Another common Git workflow involves an integration manager — a single person who commits to the 'blessed' repository. A number of developers then clone from that repository, push to their own independent repositories, and ask the integrator to pull in their changes. This is the type of development model often seen with open source or GitHub repositories.
+      <%= t('.p5') %>
     </p>
     <p class="center">
-    <img src="/images/about/workflow-b@2x.png" width="407" height="164" alt="Workflow B">
+    <img src="/images/about/workflow-b@2x.png" width="407" height="164" alt="<%= t('.img_alt_workflow_b') %>">
     </p>
-    <h4>Dictator and Lieutenants Workflow</h4>
+    <h4></h4>
     <p>
-    For more massive projects, a development workflow like that of the Linux kernel is often effective.
-    In this model, some people ('lieutenants') are in charge of a specific subsystem of the project and they merge in all changes related to that subsystem. Another integrator (the 'dictator') can pull changes from only his/her lieutenants and then push to the 'blessed' repository that everyone then clones from again.
+    <%= t('.p6') %>
     </p>
     <p class="center">
     <img src="/images/about/workflow-c@2x.png" width="562" height="303" alt="Workflow C">
     </p>
     <div class="bottom-nav" style="display: block;">
-      <a href="#small-and-fast" class="previous" data-section-id="small-and-fast">← Small and Fast</a>
-      <a href="#info-assurance" class="next" data-section-id="info-assurance">Data Assurance →</a>
+      <a href="#small-and-fast" class="previous" data-section-id="small-and-fast"><%= t('.small_and_fast') %></a>
+      <a href="#info-assurance" class="next" data-section-id="info-assurance"><%= t('.data_assurance') %></a>
     </div>
   </section>

--- a/app/views/about/_free_and_open_source.html.erb
+++ b/app/views/about/_free_and_open_source.html.erb
@@ -1,28 +1,27 @@
   <section class="about" id="free-and-open-source" style="display: none;">
-    <h2>Free and Open Source</h2>
+    <h2><%= t(".free_and_open_source") %></h2>
     <p>
-    Git is released under the <a href="https://github.com/git/git/blob/master/COPYING">GPLv2</a> <a href="http://www.opensource.org/docs/osd">open source license</a>.  This means that you are free to <a href="https://github.com/git/git">inspect the source code</a> at any time or <a href="https://github.com/git/git/blob/master/Documentation/SubmittingPatches">contribute</a> to the project yourself.
+      <%= t(".p1_html") %>
     </p>
     <p>
-    Under Git's GPLv2 software license, you <strong>may</strong>:
+      <%= t(".p2_html") %>
     </p><ul class="bullets">
-      <li>Use Git on open or proprietary projects for free, forever</li>
-      <li>Download, inspect and modify the source code to Git</li>
-      <li>Make proprietary changes to Git that you do not redistribute publicly</li>
-      <li>Call Git binaries from your open or proprietary programs</li>
-      <li>Publicly redistribute Git binaries with open or proprietary programs, given that they are unmodified or the modifications are public</li>
+      <li><%= t(".ul1_li1") %></li>
+      <li><%= t(".ul1_li2") %></li>
+      <li><%= t(".ul1_li3") %></li>
+      <li><%= t(".ul1_li4") %></li>
+      <li><%= t(".ul1_li5") %></li>
     </ul>
     <p></p>
     <p>
-    Under this license you <strong>may not</strong>:
+      <%= t(".p3_html") %>
     </p><ul class="bullets">
-      <li>Make proprietary changes to Git and publicly redistribute it without sharing the changes</li>
-      <li>Make and publicly distribute changes to Git under a different license</li>
-      <li>Use source code from the Git repository in a project under a different license without permission</li>
+      <li><%= t(".ul2_li1") %></li>
+      <li><%= t(".ul2_li2") %></li>
+      <li><%= t(".ul2_li3") %></li>
     </ul>
     <p></p>
     <div class="bottom-nav" style="display: block;">
-      <a href="#staging-area" class="previous" data-section-id="staging-area">← Staging Area</a>
+      <a href="#staging-area" class="previous" data-section-id="staging-area"><%= t(".staging_area") %></a>
     </div>
   </section>
-

--- a/app/views/about/_small_and_fast.html.erb
+++ b/app/views/about/_small_and_fast.html.erb
@@ -1,152 +1,132 @@
   <section class="about" id="small-and-fast" style="display: none;">
 
-    <h2>Small and Fast</h2>
+    <h2><%= t(".small_and_fast") %></h2>
     
     <p>
-      <strong>Git is fast</strong>. With Git, nearly all operations are performed locally, giving it a huge speed advantage on centralized systems that constantly have to communicate with a server somewhere.
+      <%= t(".p1_html") %>
     </p>
     
     <p>
-      Git was built to work on the Linux kernel, meaning that it has had to effectively handle large repositories from day one. Git is written in C, reducing the overhead of runtimes associated with higher-level languages. Speed and performance has been a primary design goal of the Git from the start.
+      <%= t(".p2") %>
     </p>
     
-    <h3>Benchmarks</h3>
+    <h3><%= t(".benchmarks") %></h3>
     
     <p>
-      Let's see how common operations stack up against
-      Subversion, a common centralized version control system that is similar
-      to CVS or Perforce. <em>Smaller is faster.</em>
+      <%= t(".p3_html") %>
     </p>
     
     <table width="100%">
       <tbody>
         <tr>
           <td>
-            <img src="http://chart.apis.google.com/chart?chxt=x&amp;cht=bvs&amp;chl=git|svn&amp;chd=t:0.649,2.6&amp;chds=0,2.6&amp;chs=100x125&amp;chco=E09FA0|E05F49&amp;chf=bg,s,fcfcfa&amp;chtt=Commit A" alt="init benchmarks">
+            <img src="http://chart.apis.google.com/chart?chxt=x&amp;cht=bvs&amp;chl=git|svn&amp;chd=t:0.649,2.6&amp;chds=0,2.6&amp;chs=100x125&amp;chco=E09FA0|E05F49&amp;chf=bg,s,fcfcfa&amp;chtt=Commit A" alt="<%= t(".img_alt_init_benchmarks") %>">
           </td>
           <td>
-            <img src="http://chart.apis.google.com/chart?chxt=x&amp;cht=bvs&amp;chl=git|svn&amp;chd=t:1.53,24.7&amp;chds=0,24.7&amp;chs=100x125&amp;chco=E09FA0|E05F49&amp;chf=bg,s,fcfcfa&amp;chtt=Commit B" alt="init benchmarks">
+            <img src="http://chart.apis.google.com/chart?chxt=x&amp;cht=bvs&amp;chl=git|svn&amp;chd=t:1.53,24.7&amp;chds=0,24.7&amp;chs=100x125&amp;chco=E09FA0|E05F49&amp;chf=bg,s,fcfcfa&amp;chtt=Commit B" alt="<%= t(".img_alt_init_benchmarks") %>">
           </td>
           <td>
-            <img src="http://chart.apis.google.com/chart?chxt=x&amp;cht=bvs&amp;chl=git|svn&amp;chd=t:0.257,1.09&amp;chds=0,1.09&amp;chs=100x125&amp;chco=E09FA0|E05F49&amp;chf=bg,s,fcfcfa&amp;chtt=Diff Curr" alt="init benchmarks">
+            <img src="http://chart.apis.google.com/chart?chxt=x&amp;cht=bvs&amp;chl=git|svn&amp;chd=t:0.257,1.09&amp;chds=0,1.09&amp;chs=100x125&amp;chco=E09FA0|E05F49&amp;chf=bg,s,fcfcfa&amp;chtt=Diff Curr" alt="<%= t(".img_alt_init_benchmarks") %>">
           </td>
           <td>
-            <img src="http://chart.apis.google.com/chart?chxt=x&amp;cht=bvs&amp;chl=git|svn&amp;chd=t:0.248,3.99&amp;chds=0,3.99&amp;chs=100x125&amp;chco=E09FA0|E05F49&amp;chf=bg,s,fcfcfa&amp;chtt=Diff Rec" alt="init benchmarks">
+            <img src="http://chart.apis.google.com/chart?chxt=x&amp;cht=bvs&amp;chl=git|svn&amp;chd=t:0.248,3.99&amp;chds=0,3.99&amp;chs=100x125&amp;chco=E09FA0|E05F49&amp;chf=bg,s,fcfcfa&amp;chtt=Diff Rec" alt="<%= t(".img_alt_init_benchmarks") %>">
           </td>
           <td>
-            <img src="http://chart.apis.google.com/chart?chxt=x&amp;cht=bvs&amp;chl=git|svn&amp;chd=t:1.17,83.57&amp;chds=0,83.57&amp;chs=100x125&amp;chco=E09FA0|E05F49&amp;chf=bg,s,fcfcfa&amp;chtt=Diff Tags" alt="init benchmarks">
+            <img src="http://chart.apis.google.com/chart?chxt=x&amp;cht=bvs&amp;chl=git|svn&amp;chd=t:1.17,83.57&amp;chds=0,83.57&amp;chs=100x125&amp;chco=E09FA0|E05F49&amp;chf=bg,s,fcfcfa&amp;chtt=Diff Tags" alt="<%= t(".img_alt_init_benchmarks") %>">
           </td>
           <td>
-            <img src="http://chart.apis.google.com/chart?chxt=x&amp;cht=bvs&amp;chl=git*|git|svn&amp;chd=t:21.0,107.5,14.0&amp;chds=0,107.5&amp;chs=100x125&amp;chco=E09FA0|E09FA0|E05F49&amp;chf=bg,s,fcfcfa&amp;chtt=Clone" alt="init benchmarks">
+            <img src="http://chart.apis.google.com/chart?chxt=x&amp;cht=bvs&amp;chl=git*|git|svn&amp;chd=t:21.0,107.5,14.0&amp;chds=0,107.5&amp;chs=100x125&amp;chco=E09FA0|E09FA0|E05F49&amp;chf=bg,s,fcfcfa&amp;chtt=Clone" alt="<%= t(".img_alt_init_benchmarks") %>">
           </td>
         </tr>
         <tr>
           <td>
-            <img src="http://chart.apis.google.com/chart?chxt=x&amp;cht=bvs&amp;chl=git|svn&amp;chd=t:0.012,0.381&amp;chds=0,0.381&amp;chs=100x125&amp;chco=E09FA0|E05F49&amp;chf=bg,s,fcfcfa&amp;chtt=Log (50)" alt="init benchmarks">
+            <img src="http://chart.apis.google.com/chart?chxt=x&amp;cht=bvs&amp;chl=git|svn&amp;chd=t:0.012,0.381&amp;chds=0,0.381&amp;chs=100x125&amp;chco=E09FA0|E05F49&amp;chf=bg,s,fcfcfa&amp;chtt=Log (50)" alt="<%= t(".img_alt_init_benchmarks") %>">
           </td>
           <td>
-            <img src="http://chart.apis.google.com/chart?chxt=x&amp;cht=bvs&amp;chl=git|svn&amp;chd=t:0.519,169.197&amp;chds=0,169.197&amp;chs=100x125&amp;chco=E09FA0|E05F49&amp;chf=bg,s,fcfcfa&amp;chtt=Log (All)" alt="init benchmarks">
+            <img src="http://chart.apis.google.com/chart?chxt=x&amp;cht=bvs&amp;chl=git|svn&amp;chd=t:0.519,169.197&amp;chds=0,169.197&amp;chs=100x125&amp;chco=E09FA0|E05F49&amp;chf=bg,s,fcfcfa&amp;chtt=Log (All)" alt="<%= t(".img_alt_init_benchmarks") %>">
           </td>
           <td>
-            <img src="http://chart.apis.google.com/chart?chxt=x&amp;cht=bvs&amp;chl=git|svn&amp;chd=t:0.601,82.843&amp;chds=0,82.843&amp;chs=100x125&amp;chco=E09FA0|E05F49&amp;chf=bg,s,fcfcfa&amp;chtt=Log (File)" alt="init benchmarks">
+            <img src="http://chart.apis.google.com/chart?chxt=x&amp;cht=bvs&amp;chl=git|svn&amp;chd=t:0.601,82.843&amp;chds=0,82.843&amp;chs=100x125&amp;chco=E09FA0|E05F49&amp;chf=bg,s,fcfcfa&amp;chtt=Log (File)" alt="<%= t(".img_alt_init_benchmarks") %>">
           </td>
           <td>
-            <img src="http://chart.apis.google.com/chart?chxt=x&amp;cht=bvs&amp;chl=git|svn&amp;chd=t:0.896,2.816&amp;chds=0,2.816&amp;chs=100x125&amp;chco=E09FA0|E05F49&amp;chf=bg,s,fcfcfa&amp;chtt=Update" alt="init benchmarks">
+            <img src="http://chart.apis.google.com/chart?chxt=x&amp;cht=bvs&amp;chl=git|svn&amp;chd=t:0.896,2.816&amp;chds=0,2.816&amp;chs=100x125&amp;chco=E09FA0|E05F49&amp;chf=bg,s,fcfcfa&amp;chtt=Update" alt="<%= t(".img_alt_init_benchmarks") %>">
           </td>
           <td>
-            <img src="http://chart.apis.google.com/chart?chxt=x&amp;cht=bvs&amp;chl=git|svn&amp;chd=t:1.91,3.04&amp;chds=0,3.04&amp;chs=100x125&amp;chco=E09FA0|E05F49&amp;chf=bg,s,fcfcfa&amp;chtt=Blame" alt="init benchmarks">
+            <img src="http://chart.apis.google.com/chart?chxt=x&amp;cht=bvs&amp;chl=git|svn&amp;chd=t:1.91,3.04&amp;chds=0,3.04&amp;chs=100x125&amp;chco=E09FA0|E05F49&amp;chf=bg,s,fcfcfa&amp;chtt=Blame" alt="<%= t(".img_alt_init_benchmarks") %>">
           </td>
           <td>
-            <img src="http://chart.apis.google.com/chart?chxt=x&amp;cht=bvs&amp;chl=git|svn&amp;chd=t:181,132&amp;chds=0,181&amp;chs=100x125&amp;chco=E09FA0|E05F49&amp;chf=bg,s,fcfcfa&amp;chtt=Size" alt="init benchmarks">
+            <img src="http://chart.apis.google.com/chart?chxt=x&amp;cht=bvs&amp;chl=git|svn&amp;chd=t:181,132&amp;chds=0,181&amp;chs=100x125&amp;chco=E09FA0|E05F49&amp;chf=bg,s,fcfcfa&amp;chtt=Size" alt="<%= t(".img_alt_init_benchmarks") %>">
           </td>
         </tr>
       </tbody>
     </table>
 
     <p>
-      For testing, large AWS instances were set up in the same availability zone.
-      Git and SVN were installed on both machines, the Ruby repository was copied to
-      both Git and SVN servers, and common operations were performed on both.
+      <%= t(".p4") %>
     </p>
 
     <p>
-      In some cases the commands don't match up exactly. Here, matching on the lowest
-      common denominator was attempted. For example, the 'commit' tests also include
-      the time to push for Git, though most of the time you would not actually be pushing
-      to the server immediately after a commit where the two commands cannot be separated
-      in SVN.
+      <%= t(".p5") %>
     </p>
 
     <p>
-      All of these times are in seconds.
+      <%= t(".p6") %>
     </p>
 
     <table class="benchmarks">
       <tbody>
         <tr>
-          <th>Operation</th>
+          <th><%= t(".operation") %></th>
           <th></th>
           <th class="right">Git</th>
           <th class="right">SVN</th>
         </tr>
-        <tr><td nowrap="">Commit Files (A)</td><td class="desc">Add, commit and push 113 modified files (2164+, 2259-)</td><td class="number"> 0.64</td><td class="number"> 2.60</td><td class="number">4x</td></tr>
-        <tr><td nowrap="">Commit Images (B)</td><td class="desc">Add, commit and push 1000 1k images</td><td class="number"> 1.53</td><td class="number">24.70</td><td class="number">16x</td></tr>
-        <tr><td nowrap="">Diff Current</td><td class="desc">Diff 187 changed files (1664+, 4859-) against last commit</td><td class="number"> 0.25</td><td class="number"> 1.09</td><td class="number">4x</td></tr>
-        <tr><td nowrap="">Diff Recent</td><td class="desc">Diff against 4 commits back (269 changed/3609+,6898-)</td><td class="number"> 0.25</td><td class="number"> 3.99</td><td class="number">16x</td></tr>
-        <tr><td nowrap="">Diff Tags</td><td class="desc">Diff two tags against each other (v1.9.1.0/v1.9.3.0 )</td><td class="number"> 1.17</td><td class="number">83.57</td><td class="number">71x</td></tr>
-        <tr><td nowrap="">Log (50)</td><td class="desc">Log of the last 50 commits (19k of output)</td><td class="number"> 0.01</td><td class="number"> 0.38</td><td class="number">31x</td></tr>
-        <tr><td nowrap="">Log (All)</td><td class="desc">Log of all commits (26,056 commits - 9.4M of output)</td><td class="number"> 0.52</td><td class="number">169.20</td><td class="number">325x</td></tr>
-        <tr><td nowrap="">Log (File)</td><td class="desc">Log of the history of a single file (array.c - 483 revs)</td><td class="number"> 0.60</td><td class="number">82.84</td><td class="number">138x</td></tr>
-        <tr><td nowrap="">Update</td><td class="desc">Pull of Commit A scenario (113 files changed, 2164+, 2259-)</td><td class="number"> 0.90</td><td class="number"> 2.82</td><td class="number">3x</td></tr>
-        <tr><td nowrap="">Blame</td><td class="desc">Line annotation of a single file (array.c)</td><td class="number"> 1.91</td><td class="number"> 3.04</td><td class="number">1x</td></tr>
+        <tr><td nowrap=""><%= t(".table_row_1") %></td><td class="desc"><%= t(".table_row_1_desc") %></td><td class="number"> 0.64</td><td class="number"> 2.60</td><td class="number">4x</td></tr>
+        <tr><td nowrap=""><%= t(".table_row_2") %></td><td class="desc"><%= t(".table_row_2_desc") %></td><td class="number"> 1.53</td><td class="number">24.70</td><td class="number">16x</td></tr>
+        <tr><td nowrap=""><%= t(".table_row_3") %></td><td class="desc"><%= t(".table_row_3_desc") %></td><td class="number"> 0.25</td><td class="number"> 1.09</td><td class="number">4x</td></tr>
+        <tr><td nowrap=""><%= t(".table_row_4") %></td><td class="desc"><%= t(".table_row_4_desc") %></td><td class="number"> 0.25</td><td class="number"> 3.99</td><td class="number">16x</td></tr>
+        <tr><td nowrap=""><%= t(".table_row_5") %></td><td class="desc"><%= t(".table_row_5_desc") %></td><td class="number"> 1.17</td><td class="number">83.57</td><td class="number">71x</td></tr>
+        <tr><td nowrap=""><%= t(".table_row_6") %></td><td class="desc"><%= t(".table_row_6_desc") %></td><td class="number"> 0.01</td><td class="number"> 0.38</td><td class="number">31x</td></tr>
+        <tr><td nowrap=""><%= t(".table_row_7") %></td><td class="desc"><%= t(".table_row_7_desc") %></td><td class="number"> 0.52</td><td class="number">169.20</td><td class="number">325x</td></tr>
+        <tr><td nowrap=""><%= t(".table_row_8") %></td><td class="desc"><%= t(".table_row_8_desc") %></td><td class="number"> 0.60</td><td class="number">82.84</td><td class="number">138x</td></tr>
+        <tr><td nowrap=""><%= t(".table_row_9") %></td><td class="desc"><%= t(".table_row_9_desc") %></td><td class="number"> 0.90</td><td class="number"> 2.82</td><td class="number">3x</td></tr>
+        <tr><td nowrap=""><%= t(".table_row_10") %></td><td class="desc"><%= t(".table_row_10_desc") %></td><td class="number"> 1.91</td><td class="number"> 3.04</td><td class="number">1x</td></tr>
       </tbody>
     </table>
     
     <p>
-      Note that this is the best case scenario for SVN - a server with no load with an
-      80MB/s bandwidth connection to the client machine.  Nearly all of these
-      times would be even worse for SVN if that connection was slower, while
-      many of the Git times would not be affected.
+      <%= t(".p7") %>
     </p>
 
     <p>
-      Clearly, in many of these common version control operations, <strong>Git is
-      one or two orders of magnitude faster than SVN</strong>, even under ideal conditions
-      for SVN.
+      <%= t(".p8_html") %>
     </p>
     
     <p>
-      One place where Git is slower is in the initial clone operation.
-      Here, Git is downloading the entire history rather than only the latest
-      version. As seen in the above charts, it's not considerably slower for an operation
-      that is only performed once.
+      <%= t(".p9") %>
     </p>
     
     <table class="benchmarks">
       <tbody>
         <tr>
-          <th>Operation</th>
+          <th><%= t(".operation") %></th>
           <th></th>
           <th class="right">Git*</th>
           <th class="right">Git</th>
           <th class="right">SVN</th>
         </tr>
-        <tr><td nowrap="">Clone</td><td class="desc">Clone and shallow clone(*) in Git vs checkout in SVN</td><td class="number"> 21.0</td><td class="number">107.5</td><td class="number"> 14.0</td></tr>
-        <tr><td nowrap="">Size (M)</td><td class="desc">Size of total client side data and files after clone/checkout (in M)</td><td></td><td class="number">181.0</td><td class="number">132.0</td></tr>
-      </tbody>
+        <tr><td nowrap=""><%= t(".clone") %></td><td class="desc"><%= t(".clone_desc") %></td><td class="number"> 21.0</td><td class="number">107.5</td><td class="number"> 14.0</td></tr>
+        <tr><td nowrap=""><%= t(".size_m") %></td><td class="desc"><%= t(".clone_desc") %></td><td></td><td class="number">181.0</td><td class="number">132.0</td></tr>
+        </tbody>
     </table>
     
     <p>
-      It's also interesting to note that the size of the data on the client side
-      is very similar even though Git also has every version of every file for the
-      entire history of the project. This illustrates how efficient it is at compressing
-      and storing data on the client side.
+      <%= t(".p10") %>
     </p>
     
     <div class="bottom-nav" style="display: block;">
-      <a href="#branching-and-merging" class="previous" data-section-id="branching-and-merging">← Branching and Merging</a>
-      <a href="#distributed" class="next" data-section-id="distributed">Distributed →</a>
+      <a href="#branching-and-merging" class="previous" data-section-id="branching-and-merging"><%= t(".branching_and_merging") %></a>
+      <a href="#distributed" class="next" data-section-id="distributed"><%= t(".distributed") %></a>
     </div>
 
   </section>
-

--- a/app/views/about/_staging_area.html.erb
+++ b/app/views/about/_staging_area.html.erb
@@ -1,26 +1,25 @@
  <section class="about" id="staging-area" style="display: none;">
-    <h2>Staging Area</h2>
+    <h2><%= t(".staging_area") %></h2>
     <p>
-    Unlike the other systems, Git has something called the "staging area" or "index". This is an intermediate area where commits can be formatted and reviewed before completing the commit.
+    <%= t(".p1") %>
     </p>
     <p>
-    One thing that sets Git apart from other tools is that it's possible to quickly stage some of your files and commit them without committing all of the other modified files in your working directory or having to list them on the command line during the commit.
+    <%= t(".p2") %>
     </p>
     <p class="center">
-    <img src="/images/about/index1@2x.png" width="336" height="194" alt="Index 1">
+    <img src="/images/about/index1@2x.png" width="336" height="194" alt="<%= t(".img1_alt") %>">
     </p>
     <p>
-    This allows you to stage only portions of a modified file. Gone are the days of making two logically unrelated modifications to a file before you realized that you forgot to commit one of them. Now you can just stage the change you need for the current commit and stage the other change for the next commit. This feature scales up to as many different changes to your file as needed.
+    <%= t(".p3") %>
     </p>
     <p>
-    Of course, Git also makes it easy to ignore this feature if you don't want that kind of control — just add a '-a' to your commit command in order to add all changes to all files to the staging area.
+    <%= t(".p4") %>
     </p>
     <p class="center">
-    <img src="/images/about/index2@2x.png" width="338" height="185" alt="Index 2">
+    <img src="/images/about/index2@2x.png" width="338" height="185" alt="<%= t(".img2_alt") %>">
     </p>
     <div class="bottom-nav" style="display: block;">
-      <a href="#info-assurance" class="previous" data-section-id="info-assurance">← Data Assurance</a>
-      <a href="#free-and-open-source" class="next" data-section-id="free-and-open-source">Free and Open Source →</a>
+      <a href="#info-assurance" class="previous" data-section-id="info-assurance"><%= t(".data_assurance") %></a>
+      <a href="#free-and-open-source" class="next" data-section-id="free-and-open-source"><%= t(".free_and_open_source") %></a>
     </div>
   </section>
-

--- a/app/views/about/index.html.erb
+++ b/app/views/about/index.html.erb
@@ -1,25 +1,25 @@
 <div id="main">
   
-  <h1>About</h1>
+  <h1><%= t(".about") %></h1>
   
   <ol id="about-nav">
     <li>
-      <a href="#branching-and-merging" class="three-line current" id="nav-branching-and-merging" data-section-id="branching-and-merging">Branching and Merging</a>
+      <a href="#branching-and-merging" class="three-line current" id="nav-branching-and-merging" data-section-id="branching-and-merging"><%= t(".branching_and_merging") %></a>
     </li>
     <li>
-      <a href="#small-and-fast" class="two-line" id="nav-small-and-fast" data-section-id="small-and-fast">Small and Fast</a>
+      <a href="#small-and-fast" class="two-line" id="nav-small-and-fast" data-section-id="small-and-fast"><%= t(".small_and_fast") %></a>
     </li>
     <li>
-      <a href="#distributed" class="one-line" id="nav-distributed" data-section-id="distributed">Distributed</a>
+      <a href="#distributed" class="one-line" id="nav-distributed" data-section-id="distributed"><%= t(".distributed") %></a>
     </li>
     <li>
-      <a href="#info-assurance" class="two-line" id="nav-info-assurance" data-section-id="info-assurance">Data Assurance</a>
+      <a href="#info-assurance" class="two-line" id="nav-info-assurance" data-section-id="info-assurance"><%= t(".data_assurance") %></a>
     </li>
     <li>
-      <a href="#staging-area" class="two-line" id="nav-staging-area" data-section-id="staging-area">Staging Area</a>
+      <a href="#staging-area" class="two-line" id="nav-staging-area" data-section-id="staging-area"><%= t(".stating_area") %></a>
     </li>
     <li>
-      <a href="#free-and-open-source" class="three-line" id="nav-free-and-open-source" data-section-id="free-and-open-source">Free and Open Source</a>
+      <a href="#free-and-open-source" class="three-line" id="nav-free-and-open-source" data-section-id="free-and-open-source"><%= t(".free_and_open_source") %></a>
     </li>
   </ol>
 

--- a/app/views/books/_chapters.html.erb
+++ b/app/views/books/_chapters.html.erb
@@ -1,4 +1,4 @@
-<a class="dropdown-trigger" id="book-chapters-trigger" data-panel-id="chapters-dropdown" href="#">Chapters ▾</a>
+<a class="dropdown-trigger" id="book-chapters-trigger" data-panel-id="chapters-dropdown" href="#"><%= t(".chapters") %></a>
 <div class='dropdown-panel' id='chapters-dropdown'>
   <div class="three-column">
     <div class='column-left'>
@@ -11,7 +11,7 @@
       <%= render :partial => 'chapter_listings', :locals => {:column => 3} %>
       <ol class="book-toc">
         <li class='chapter'>
-          <h2><a href="/book/commands">Index of Commands</a></h2>
+          <h2><a href="/book/commands"><%= t(".index_of_commands") %></a></h2>
         </li>
       </ol>
     </div>

--- a/app/views/books/_ebooks.html.erb
+++ b/app/views/books/_ebooks.html.erb
@@ -1,1 +1,1 @@
-<p>Download this book in <a href="https://github.s3.amazonaws.com/media/progit.en.pdf">PDF</a>, <a href="https://github.s3.amazonaws.com/media/pro-git.en.mobi">mobi</a>, or <a href="https://github.s3.amazonaws.com/media/progit.epub">ePub</a> form for free.</p>
+<%= t(".p1_html") %>

--- a/app/views/books/_translations.html.erb
+++ b/app/views/books/_translations.html.erb
@@ -1,5 +1,5 @@
 <p>
-This book is translated into 
+  <%= t(".translated_into") %>
   <a href="/book/de">German</a>,
   <a href="/book/zh">中文</a>,
   <a href="/book/fr">French</a>,
@@ -11,7 +11,7 @@ This book is translated into
   <a href="/book/cs">Czech</a>.
 </p>
 <p>
-Partial translations available in
+<%= t(".partial_tanslations") %>
   <a href="/book/ar">Arabic</a>,
   <a href="/book/es">Spanish</a>,
   <a href="/book/id">Indonesian</a>,
@@ -23,7 +23,7 @@ Partial translations available in
   <a href="/book/zh-tw">Taiwanese Mandarin</a>,
 </p>
 <p>
-Translations started for
+<%= t(".translations_started_for") %>
   <a href="/book/az">Azerbaijani</a>,
   <a href="/book/be">Belarusian</a>,
   <a href="/book/ca">Catalan</a>,
@@ -38,6 +38,5 @@ Translations started for
 </p>
 <hr class="sidebar"/>
 <p>
-The source of this book and the translations are <a href="https://github.com/progit/progit">hosted on GitHub.</a></br>
-Patches, suggestions, and comments are welcome.
+<%= t(".p1_html") %>
 </p>

--- a/app/views/books/commands.html.erb
+++ b/app/views/books/commands.html.erb
@@ -2,7 +2,7 @@
 <% @subsection = 'book' %>
 
 <div id='main' class='book'>
-  <h1>Index of Commands</h1>
+  <h1><%= t(".index_of_commands") %></h1>
   <table class="commands">
   <% @groups.each do |title, commands| %>
     <tr>

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -1,6 +1,6 @@
 <%- @section    = 'documentation' %>
 <%- @subsection = 'book' %>
-<%- @page_title = "Git - Book" %>
+<%- @page_title = t(".page_title") %>
 
 <% content_for :sidebar do %>
   <%= render 'ebooks' %>
@@ -11,7 +11,7 @@
   <h1>Book</h1>
   <img style="float:right;margin: -20px 40px 0 40px;" src="/images/books/pro-git@2x.jpg" width="118" height="157" />
   <p>
-  The entire Pro Git book, written by Scott Chacon and published by Apress, is available here. All content is licensed under the <a href="http://creativecommons.org/licenses/by-nc-sa/3.0/">Creative Commons Attribution Non Commercial Share Alike 3.0 license</a>.  Print versions of the book are available on <a href="http://www.amazon.com/gp/product/1430218339?ie=UTF8&camp=1789&creative=9325&creativeASIN=1430218339&linkCode=as2&tag=git-sfconservancy-20">Amazon.com</a>.</>
+    <%= t(".main_p1_html") %>
   </p>
   <ol class='book-toc'>
     <% @book.chapters.each do |chapter| %>
@@ -30,8 +30,7 @@
     </li>
   <% end %>
   <li class='chapter'>
-    <h2><a href="/book/commands">Index of Commands</a></h2>
+    <h2><a href="/book/commands"><%= t(".index_of_commands") %></a></h2>
   </li>
   </ol>
 </div>
-

--- a/app/views/community/index.html.haml
+++ b/app/views/community/index.html.haml
@@ -1,37 +1,36 @@
 - @section = "community"
 - @subsection = ""
-- @page_title = "Git - Community"
+- @page_title = t(".page_title")
 
 - content_for :sidebar do
   = render 'shared/book'
 
 %div#main
-  %h1 Community
+  %h1 #{t('.main_h1')}
 
-  %h2 Mailing List
-
-  %p
-    Questions or comments for the Git community can be sent to the mailing list by using the email address <a href="mailto:git@vger.kernel.org">git@vger.kernel.org</a>. <strong>Bug reports should be sent to this mailing list.</strong> 
+  %h2 #{t('.main_h2_mailing')}
 
   %p
-    You do not need to subscribe: you will be Cc&apos;d in replies. Please keep the Cc list intact when replying (use &quot;Reply to all&quot;). Greylisting may delay your first post for a few hours.
+    #{t('.main_p1_html')}
+
+  %p
+    #{t('.main_p2')}
     
   %p
-    The <a href="http://dir.gmane.org/gmane.comp.version-control.git">archive</a> can be found on Gmane.  Click <a href="mailto:majordomo@vger.kernel.org?body=subscribe git">here</a> to subscribe.  
+    #{t('.main_p3_html')}  
 
   %p
-    There is also <a href="https://groups.google.com/forum/?fromgroups#!forum/git-users">Git user mailing list</a> on Google Groups which is a nice place for beginners to ask about anything.
+    #{t('.main_p4_html')}
 
-  %h2 IRC Channel
-
-  %p
-    If the manpages and this book aren’t enough and you need in-person help, you can try the <span class="highlight fixed">#git</span> channel on the Freenode IRC server (<strong>irc.freenode.net</strong>). These channels are regularly filled with hundreds of people who are all very knowledgeable about Git and are often willing to help.
+  %h2 #{t('.main_h2_irc')}
 
   %p
-    If you need specific help about one of the for-profit Git hosting sites, you might try their own IRC channels (such as <span class="highlight fixed">#github</span> or <span class="highlight fixed">#gitorious</span>) on the same IRC server.
-
-  %h2 Contributing to Git
+    #{t('.main_p5_html')}
 
   %p
-    The <a href="https://github.com/git/git/tree/master/Documentation">Documentation directory</a> in the Git source code has several files of interest to developers who are looking to help contribute. After reading the <a href="https://github.com/git/git/blob/master/Documentation/CodingGuidelines">coding guidelines</a>, you can learn <a href="https://github.com/git/git/blob/master/Documentation/SubmittingPatches">how to submit patches</a>. For those looking to get more deeply involved, there is a <a href="https://github.com/git/git/blob/master/Documentation/howto/maintain-git.txt">howto for Git maintainers</a>.
+    #{t('.main_p6_html')}
 
+  %h2 #{t('.main_h2_contributing')}
+
+  %p
+    #{t('.main_p7_html')}

--- a/app/views/doc/ext.html.erb
+++ b/app/views/doc/ext.html.erb
@@ -1,109 +1,108 @@
 <%- @section    = 'documentation' %>
 <%- @subsection = 'external-links' %>
-<%- @page_title = 'Git - External Links' %>
+<%- @page_title = t(".page_title") %>
 
 <div id='main'>
-  <h1>External Links</h1>
-  <h2>Tutorials</h2>
+  <h1><%= t(".external_links") %></h1>
+  <h2><%= t(".tutorials") %></h2>
   <div class='two-column'>
     <div class='column-left'>
-      <h3>Short &amp; Sweet</h3>
+      <h3><%= t(".short_and_sweet_html") %></h3>
       <ul class='content-list'>
         <li>
-          <h4><a href="http://gitref.org/">Introductory Reference &amp; Tutorial</a></h4>
+          <h4><a href="http://gitref.org/"><%= t(".introductory_reference") %></a></h4>
           <p class='description'>
-            This introductory walkthrough acts as a nice tutorial.
+            <%= t(".introductory_ref_description") %>
           </p>
         </li>
         <li>
-          <h4><a href="/docs/gittutorial">Official Git Tutorial</a></h4>
+          <h4><a href="/docs/gittutorial"><%= t(".official_git_tut") %></a></h4>
           <p class='description'>
-            The official gittutorial man page is a good place to start.
+            <%= t(".official_git_tut_description") %>
           </p>
         </li>
         <li>
-          <h4><a href="/docs/everyday">Everyday Git</a></h4>
+          <h4><a href="/docs/everyday"><%= t(".everyday_git") %></a></h4>
           <p class='description'>
-            Learn the basics with 20 of the most common commands.
+            <%= t(".everyday_git_description") %>
           </p>
         </li>
         <li>
-          <h4><a href="http://gitimmersion.com/">Git Immersion</a></h4>
+          <h4><a href="http://gitimmersion.com/"><%= t(".git_immersion") %></a></h4>
           <p class='description'>
-            A guided tour that walks through the fundamentals of Git.
+            <%= t(".git_immersion_description") %>
           </p>
         </li>
       </ul>
     </div>
     <div class='column-right'>
-      <h3>Diving Deeper</h3>
+      <h3><%= t(".diving_deeper") %></h3>
       <ul class='content-list'>
         <li>
           <h4><a
-		  href="http://rypress.com/tutorials/git/index.html">Ry&rsquo;s Git
-		  Tutorial</a></h4>
+		  href="http://rypress.com/tutorials/git/index.html"><%= t(".rys_git_tutorial_html") %></a></h4>
           <p class='description'>
-			A hands-on introduction to the entire Git porcelain.
+			         <%= t(".rys_git_tut_description") %>
           </p>
         </li>
         <li>
-          <h4><a href="http://hoth.entp.com/output/git_for_designers.html">Git for Designers</a></h4>
+          <h4><a href="http://hoth.entp.com/output/git_for_designers.html"><%= t(".git_for_designers") %></a></h4>
           <p class='description'>
-            No knowledge of version control? No problem.
+            <%= t(".git_for_designers_description") %>
           </p>
         </li>
         <li>
-          <h4><a href="http://eagain.net/articles/git-for-computer-scientists/">Git for Computer Scientists</a></h4>
+          <h4><a href="http://eagain.net/articles/git-for-computer-scientists/"><%= t(".git_for_computer_scientists") %></a></h4>
           <p class='description'>
-            A quick introduction to Git internals for people who aren't scared by words like Directed Acyclic Graph.
+            <%= t(".git_for_computer_scientists_desc") %>
           </p>
         </li>
         <li>
-          <h4><a href="http://www-cs-students.stanford.edu/~blynn/gitmagic/">Git Magic</a></h4>
+          <h4><a href="http://www-cs-students.stanford.edu/~blynn/gitmagic/"><%= t(".git_magic") %></a></h4>
           <p class='description'>
-            An alternative book with the source <a href="http://github.com/blynn/gitmagic/tree/master">online</a>.
+            <%= t(".git_magic_description_html") %>
           </p>
         </li>
         <li>
-          <h4><a href="http://help.github.com/">Help.GitHub</a></h4>
+          <h4><a href="http://help.github.com/"><%= t(".help_github") %></a></h4>
           <p class='description'>
-            Guides on a variety of Git and GitHub related topics.
+            <%= t(".help_github_description") %>
           </p>
         </li>
       </ul>
     </div>
   </div>
-  <h2>Books</h2>
+  <h2><%= t(".books") %></h2>
   <div class='two-column'>
     <div class='column-left'>
       <ul class='books-list'>
         <li>
           <a href="http://www.pragprog.com/titles/tsgit/pragmatic-version-control-using-git"><img src="/images/books/pragmatic-version-control@2x.jpg" width="107" height="128" /></a>
-          <h4><a href="http://www.pragprog.com/titles/tsgit/pragmatic-version-control-using-git">Pragmatic Version Control Using Git</a></h4>
+          <h4><a href="http://www.pragprog.com/titles/tsgit/pragmatic-version-control-using-git"><%= t(".pragmatic_git") %></a></h4>
           <p class='description'>
-            By Travis Swicegood
+            <%= t(".pragmatic_git_description") %>
           </p>
         </li>
         <li>
           <a href="/book"><img src="/images/books/pro-git@2x.jpg" width="107" height="141" /></a>
-          <h4><a href="/book">Pro Git</a></h4>
+          <h4><a href="/book"><%= t(".pro_git") %></a></h4>
           <p class='description'>
-            By Scott Chacon
+            <%= t(".pro_git_description") %>
             <img class="creative-commons" src="/images/creative-commons@2x.png" width="115" height="28" />
           </p>
         </li>
         <li>
           <a href="http://peepcode.com/products/git-internals-pdf"><img src="/images/books/git-internals@2x.jpg" width="107" height="81" /></a>
-          <h4><a href="http://peepcode.com/products/git-internals-pdf">Git Internals Peepcode PDF</a></h4>
+          <h4><a href="http://peepcode.com/products/git-internals-pdf"><%= t(".git_internals") %></a></h4>
           <p class='description'>
-            By Scott Chacon
+            <%= t(".git_internals_description") %>
           </p>
         </li>
         <li>
           <a href="http://cbx33.github.com/gitt/"><img src="/images/books/git-in-the-trenches@2x.jpg" /></a>
-          <h4><a href="http://cbx33.github.com/gitt/">Git in the Trenches</a></h4>
+          <h4><a href="http://cbx33.github.com/gitt/"><%= t(".git_in_trenches") %></a></h4>
           <p class='description'>
-            By Peter Savage
+            <%= t(".git_in_trenches_description") %>
             <img class="creative-commons" src="/images/creative-commons.png" />
         </li>
       </ul>
@@ -112,23 +111,23 @@
       <ul class='books-list'>
         <li>
           <a href="http://www.amazon.com/Version-Control-Git-collaborative-development/dp/0596520123"><img src="/images/books/version-control-with-git@2x.jpg" width="107" height="140" /></a>
-          <h4><a href="http://www.amazon.com/Version-Control-Git-collaborative-development/dp/1449316387">Version Control with Git, 2nd ed.</a></h4>
+          <h4><a href="http://www.amazon.com/Version-Control-Git-collaborative-development/dp/1449316387"><%= t(".version_control") %></a></h4>
           <p class='description'>
-            By Jon Loeliger &amp; Matthew McCullough
+            <%= t(".version_control_description") %>
           </p>
         </li>
         <li>
           <a href="http://www.pragprog.com/titles/pg_git/pragmatic-guide-to-git"><img src="/images/books/pragmatic-guide-to-git@2x.jpg" width="107" height="162" /></a>
-          <h4><a href="http://www.pragprog.com/titles/pg_git/pragmatic-guide-to-git">Pragmatic Guide to Git</a></h4>
+          <h4><a href="http://www.pragprog.com/titles/pg_git/pragmatic-guide-to-git"><%= t(".pragmatic_guide") %></a></h4>
           <p class='description'>
-            By Travis Swicegood
+            <%= t(".pragmatic_guide_description") %>
           </p>
         </li>
         <li>
           <a href="http://www.packtpub.com/git-version-control-for-everyone/book"><img src="http://www.packtpub.com/sites/default/files/7522OS_mockupcover_bg_0.jpg" width="107"/></a>
-          <h4><a href="http://www.packtpub.com/git-version-control-for-everyone/book">Git: Version Control for Everyone</a></h4>
+          <h4><a href="http://www.packtpub.com/git-version-control-for-everyone/book"><%= t(".git_for_everyone") %></a></h4>
           <p class='description'>
-            By Ravishankar Somasundaram
+            <%= t(".git_for_everyone_description") %>
           </p>
         </li>
       </ul>
@@ -140,9 +139,9 @@
       <ul class='video-thumbnails'>
         <li>
           <a href="http://www.youtube.com/watch?v=4XpnKHJAok8"><img src="/images/videos/linus@2x.jpg" width="294" height="180" /></a>
-          <h4><a href="http://www.youtube.com/watch?v=4XpnKHJAok8">Tech Talk: Linus Torvalds on Git</a></h4>
+          <h4><a href="http://www.youtube.com/watch?v=4XpnKHJAok8"><%= t(".tech_talk") %></a></h4>
           <p class='description'>
-            Linus Torvalds visits Google to share his thoughts on Git, the SCM system he created.
+            <%= t(".tech_talk_description") %>
           </p>
         </li>
       </ul>
@@ -151,9 +150,9 @@
       <ul class='video-thumbnails'>
         <li>
           <a href="http://www.youtube.com/watch?v=ZDR433b0HJY"><img src="/images/videos/introgit@2x.jpg" width="294" height="180" /></a>
-          <h4><a href="http://www.youtube.com/watch?v=ZDR433b0HJY">Introduction to Git: Scott Chacon</a></h4>
+          <h4><a href="http://www.youtube.com/watch?v=ZDR433b0HJY"><%= t(".introduction_to_git") %></a></h4>
           <p class='description'>
-            This talk introduces the Git Version Control System by looking at what Git is doing when you run the commands you need to do basic version control with it.
+            <%= t(".introduction_to_git_description") %>
           </p>
         </li>
       </ul>

--- a/app/views/doc/index.html.haml
+++ b/app/views/doc/index.html.haml
@@ -1,40 +1,40 @@
 - @section = "documentation"
-- @page_title = "Git - Documentation"
+- @page_title = t(".page_title")
 
 - content_for :sidebar do
   = render 'shared/book'
 
 %div#main
-  %h1 Documentation
+  %h1 #{t(".documentation")}
 
-  %h2 Reference
+  %h2 #{t(".reference")}
 
   %div.callout.ref-manual
-    %h3= link_to "Reference Manual", "/docs"
+    %h3= link_to t(".reference_manual"), "/docs"
     %p
-      The official and comprehensive <strong>man pages</strong> that are included in the Git package itself.
+      #{t(".callout_p1")}
 
   %p.quickref
-    Quick reference guides:
-    =link_to "Heroku Cheat Sheet", "https://na1.salesforce.com/help/doc/en/salesforce_git_developer_cheatsheet.pdf"
+    #{t(".quick_reference")}
+    =link_to t(".heroku_cheat_sheet"), "https://na1.salesforce.com/help/doc/en/salesforce_git_developer_cheatsheet.pdf"
     %small.light (PDF) &nbsp;|&nbsp;
-    =link_to "Visual Git Cheat Sheet", "http://ndpsoftware.com/git-cheatsheet.html"
+    =link_to t(".visual_git_cheat_sheet"), "http://ndpsoftware.com/git-cheatsheet.html"
     %small.light (SVG | PNG)
 
-  %h2 Book
+  %h2 #{t(".book")}
 
   %div#book-container
     %div#book-intro
       %p
-        Pro Git is written by Scott Chacon and published by Apress.
+        #{t(".book_intro_p1")}
 
       %p
-        Print copies can be purchased from <a href="http://www.amazon.com/gp/product/1430218339?ie=UTF8&camp=1789&creative=9325&creativeASIN=1430218339&linkCode=as2&tag=git-sfconservancy-20">Amazon</a> and <a href="https://github.s3.amazonaws.com/media/progit.en.pdf">PDF</a>, <a href="https://github.s3.amazonaws.com/media/pro-git.en.mobi">mobi</a>, and <a href="https://github.s3.amazonaws.com/media/progit.epub">ePub</a> versions are available for free.
+        #{t(".book_intro_p2_html")}
       %p
-        <a href="#" id="open-book">Back to book →</a>
+        <a href="#" id="open-book">#{t(".back_to_book")}</a>
       %p.license
         %img.creative-commons{:src => "/images/creative-commons@2x.png", :width => 115, :height => 28}
-        All content under the Creative Commons Attribution Non Commercial Share Alike 3.0 license.
+        #{t(".creative_commons")}
     %div#flippy-book
       %div#book-inside-page
         %span.header Scott Chacon
@@ -45,7 +45,7 @@
                 = chapter.number.to_s + '.'
                 %a{:href=>"/book/#{@book.code}/#{chapter.sections.first.slug}"}= chapter.title
           %li.chapter
-            %h2 <a href="/book/commands">Index of Commands</a>
+            %h2 <a href="/book/commands">#{t(".index_of_commands")}</a>
       %div#book-cover.open
         %div#book-cover-outside.face
           Pro Git
@@ -57,10 +57,10 @@
                 %h2
                   = chapter.number.to_s + '.'
                   %a{:href=>"/book/#{@book.code}/#{chapter.sections.first.slug}"}= chapter.title
-          <a href="#" id="about-book">Book information and downloads</a>
+          <a href="#" id="about-book">#{t(".book_information")}</a>
 
 
-  %h2 Videos
+  %h2 #{t(".videos")}
 
   - groups = @videos[0,4].group_by { |i| i[0] % 2 }
 
@@ -86,8 +86,7 @@
   %p
     %strong= link_to "See all videos →", "/videos"
 
-  %h2 External Links
+  %h2 #{t(".external_links")}
 
   %p
-    The <a href="/documentation/external-links">External Links section</a> is a curated, ever-evolving collection of tutorials, books, videos, and other Git resources.
-
+    #{t(".external_links_p1_html")}

--- a/app/views/doc/ref.html.erb
+++ b/app/views/doc/ref.html.erb
@@ -1,15 +1,15 @@
 <%- @section    = 'documentation' %>
 <%- @subsection = 'reference' %>
-<%- @page_title = "Git - Reference" %>
+<%- @page_title = t(".page_title") %>
 
 <div id='main'>
-  <h1>Reference</h1>
+  <h1><%= t(".reference") %></h1>
   <div class='callout quickref'>
     <p>
-      Quick reference guides:
-      <a href=" https://na1.salesforce.com/help/doc/en/salesforce_git_developer_cheatsheet.pdf">Heroku Cheat Sheet</a>
+      <%= t(".quick_reference") %>
+      <a href=" https://na1.salesforce.com/help/doc/en/salesforce_git_developer_cheatsheet.pdf"><%= t(".heroku_cheat_sheet") %></a>
       <small class='light'>(PDF) &nbsp;|&nbsp;</small>
-      <a href="http://ndpsoftware.com/git-cheatsheet.html">Visual Git Cheat Sheet</a>
+      <a href="http://ndpsoftware.com/git-cheatsheet.html"><%= t(".visual_git_cheat_sheet") %></a>
       <small class='light'>(SVG | PNG)</small>
     </p>
   </div>

--- a/app/views/doc/videos.html.erb
+++ b/app/views/doc/videos.html.erb
@@ -1,11 +1,11 @@
 <%- @section    = 'documentation' %>
 <%- @subsection = 'videos' %>
-<%- @page_title = 'Git - Videos' %>
+<%- @page_title = t(".page_title") %>
 
 <% groups = @videos.group_by { |i| i[0] % 2 } %>
 
 <div id='main'>
-  <h1>Videos</h1>
+  <h1><%= t(".videos") %></h1>
   <div class='two-column'>
     <div class='column-left'>
       <ul class='video-thumbnails'>
@@ -14,7 +14,7 @@
             <a href="/video/<%= video[4] %>"><img src="/images/video/ep<%= video[0] %>@2x.png" width="294" height="164" /></a>
             <h4><a href="/video/<%= video[4] %>"><%= video[3] %></a></h4>
             <p class='description'>
-              <strong>Length:</strong> <%= video[5] %>
+              <strong><%= t(".length") %></strong> <%= video[5] %>
             </p>
           </li>
         <% end %>
@@ -27,7 +27,7 @@
             <a href="/video/<%= video[4] %>"><img src="/images/video/ep<%= video[0] %>@2x.png" width="294" height="164" /></a>
             <h4><a href="/video/<%= video[4] %>"><%= video[3] %></a></h4>
             <p class='description'>
-              <strong>Length:</strong> <%= video[5] %>
+              <strong><%= t(".length") %></strong> <%= video[5] %>
             </p>
           </li>
         <% end %>

--- a/app/views/downloads/download_linux.html.erb
+++ b/app/views/downloads/download_linux.html.erb
@@ -2,8 +2,8 @@
 <%- @subsection = "" %>
 
 <div id="main">
-  <h1>Download for Linux and Unix</h1>
-  <p>It is easiest to install Git on Linux using the preferred package manager of your Linux distribution.</p>
+  <h1><%= t(".main_h1") %></h1>
+  <p><%= t(".main_p1") %></p>
 
   <h3>Debian/Ubuntu</h3>
   <code>$ apt-get install git</code>

--- a/app/views/downloads/downloading.html.haml
+++ b/app/views/downloads/downloading.html.haml
@@ -1,46 +1,45 @@
 - @section = "downloads"
 - @subsection = ""
-- @page_title = "Git - Downloading Package"
+- @page_title = t(".page_title")
 
 - content_for :sidebar do
   = render 'shared/book'
 
 %div#main
-  %h1 Downloading Git
+  %h1 #{t(".main_h1")}
 
   %div.callout.downloading
-    %h3 Your download is starting...
+    %h3 #{t(".callout_h3")}
 
-    %p=raw "You are downloading version <strong>#{@download.version.name}</strong> of Git for the <strong>#{@platform.capitalize}</strong> platform. This is the most recent <a href='#{@project_url}'>maintained build</a> for this platform. It was released <strong>#{time_ago_in_words @download.release_date} ago</strong>, on #{@download.release_date.strftime("%Y-%m-%d")}."
+    %p #{t(".callout_p1_html", download_version_name: @download.version.name, platform_capitalized: @platform.capitalize, project_url: @project_url, released_time_ago: time_ago_in_words(@download.release_date), download_release_date: @download.release_date.strftime("%Y-%m-%d"))}
 
-    %p=raw "<strong>If your download hasn't started, <a href=\"#{@download.url}\">click here to download manually</a>.</strong>"
+    %p #{t(".callout_p2_html", download_url: @download.url)}
 
-    %p.small=raw "The current source code release is version <strong>#{@latest.name}</strong>. If you want the newer version, you can build it from <a href=\"#{@source_url}\">the source code</a>."
+    %p.small #{t(".callout_p3_html", latest_name: @latest.name, source_url: @source_url)}
 
   %iframe{:width => 1, :height => 1, :frameborder => 0, :src => @download.url}
 
-  %h2 Now What?
+  %h2 #{t(".now_what")}
 
   %p
-    Now that you have downloaded Git, it's time to start using it.
+    #{t(".now_what_p1")}
 
   %ul#download-next-steps
     %li
       <a href="/book">
       <img src="/images/icons/nav-read-book.png" />
-      <h3>Read the Book</h3>
-      <p>Dive into the Pro Git book and learn at your own pace.</p>
+      <h3>#{t(".next_steps_li_1_h3")}</h3>
+      <p>#{t(".next_steps_li_1_p1")}</p>
       </a>
     %li
       <a href="/downloads/guis">
       <img src="/images/icons/nav-download-gui.png" />
-      <h3>Download a GUI</h3>
-      <p>Several free and commercial GUI tools are available for the #{@platform.capitalize} platform.</p>
+      <h3>#{t(".next_steps_li_2_h3")}</h3>
+      <p>#{t(".next_steps_li_2_p1", platform_capitalized: @platform.capitalize)}</p>
       </a>
     %li
       <a href="/community">
       <img src="/images/icons/nav-get-involved.png" />
-      <h3>Get Involved</h3>
-      <p>A knowledgeable Git community is available to answer your questions.</p>
+      <h3>#{t(".next_steps_li_3_h3")}</h3>
+      <p>#{t(".next_steps_li_3_p1")}</p>
       </a>
-

--- a/app/views/downloads/guis/index.html.haml
+++ b/app/views/downloads/guis/index.html.haml
@@ -1,90 +1,89 @@
 - @section = "downloads"
 - @subsection = "guis"
-- @page_title = "Git - GUI Clients"
+- @page_title = t(".page_title")
 
 - content_for :sidebar do
   = render 'shared/book'
 
 %div#main
-  %h1 GUI Clients
+  %h1 #{t(".main_h1")}
 
   %p
-    Git comes with built-in GUI tools for committing (<a href="/docs/git-gui">git-gui</a>) and browsing (<a href="/docs/gitk">gitk</a>), but there are several third-party tools for users looking for platform-specific experience.
+    #{t(".main_p1_html")}
 
   %p
-    =link_to "Only show GUIs for my OS (Linux)", "#", {:class => "subtle-button", :id => "gui-os-filter", 'data-os' => 'linux'}
+    =link_to t(".main_p2_link"), "#", {:class => "subtle-button", :id => "gui-os-filter", 'data-os' => 'linux'}
     %span#os-filter-count
       %strong 0
       %span.os Linux
-      GUIs are highlighted below ↓
+      #{t(".main_p2_highlighted")}
 
   %div.two-column
     %div.column-left
       %ul.gui-thumbnails
         %li.mac
           =link_to(image_tag('guis/github-for-mac@2x.png', {:width => '294', :height => '166'}), "http://mac.github.com/")
-          %h4= link_to "GitHub for Mac", "http://mac.github.com/"
+          %h4= link_to t(".clients_github_for_mac"), "http://mac.github.com/"
           %p.description
-            <strong>Platforms:</strong> Mac</br>
-            <strong>Price:</strong> Free
+            <strong>#{t(".clients_platforms")}</strong> Mac</br>
+            <strong>#{t(".clients_price")}</strong> #{t(".clients_price_free")}
         %li.windows
           =link_to(image_tag('guis/github-for-windows@2x.png', {:width => '294', :height => '166'}), "http://windows.github.com/")
-          %h4= link_to "GitHub for Windows", "http://windows.github.com/"
+          %h4= link_to t(".clients_github_for_windows"), "http://windows.github.com/"
           %p.description
-            <strong>Platforms:</strong> Windows</br>
-            <strong>Price:</strong> Free
+            <strong>#{t(".clients_platforms")}</strong> Windows</br>
+            <strong>#{t(".clients_price")}</strong> #{t(".clients_price_free")}
         %li.mac
           =link_to(image_tag('guis/gitx@2x.png', {:width => '294', :height => '166'}), "http://rowanj.github.io/gitx/")
           %h4= link_to "GitX-dev ", "http://rowanj.github.io/gitx/"
           %p.description
-            <strong>Platforms:</strong> Mac</br>
-            <strong>Price:</strong> Free
+            <strong>#{t(".clients_platforms")}</strong> Mac</br>
+            <strong>#{t(".clients_price")}</strong> #{t(".clients_price_free")}
         %li.mac.windows
           =link_to(image_tag('guis/sourcetree@2x.png', {:width => '294', :height => '166'}), "http://www.sourcetreeapp.com/")
           %h4= link_to "SourceTree", "http://www.sourcetreeapp.com/"
           %p.description
-            <strong>Platforms:</strong> Mac, Windows</br>
-            <strong>Price:</strong> Free
+            <strong>#{t(".clients_platforms")}</strong> Mac, Windows</br>
+            <strong>#{t(".clients_price")}</strong> #{t(".clients_price_free")}
         %li.mac.windows.linux
           =link_to(image_tag('guis/smartgit@2x.png', {:width => '294', :height => '166'}), "http://www.syntevo.com/smartgit/index.html")
           %h4= link_to "SmartGit", "http://www.syntevo.com/smartgit/index.html"
           %p.description
-            <strong>Platforms:</strong> Windows, Mac, Linux</br>
-            <strong>Price:</strong> $79/user / Free for non-commercial use
+            <strong>#{t(".clients_platforms")}</strong> Windows, Mac, Linux</br>
+            <strong>#{t(".clients_price")}</strong> $79/user / Free for non-commercial use
     %div.column-right
       %ul.gui-thumbnails
         %li.mac
           =link_to(image_tag('guis/tower@2x.png', {:width => '294', :height => '166'}), "http://git-tower.com/")
           %h4= link_to "Tower", "http://www.git-tower.com/"
           %p.description
-            <strong>Platforms:</strong> Mac</br>
-            <strong>Price:</strong> $59/user (Free 30 day trial)
+            <strong>#{t(".clients_platforms")}</strong> Mac</br>
+            <strong>#{t(".clients_price")}</strong> $59/user (Free 30 day trial)
         %li.mac
           =link_to(image_tag('guis/gitbox@2x.png', {:width => '294', :height => '166'}), "http://gitboxapp.com/")
           %h4= link_to "Gitbox", "http://www.gitboxapp.com/"
           %p.description
-            <strong>Platforms:</strong> Mac</br>
-            <strong>Price:</strong> $14.99
+            <strong>#{t(".clients_platforms")}</strong> Mac</br>
+            <strong>#{t(".clients_price")}</strong> $14.99
         %li.windows
           =link_to(image_tag('guis/git-extensions@2x.png', {:width => '294', :height => '166'}), "http://code.google.com/p/gitextensions/")
           %h4= link_to "Git Extensions", "http://code.google.com/p/gitextensions/"
           %p.description
-            <strong>Platforms:</strong> Windows</br>
-            <strong>Price:</strong> Free
+            <strong>#{t(".clients_platforms")}</strong> Windows</br>
+            <strong>#{t(".clients_price")}</strong> #{t(".clients_price_free")}
         %li.mac.windows.linux
           =link_to(image_tag('guis/git-cola@2x.png', {:width => '294', :height => '166'}), "http://git-cola.github.com/")
           %h4= link_to "git-cola", "http://git-cola.github.com/"
           %p.description
-            <strong>Platforms:</strong> Windows, Mac, Linux</br>
-            <strong>Price:</strong> Free
+            <strong>#{t(".clients_platforms")}</strong> Windows, Mac, Linux</br>
+            <strong>#{t(".clients_price")}</strong> #{t(".clients_price_free")}
         %li.mac.windows.linux
           =link_to(image_tag('guis/giteye@2x.png', {:width => '294', :height => '166'}), "http://www.giteyeapp.com/")
           %h4= link_to "GitEye", "http://www.giteyeapp.com/"
           %p.description
-            <strong>Platforms:</strong> Windows, Mac, Linux</br>
-            <strong>Price:</strong> Free
+            <strong>#{t(".clients_platforms")}</strong> Windows, Mac, Linux</br>
+            <strong>#{t(".clients_price")}</strong> #{t(".clients_price_free")}
 
   %div.callout
     %p
-      There are other great GUI tools available as well. Have a look at the list of <a href="https://git.wiki.kernel.org/index.php/InterfacesFrontendsAndTools">interfaces, frontends and tools</a> in the Git Wiki.
-
+      #{t(".callout_p1_html")}

--- a/app/views/downloads/index.html.haml
+++ b/app/views/downloads/index.html.haml
@@ -1,6 +1,6 @@
 - @section = "downloads"
 - @subsection = ""
-- @page_title = "Git - Downloads"
+- @page_title = t(".page_title")
 
 - content_for :sidebar do
   = render 'shared/book'
@@ -8,7 +8,7 @@
 %div#main
   %div.two-column
     %div.column-left
-      %h1 Downloads
+      %h1 #{t(".downloads")}
       %div.callout
         %table.binaries
           %tr
@@ -19,7 +19,7 @@
             %td= link_to "Solaris", "/download/linux", {:class => 'icon solaris'}
 
       %p
-        <a href="http://code.google.com/p/git-core/downloads/list">Older releases</a> are available and the <a href="https://github.com/git/git">Git source repository</a> is on GitHub.
+        #{t(".older_releases_html")}
 
 
     %div.column-right
@@ -29,29 +29,29 @@
   %div.callout#more-downloads
     %div.two-column
       %div.column-left
-        %h2 GUI Clients
+        %h2 #{t(".gui_clients")}
 
         %p
-          Git comes with built-in GUI tools (<strong>git-gui</strong>, <strong>gitk</strong>), but there are several third-party tools for users looking for a platform-specific experience.
+          #{t(".gui_clients_p1_html")}
 
         %p
-          %strong= link_to "View GUI Clients →", "/downloads/guis"
+          %strong= link_to t(".gui_clients_p2"), "/downloads/guis"
 
       %div.column-right
-        %h2 Logos
+        %h2 #{t(".logos")}
 
-        %p Various Git logos in PNG (bitmap) and EPS (vector) formats are available for use in online and print projects.
+        %p #{t(".logos_p1")}
 
         %p
-          %strong= link_to "View Logos →", "/downloads/logos"
+          %strong= link_to t(".logos_p2"), "/downloads/logos"
 
-  %h2 Git via Git
+  %h2 #{t(".logos_p1")}
 
   %p
-    If you already have Git installed, you can get the latest development version via Git itself:
+    #{t(".git_via_git_p1")}
 
   %code
     git clone https://github.com/git/git
 
   %p
-    You can also always browse the current contents of the git repository using the <a href="https://github.com/git/git">web interface</a>.
+    #{t(".git_via_git_p2_html")}

--- a/app/views/downloads/logos/index.html.haml
+++ b/app/views/downloads/logos/index.html.haml
@@ -1,6 +1,6 @@
 - @section = "downloads"
 - @subsection = "logos"
-- @page_title = "Git - Logo Downloads"
+- @page_title = t(".page_title")
 
 - content_for :sidebar do
   = render 'shared/book'
@@ -13,28 +13,28 @@
       %ul.content-list
         %li
           =link_to(image_tag('logos/2color-lightbg@2x.png', {:width => 294, :height => 100}))
-          %h4 Full color Git logo for light backgrounds
+          %h4 #{t(".column_left_li1_h4")}
           %p.description
             =link_to "PNG (bitmap)", "/images/logos/downloads/Git-Logo-2Color.png"
             &middot;
             =link_to "EPS (vector)", "/images/logos/downloads/Git-Logo-2Color.eps"
         %li
           =link_to(image_tag('logos/1color-orange-lightbg@2x.png', {:width => 294, :height => 100}))
-          %h4 Orange Git logo for light backgrounds
+          %h4 #{t(".column_left_li2_h4")}
           %p.description
             =link_to "PNG (bitmap)", "/images/logos/downloads/Git-Logo-1788C.png"
             &middot;
             =link_to "EPS (vector)", "/images/logos/downloads/Git-Logo-1788C.eps"
         %li
           =link_to(image_tag('logos/1color-lightbg@2x.png', {:width => 294, :height => 100}))
-          %h4 One color Git logo for light backgrounds
+          %h4 #{t(".column_left_li3_h4")}
           %p.description
             =link_to "PNG (bitmap)", "/images/logos/downloads/Git-Logo-Black.png"
             &middot;
             =link_to "EPS (vector)", "/images/logos/downloads/Git-Logo-Black.eps"
         %li
           =link_to(image_tag('logos/1color-darkbg@2x.png', {:width => 294, :height => 100}))
-          %h4 One color Git logo for dark backgrounds
+          %h4 #{t(".column_left_li4_h4")}
           %p.description
             =link_to "PNG (bitmap)", "/images/logos/downloads/Git-Logo-White.png"
             &middot;
@@ -44,21 +44,21 @@
       %ul.content-list
         %li
           =link_to(image_tag('logos/logomark-orange@2x.png', {:width => 100, :height => 100}))
-          %h4 Orange logomark for light backgrounds
+          %h4 #{t(".column_right_li1_h4")}
           %p.description
             =link_to "PNG (bitmap)", "/images/logos/downloads/Git-Icon-1788C.png"
             &middot;
             =link_to "EPS (vector)", "/images/logos/downloads/Git-Icon-1788C.eps"
         %li
           =link_to(image_tag('logos/logomark-black@2x.png', {:width => 100, :height => 100}))
-          %h4 Black logomark for light backgrounds
+          %h4 #{t(".column_right_li2_h4")}
           %p.description
             =link_to "PNG (bitmap)", "/images/logos/downloads/Git-Icon-Black.png"
             &middot;
             =link_to "EPS (vector)", "/images/logos/downloads/Git-Icon-Black.eps"
         %li
           =link_to(image_tag('logos/logomark-white@2x.png', {:width => 100, :height => 100}))
-          %h4 White logomark for dark backgrounds
+          %h4 #{t(".column_right_li3_h4")}
           %p.description
             =link_to "PNG (bitmap)", "/images/logos/downloads/Git-Icon-White.png"
             &middot;
@@ -67,7 +67,7 @@
   %div#logo-license
     %p
       <img src="/images/creative-commons.png" />
-      Git Logo by <a href="http://twitter.com/jasonlong">Jason Long</a> is licensed under the <a href="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 Unported License</a>.
+      #{t(".logo_license_p1_html")}
 
     %p
-      This license lets others distribute, remix, tweak, and build upon your work, even commercially, as long as they credit you for the original creation. This is the most accommodating of the CC licenses offered. Recommended for maximum dissemination and use of licensed materials.
+      #{t(".logo_license_p2")}

--- a/app/views/shared/_book.html.erb
+++ b/app/views/shared/_book.html.erb
@@ -1,6 +1,4 @@
 <div class="callout">
-  <p>The entire <strong><a href="/book">Pro Git book</a></strong> written
-  by Scott Chacon is available to <a href="/book">read online for free</a>.
-  Dead tree versions are available on <a href="http://www.amazon.com/gp/product/1430218339?ie=UTF8&camp=1789&creative=9325&creativeASIN=1430218339&linkCode=as2&tag=git-sfconservancy-20">Amazon.com</a>. 
+  <%= t(".book_callout_html") %>
   </p>
 </div>

--- a/app/views/shared/_footer.html.haml
+++ b/app/views/shared/_footer.html.haml
@@ -1,9 +1,8 @@
 %footer
   %div.site-source
-    This <a href="https://github.com/github/gitscm-next/blob/master/README.md#license">open sourced</a> site is <a href="https://github.com/github/gitscm-next">hosted on GitHub.</a><br>
-    Patches, suggestions, and comments are welcome.
+    #{t(".site_source_html")}
 
   %div.sfc-member
-    Git is a member of <a href="/sfc">Software Freedom Conservancy</a>
+    #{t(".sfc_member_html")}
 
 = javascript_include_tag "jquery-1.7.1.min.js", "jquery-ui-1.8.18.custom.min.js", "jquery.defaultvalue.js", "session.min.js", "site.js"

--- a/app/views/shared/_header.html.haml
+++ b/app/views/shared/_header.html.haml
@@ -4,6 +4,6 @@
     =raw random_tagline
 
   %form#search{:action => '/search/results'}
-    <input id="search-text" name="search" placeholder="Search entire site..." autocomplete="off" type="text" />
+    <input id="search-text" name="search" placeholder="#{t(".search_placeholder")}" autocomplete="off" type="text" />
 
   %div#search-results

--- a/app/views/shared/_masthead.html.erb
+++ b/app/views/shared/_masthead.html.erb
@@ -1,22 +1,21 @@
 <div id="masthead">
   <div class="inner">
     <p>
-      Git is a <%= link_to "free and open source", "/about/free-and-open-source" %>
-      distributed version control system designed to handle everything from small to
-      very large projects with speed and efficiency.
+      <%= t(".git_masthead_p1_html", :link => link_to(t(".free_and_open_source"), "/about/free-and-open-source")) %>
     </p>
 
     <p>
-      Git is <%= link_to "easy to learn", "/documentation" %> and has a
-      <%= link_to "tiny footprint with lightning fast performance", "/about/small-and-fast" %>.
-      It outclasses SCM tools like Subversion, CVS, Perforce, and ClearCase
-      with features like <%= link_to "cheap local branching", "/about/branching-and-merging" %>,
-      convenient <%= link_to "staging areas", "/about/staging-area" %>, and
-      <%= link_to "multiple workflows", "/about/distributed" %>.
+      <%= t(".git_masthead_p2_html", :link_01 => link_to(t(".easy_to_learn"), "/documentation"),
+          :link_02 => link_to(t(".tiny_footprint"), "/about/small-and-fast"),
+          :link_03 => link_to(t(".cheap_local_branching"), "/about/branching-and-merging"),
+          :link_04 => link_to(t(".staging_areas"), "/about/staging-area"),
+          :link_05 => link_to(t(".multiple_workflows"), "/about/distributed"))
+      %>
     </p>
 
     <p class="promo">
-      <img src="https://d1ffx7ull4987f.cloudfront.net/images/achievements/large_badge/121/completed-try-git-1d5111823aae2bb9d14fbcb663998353.png" height="42" width="42" style="float: left; margin: -2px 4px 0 0;"/> Learn Git in your browser for free with <a href="http://try.github.com">Try Git</a>.
+      <img src="https://d1ffx7ull4987f.cloudfront.net/images/achievements/large_badge/121/completed-try-git-1d5111823aae2bb9d14fbcb663998353.png" height="42" width="42" style="float: left; margin: -2px 4px 0 0;"/>
+      <%= t(".learn_git_html") %>
     </p>
 
     <img class="illustration" src="/images/branching-illustration@2x.png" width="389" height="251" />

--- a/app/views/shared/_monitor.html.haml
+++ b/app/views/shared/_monitor.html.haml
@@ -1,8 +1,8 @@
 %div.monitor
-  %h4 Latest stable release
+  %h4 #{t(".latest_stable")}
   %span.version= latest_version
 
-  =link_to "Release Notes", latest_relnote_url
+  =link_to t(".release_notes"), latest_relnote_url
   %span.release-date= latest_release_date
 
-  =link_to "Download Source Code", "http://code.google.com/p/git-core/downloads/list", {:class => 'button', :id => 'download-link'}
+  =link_to t(".download_source"), "http://code.google.com/p/git-core/downloads/list", {:class => 'button', :id => 'download-link'}

--- a/app/views/shared/_related.html.erb
+++ b/app/views/shared/_related.html.erb
@@ -1,15 +1,15 @@
 <% if @related && @related.size > 0 %>
-  <h4>Related Material</h4>
+  <h4><%= t(".related_material") %></h4>
   <ul class="related-material">
     <% @related.each do |rel| %>
       <li class="<%= rel.content_type %>">
       <strong><a href="<%= rel.content_url %>"><%= rel.name %></a></strong>
       <% if rel.content_type == "reference" %>
-        in <a href="/docs">Reference</a>
+        in <a href="/docs"><%= t(".reference") %></a>
       <% elsif rel.content_type == "book" %>
-        in <a href="/book/en">Books</a>
+        in <a href="/book/en"><%= t(".books") %></a>
       <% elsif rel.content_type == "video" %>
-        in <a href="/videos">Videos</a>
+        in <a href="/videos"><%= t(".videos") %></a>
       <% end %>
       </li>
     <% end %>

--- a/app/views/shared/_search.html.haml
+++ b/app/views/shared/_search.html.haml
@@ -5,7 +5,7 @@
     %td.matches
       %ul
         %li
-          %a{:href=>"/search/results?search=#{@term}"} Show all results...
+          %a{:href=>"/search/results?search=#{@term}"} #{t(".show_all_results")}
   - @data[:results].each do |cat|
     %tr
       %td.category

--- a/app/views/shared/_sidebar.html.erb
+++ b/app/views/shared/_sidebar.html.erb
@@ -2,41 +2,41 @@
   <nav>
     <ul>
       <li>
-        <%= link_to "About", "/about", sidebar_link_options("about") %>
+        <%= link_to t("common.about"), "/about", sidebar_link_options("about") %>
       </li>
       <li>
-        <%= link_to "Documentation", "/doc", sidebar_link_options("documentation") %>
+        <%= link_to t("common.documentation"), "/doc", sidebar_link_options("documentation") %>
         <ul class="<%= @section == "documentation" ? "expanded" : ""%>">
           <li>
-            <%= link_to "Reference", "/docs", sidebar_link_options("reference") %>
+            <%= link_to t("common.reference"), "/docs", sidebar_link_options("reference") %>
           </li>
           <li>
-            <%= link_to "Book", "/book", sidebar_link_options("book") %>
+            <%= link_to t("common.book"), "/book", sidebar_link_options("book") %>
           </li>
           <li>
-            <%= link_to "Videos", "/videos", sidebar_link_options("videos") %>
+            <%= link_to t("common.videos"), "/videos", sidebar_link_options("videos") %>
           </li>
           <li>
-            <%= link_to "External Links", "/doc/ext", sidebar_link_options("external-links") %>
+            <%= link_to t("common.external_links"), "/doc/ext", sidebar_link_options("external-links") %>
           </li>
         </ul>
       </li>
       <li>
-        <%= link_to "Blog", "/blog", sidebar_link_options("blog") %>
+        <%= link_to t("common.blog"), "/blog", sidebar_link_options("blog") %>
       </li>
       <li>
-        <%= link_to "Downloads", "/downloads", sidebar_link_options("downloads") %>
+        <%= link_to t("common.downloads"), "/downloads", sidebar_link_options("downloads") %>
         <ul class="<%= @section == "downloads" ? "expanded" : "" %>">
           <li>
-            <%= link_to "GUI Clients", "/downloads/guis", sidebar_link_options("guis") %>
+            <%= link_to t("common.gui_clients"), "/downloads/guis", sidebar_link_options("guis") %>
           </li>
           <li>
-            <%= link_to "Logos", "/downloads/logos", sidebar_link_options("logos") %>
+            <%= link_to t("common.logos"), "/downloads/logos", sidebar_link_options("logos") %>
           </li>
         </ul>
       </li>
       <li>
-        <%= link_to "Community", "/community", sidebar_link_options("community") %>
+        <%= link_to t("common.community"), "/community", sidebar_link_options("community") %>
       </li>
     </ul>
     <% if content_for(:sidebar) %>

--- a/app/views/shared/ref/_admin.html.erb
+++ b/app/views/shared/ref/_admin.html.erb
@@ -1,4 +1,4 @@
-<h3 class='admin'>Administration</h3>
+<h3 class='admin'><%= t("shared.ref.administration") %></h3>
 <ul class='unstyled'>
   <li><%= man('git-clean') %></li>
   <li><%= man('git-gc') %></li>

--- a/app/views/shared/ref/_branching.html.erb
+++ b/app/views/shared/ref/_branching.html.erb
@@ -1,4 +1,4 @@
-<h3 class='branching'>Branching and Merging</h3>
+<h3 class='branching'><%= t("shared.ref.branching_and_mergin") %></h3>
 <ul class='unstyled'>
   <li><%= man('git-branch') %></li>
   <li><%= man('git-checkout') %></li>

--- a/app/views/shared/ref/_creating.html.erb
+++ b/app/views/shared/ref/_creating.html.erb
@@ -1,4 +1,4 @@
-<h3 class='projects'>Getting and Creating Projects</h3>
+<h3 class='projects'><%= t("shared.ref.creating") %></h3>
 <ul class='unstyled'>
   <li><%= man('git-init') %></li>
   <li><%= man('git-clone') %></li>

--- a/app/views/shared/ref/_debugging.html.erb
+++ b/app/views/shared/ref/_debugging.html.erb
@@ -1,4 +1,4 @@
-<h3 class='debugging'>Debugging</h3>
+<h3 class='debugging'><%= t("shared.ref.debugging") %></h3>
 <ul class='unstyled'>
   <li><%= man('git-bisect') %></li>
   <li><%= man('git-blame') %></li>

--- a/app/views/shared/ref/_email.html.erb
+++ b/app/views/shared/ref/_email.html.erb
@@ -1,4 +1,4 @@
-<h3 class='email'>Email</h3>
+<h3 class='email'><%= t("shared.ref.email") %></h3>
 <ul class='unstyled'>
   <li><%= man('git-am') %></li>
   <li><%= man('git-apply') %></li>

--- a/app/views/shared/ref/_external.html.erb
+++ b/app/views/shared/ref/_external.html.erb
@@ -1,4 +1,4 @@
-<h3 class='external'>External Systems</h3>
+<h3 class='external'><%= t("shared.ref.external_systems") %></h3>
 <ul class='unstyled'>
   <li><%= man('git-svn') %></li>
   <li><%= man('git-fast-import') %></li>

--- a/app/views/shared/ref/_inspection.html.erb
+++ b/app/views/shared/ref/_inspection.html.erb
@@ -1,4 +1,4 @@
-<h3 class='inspection'>Inspection and Comparison</h3>
+<h3 class='inspection'><%= t("shared.ref.inspection_and_comparison") %></h3>
 <ul class='unstyled'>
   <li><%= man('git-show') %></li>
   <li><%= man('git-log') %></li>

--- a/app/views/shared/ref/_patching.html.erb
+++ b/app/views/shared/ref/_patching.html.erb
@@ -1,4 +1,4 @@
-<h3 class='patching'>Patching</h3>
+<h3 class='patching'><%= t("shared.ref.patching") %></h3>
 <ul class='unstyled'>
   <li><%= man('git-diff') %></li>
   <li><%= man('git-apply') %></li>

--- a/app/views/shared/ref/_plumbing.html.erb
+++ b/app/views/shared/ref/_plumbing.html.erb
@@ -1,4 +1,4 @@
-<h3 class='plumbing'>Plumbing Commands</h3>
+<h3 class='plumbing'><%= t("shared.ref.plumbing") %></h3>
 <ul class='unstyled'>
   <li><%= man('git-cat-file') %></li>
   <li><%= man('git-commit-tree') %></li>

--- a/app/views/shared/ref/_server.html.erb
+++ b/app/views/shared/ref/_server.html.erb
@@ -1,4 +1,4 @@
-<h3 class='server-admin'>Server Admin</h3>
+<h3 class='server-admin'><%= t("shared.ref.server_admin") %></h3>
 <ul class='unstyled'>
   <li><%= man('git-daemon') %></li>
   <li><%= man('git-update-server-info') %></li>

--- a/app/views/shared/ref/_setup.html.erb
+++ b/app/views/shared/ref/_setup.html.erb
@@ -1,4 +1,4 @@
-<h3 class='setup'>Setup and Config</h3>
+<h3 class='setup'><%= t("shared.ref.setup_and_config") %></h3>
 <ul class='unstyled'>
   <li><%= man('git-config') %></li>
   <li><%= man('git-help') %></li>

--- a/app/views/shared/ref/_sharing.html.erb
+++ b/app/views/shared/ref/_sharing.html.erb
@@ -1,4 +1,4 @@
-<h3 class='sharing'>Sharing and Updating Projects</h3>
+<h3 class='sharing'><%= t("shared.ref.sharing_and_updating") %></h3>
 <ul class='unstyled'>
   <li><%= man('git-fetch') %></li>
   <li><%= man('git-pull') %></li>

--- a/app/views/shared/ref/_snapshot.html.erb
+++ b/app/views/shared/ref/_snapshot.html.erb
@@ -1,4 +1,4 @@
-<h3 class='snapshotting'>Basic Snapshotting</h3>
+<h3 class='snapshotting'><%= t("shared.ref.basic_snapshotting") %></h3>
 <ul class='unstyled'>
   <li><%= man('git-add') %></li>
   <li><%= man('git-status') %></li>

--- a/app/views/site/404.html.haml
+++ b/app/views/site/404.html.haml
@@ -1,16 +1,16 @@
 %p
   <img src="/images/404@2x.png" alt="404" width="456" height="149" />
 
-%h1 That page doesn't exist.
+%h1 #{t(".page_does_not_exist")}
 
 %p
-  We recently redesigned the site and older URLs may now lead to missing pages. We apologize for the inconvenience.
+  #{t(".recent_redesign_notice")}
 
 %nav
   %ul
-    %li= link_to "Home", "/"
-    %li= link_to "About", "/about"
-    %li= link_to "Documentation", "/documentation"
-    %li= link_to "Downloads", "/downloads"
-    %li= link_to "Community", "/community"
+    %li= link_to t("common.home"), "/"
+    %li= link_to t("common.about"), "/about"
+    %li= link_to t("common.documentation"), "/documentation"
+    %li= link_to t("common.downloads"), "/downloads"
+    %li= link_to t("common.community"), "/community"
 

--- a/app/views/site/admin.html.erb
+++ b/app/views/site/admin.html.erb
@@ -1,5 +1,5 @@
 <div id='main'>
-  <h1>Admin Page</h1>
+  <h1><%= t(".admin_page") %></h1>
 
   <table>
   <% @downloads.each do |down| %>

--- a/app/views/site/index.html.haml
+++ b/app/views/site/index.html.haml
@@ -5,49 +5,46 @@
         %li#nav-about
           <a href="/about">
           <img src="/images/icons/nav-about@2x.png" width="74" height="74" />
-          <h3>About</h3>
-          <p>The advantages of Git compared to other source control systems.</p>
+          <h3>#{t("common.about")}</h3>
+          <p>#{t(".about_intro")}</p>
           </a>
         %li#nav-documentation
           <a href="/documentation">
           <img src="/images/icons/nav-documentation@2x.png" width="74" height="74" />
-          <h3>Documentation</h3>
-          <p>Command reference pages, Pro Git book content, videos and other material.</p>
+          <h3>#{t("common.documentation")}</h3>
+          <p>#{t(".documentation_intro")}</p>
           </a>
         %li#nav-downloads
           <a href="/downloads">
           <img src="/images/icons/nav-downloads@2x.png" width="74" height="74" />
-          <h3>Downloads</h3>
-          <p>GUI clients and binary releases for all major platforms.</p>
+          <h3>#{t("common.downloads")}</h3>
+          <p>#{t(".downloads_intro")}</p>
           </a>
         %li#nav-community
           <a href="/community">
           <img src="/images/icons/nav-community@2x.png" width="74" height="74" />
-          <h3>Community</h3>
-          <p>Get involved! Mailing list, chat, development and more.</p> </a>
+          <h3>#{t("common.community")}</h3>
+          <p>#{t(".community_intro")}</p> </a>
 
     %div#front-book
       <img src="/images/pro-git-56x74@2x.jpg" width="56" height="74" />
       %p
-        <strong><a href="/book">Pro Git</a></strong>
-        by Scott Chacon is available to
-        <a href="/book">read online for free</a>.
-        Dead tree versions are available on <a href="http://www.amazon.com/gp/product/1430218339?ie=UTF8&camp=1789&creative=9325&creativeASIN=1430218339&linkCode=as2&tag=git-sfconservancy-20">Amazon.com</a>.
+        #{t(".pro_git_promo_html")}
 
   %section#front-downloads
     = partial 'shared/monitor'
 
     %table
       %tr
-        %td{:nowrap => true}= link_to "Graphical UIs", "/downloads/guis", {:class => 'icon gui', :id => 'gui-link'}
-        %td{:nowrap => true}= link_to "Tarballs", "http://code.google.com/p/git-core/downloads/list", {:class => 'icon older-releases'}
+        %td{:nowrap => true}= link_to t(".graphical_uis"), "/downloads/guis", {:class => 'icon gui', :id => 'gui-link'}
+        %td{:nowrap => true}= link_to t(".tarballs"), "http://code.google.com/p/git-core/downloads/list", {:class => 'icon older-releases'}
       %tr
-        %td{:nowrap => true}= link_to "Windows Build", "/download/win", {:class => 'icon windows', :id => 'alt-link'}
-        %td{:nowrap => true}= link_to "Source Code", "https://github.com/git/git", {:class => 'icon source'}
+        %td{:nowrap => true}= link_to t(".windows_build"), "/download/win", {:class => 'icon windows', :id => 'alt-link'}
+        %td{:nowrap => true}= link_to t(".source_code"), "https://github.com/git/git", {:class => 'icon source'}
 
 
 %section#companies-projects
-  %h3 Companies &amp; Projects Using Git
+  %h3 #{t(".git_users_shout_out_html")}
 
   %ul
     %li= link_to "Google", "https://github.com/google", {:class => 'google'}

--- a/app/views/site/results.html.haml
+++ b/app/views/site/results.html.haml
@@ -1,12 +1,12 @@
-- @section = "search"
+- @section = t("common.search")
 - @subsection = ""
-- @page_title = "Search results for #{h(@term)}"
+- @page_title = t(".search_results", :term => h(@term))
 
 - content_for :sidebar do
   = render 'shared/related'
 
 %div#main
-  %h1=raw "Search results for <strong>#{h(@term)}</strong>"
+  %h1 #{t(".search_results_html", :term => h(@term))}
 
   - if @top.size > 0
     %div.callout.top-matches
@@ -33,5 +33,5 @@
           %p=raw highlight_no_html(hit[:highlight])
 
   - if @rest.size + @top.size == 0
-    %h2 Sorry, no search matches
+    %h2 #{t(".sorry")}
 

--- a/app/views/site/sfc.html.erb
+++ b/app/views/site/sfc.html.erb
@@ -1,22 +1,14 @@
 <div id="main">
-  <h1 id="sfc">Git and Software Freedom Conservancy</h1>
+  <h1 id="sfc"><%= t(".git_and_sfc") %></h1>
 
-  <p>Git is a member project of <a href="http://sfconservancy.org/">Software
-  Freedom Conservancy</a>.  Conservancy is a not-for-profit organization that
-  provides financial and administrative assistance to open source projects.
+  <p><%= t(".p1_html") %>
 
-  <h2 class="section-start">Donation</h2>
+  <h2 class="section-start"><%= t(".donation") %></h2>
 
-  <p>Conservancy accepts donations on git's behalf. In the past, project money has
-  typically gone to defraying travel costs for developers to come to our annual
-  <a href="https://git.wiki.kernel.org/index.php/GitTogether">GitTogether</a>
-  mini-conference.  A portion of the money goes to Conservancy to cover their
-  operating expenses. You can also donate <a
-  href="http://sfconservancy.org/donate">directly</a> to Software
-  Freedom Conservancy's general fund.
+  <p><%= t(".p2_html") %>
 
   <h3 class="title">Paypal</h3>
-  <p>To donate to Git via PayPal:
+  <p><%= t(".to_donate_via_paypal") %>
   <div class="center">
     <form action="https://www.paypal.com/cgi-bin/webscr" method="post">
       <input type="hidden" name="cmd" value="_s-xclick">
@@ -30,28 +22,11 @@
     </form>
   </div>
 
-  <h3 class="title">Check or Wire</h3>
-  <p>We can also accept donations drawn in USD from banks in the USA
-  (donations from banks outside of the US or not in USD should be handled
-  by wire). Make checks payable to "Software Freedom Conservancy, Inc."
-  and place "Directed donation: Git" in the memo field. Checks should be
-  mailed to:
-  <div class="center">
-  <pre>
-  Software Freedom Conservancy, Inc.
-  137 Montague ST STE 380
-  BROOKLYN, NY 11201 USA
-  </pre>
-  </div>
+  <h3 class="title"><%= t(".check_or_wire") %></h3>
+  <p><%= t(".p3_html") %>
 
-  <p>Conservancy can accept wire donations, but the instructions vary
-  depending on the country of origin. Please contact <a
-    href="mailto:accounting@sfconservancy.org">accounting@sfconservancy.org</a>
-  for instructions.
+  <p><%= t(".p4_html") %>
 
-  <p>Conservancy also accepts stock donations on behalf of the Git
-  project. If you would like to donate stock, please contact <a
-    href="mailto:accounting@sfconservancy.org">accounting@sfconservancy.org</a>
-  for instructions on how to initiate the transfer.
+  <p><%= t(".p5_html") %>
 
 </div>

--- a/app/views/site/svn.html.erb
+++ b/app/views/site/svn.html.erb
@@ -11,32 +11,26 @@
 </style>
 
 <div id='main' class="book">
-  <h1>Git - SVN Crash Course</h1>
+  <h1><%= t(".git_svn_crash_course") %></h1>
 
-  <p>Welcome to the Git version control system! Here we will briefly
-  introduce you to Git usage based on your current Subversion knowledge. You will
-  need the latest <a href="http://git.or.cz/">Git</a> installed;
-  There is also a potentially useful
-  <a href="http://www.kernel.org/pub/software/scm/git/docs/gittutorial.html">
-  tutorial</a> in the Git documentation.</p>
+  <p><%= t(".intro_p1_html") %></p>
 
   <div class="doc-toc">
     <ul>
-      <li><a href="#read">How to Read Me</a></li>
-      <li><a href="#know">Things To Know</a></li>
-      <li><a href="#commit">Commiting</a></li>
-      <li><a href="#browse">Browsing</a></li>
-      <li><a href="#branch">Tagging and Branching</a></li>
-      <li><a href="#merge">Merging</a></li>
-      <li><a href="#remote">Going Remote</a></li>
-      <li><a href="#share">Sharing the Work</a></li>
+      <li><a href="#read"><%= t(".how_to_read_me") %></a></li>
+      <li><a href="#know"><%= t(".things_to_know") %></a></li>
+      <li><a href="#commit"><%= t(".committing") %></a></li>
+      <li><a href="#browse"><%= t(".browsing") %></a></li>
+      <li><a href="#branch"><%= t(".tagging_and_branching") %></a></li>
+      <li><a href="#merge"><%= t(".merging") %></a></li>
+      <li><a href="#remote"><%= t(".going_remote") %></a></li>
+      <li><a href="#share"><%= t(".sharing_the_work") %></a></li>
     </ul>
   </div>
 
   <div style="text-align:center;"><table class="relnotes" style="margin-left: auto; margin-right: auto; border: 1px">
   <tr><td style="text-align:center;">
-  <p style="margin: 0em 0.4em">If you are just after tracking someone else's project,
-  this get you started quickly:</p>
+  <p style="margin: 0em 0.4em"><%= t(".quick_start_p1") %></p>
   <p/>
   <table class="ccmd" style="margin:0em; margin-left: auto; margin-right: auto;"><tr>
       <td class="g">git clone <em>url</em><br />git pull</td>
@@ -49,103 +43,55 @@
 
   <hr />
 
-  <h2 id="read">How to Read Me</h2>
+  <h2 id="read"><%= t(".how_to_read_me") %></h2>
 
-  <p>In those small tables, at the left we always list the Git commands
-  for the task, while at the right the corresponding Subversion commands you would use
-  for the job are listed.  If you are in hurry, just skimming over them should
-  give you a good idea about the Git usage basics.</p>
+  <p><%= t(".how_to_read_me_p1") %></p>
 
-  <p>Before running any command the first time, it's recommended that you
-  at least quickly skim through its manual page. Many of the commands have
-  very useful and interesting features (that we won't list here) and sometimes
-  there are some extra notes you might want to know. There's a quick usage
-  help available for the Git commands if you pass them the <code>-h</code>
-  switch.</p>
+  <p><%= t(".how_to_read_me_p2") %></p>
 
 
-  <h2 id="know">Things You Should Know</h2>
+  <h2 id="know"><%= t(".things_you_should_know") %></h2>
 
-  <p>There are couple important concepts it is good to know when
-  starting with Git. If you are in hurry though, you can skip this
-  section and only get back to it when you get seriously confused;
-  it should be possible to pick up with just using your intuition.</p>
+  <p><%= t(".things_to_know_p1") %></p>
 
   <ul>
 
   <li>
 
-  <b>Repositories.</b>
-  With Subversion, for each project there is a single repository at some
-  detached central place where all the history is and which you checkout
-  and commit into. Git works differently, each copy of the project tree
-  (we call that the <em>working copy</em>) carries its own repository
-  around (in the <code>.git</code> subdirectory in the project tree root).
-  So you can have local and remote branches.
-  You can also have a so-called <em>bare repository</em> which is not
-  attached to a working copy; that is useful especially when you want
-  to publish your repository. We will get to that.
+  <b><%= t(".repositories") %></b>
+    <%= t(".repositories_brief_html") %>
   </li>
 
   <li>
-  <b>URL.</b>
-  In Subversion the <em>URL</em> identifies the location of the repository
-  and the path inside the repository, so you organize the layout of the
-  repository and its meaning. Normally you would have <code>trunk/</code>,
-
-  <code>branches/</code> and <code>tags/</code> directories. In Git
-  the <em>URL</em> is just the location of the repository, and it always
-  contains branches and tags. One of the branches is the default (normally named
-  master).
+  <b><%= t(".url") %></b>
+    <%= t(".url_brief_html") %>
   </li>
 
   <li>
-  <b>Revisions.</b>
-  Subversion identifies revisions with ids of decimal numbers growing
-  monotonically which are typically small (although they can get quickly
-  to hundreds of thousands for large projects).  That is impractical in distributed systems like Git. Git
-  identifies revisions with SHA1 ids, which are long 160-bit numbers
-  written in hexadecimal. It may look scary at first, but in practice it is
-  not a big hurdle - you can refer to the latest revision by <code>HEAD</code>,
-  its parent as <code>HEAD^</code> and its parent as <code>HEAD^^ = HEAD~2</code>
-
-  (you can go on adding carrets),
-  cut'n'paste helps a lot and you can write only the few leading digits
-  of a revision - as long as it is unique, Git will guess the rest.
-  (You can do even more advanced stuff with revision specifiers, see the
-  <a href="http://www.kernel.org/pub/software/scm/git/docs/git-rev-parse.html">git-rev-parse manpage</a> for details.)
+  <b><%= t(".revisions") %></b>
+    <%= t(".revisions_brief_html") %>
   </li>
 
   <li>
-  <b>Commits.</b>
-  Each commit has an <em>author</em> and a <em>committer</em> field,
-  which record who and when <em>created</em> the change and who <em>committed</em> it
-  (Git is designed to work well with patches coming by mail - in that case,
-  the author and the committer will be different). Git will try to guess
-  your realname and email, but especially with email it is likely to get it wrong.
-  You can check it using <code class="g">git config -l</code> and set them with:
+  <b><%= t(".commits") %></b>
+    <%= t(".commits_brief_html") %>
 
 
   <pre>
-  git config --global user.name "Your Name Comes Here"
-  git config --global user.email you@yourdomain.example.com
+  git config --global user.name "<%= t(".your_name_here") %>"
+  git config --global user.email <%= t(".fake_email") %>
   </pre>
   </li>
 
   <li>
-  <b>Commands.</b>
-  The Git commands are in the form <code>git command</code>.
-  You can interchangeably use the <code>git-command</code>
-  form as well.
+  <b><%= t(".commands") %></b>
+  <%= t(".commands_brief_html") %>
   </li>
 
   <li>
 
-  <b>Colors.</b>
-  Git can produce colorful output with some commands; since
-  some people hate colors way more than the rest likes them, by default
-  the colors are turned off. If you would like to have colors in your
-  output:
+  <b><%= t(".colors") %></b>
+  <%= t(".colors_brief") %>
 
   <pre>
   git config --global color.diff auto
@@ -156,59 +102,46 @@
 
   <li>
   <b>Visualize.</b>
-  You may find it convenient to watch your repository using
-  the <code class="g">gitk</code> repository as you go.
+    <%= t(".visualize_brief_html") %>
   </li>
 
   </ul>
 
-  <h2 id="commit">Commiting</h2>
+  <h2 id="commit"><%= t(".committing") %></h2>
 
-  <p>For the first introduction, let's make your project tracked by Git
-  and see how we get around to do daily development in it. Let's
-  <code>cd</code> to the directory with your project and initialize
-  a brand new Git repository with it:</p>
+  <p><%= t(".committing_p1_html") %></p>
 
   <table class="ccmd">
     <tr><td class="g">git init<br/>git add .<br/>git commit</td>
 
   <td>svnadmin create <em>repo</em><br/>svn import <em>file://repo</em></td></tr></table>
 
-  <p><code>git init</code> will initialize the repository,
-  <code>git add .</code> will add all the files under the current directory
-  and <code>git commit</code> will create the
-  initial import, given that repositories are coupled with working copies.</p>
+  <p><%= t(".committing_p2_html") %></p>
 
-  <p>Now your tree is officially tracked by Git. You can explore the
-  <code class="g">.git</code> subdirectory a bit if you want, or don't if you
-  don't care. Do some random changes to your tree now - poke into few
-  files or such. Let's check what we've done:</p>
+  <p><%= t(".committing_p3_html") %></p>
 
   <table class="ccmd"><tr>
       <td class="g">git diff</td>
       <td>svn diff | less</td>
   </tr></table>
 
-  <p>That's it. This is one of the more powerful commands. To get a diff with an
-  specific revision and path do:</p>
+  <p><%= t(".committing_p4_html") %></p>
 
   <table class="ccmd"><tr>
       <td class="g">git diff <em>rev</em> <em>path</em></td>
       <td>svn diff -r<em>rev</em> <em>path</em></td>
   </tr></table>
 
-  <p>Git embeds special information in
-  the diffs about adds, removals and mode changes:</p>
+  <p><%= t(".committing_p5_html") %></p>
 
   <table class="ccmd"><tr>
       <td class="g">git apply</td>
       <td>patch -p0</td>
   </tr></table>
 
-  <p>That will apply the patch while telling Git about and performing
-  those "meta-changes".</p>
+  <p><%= t(".committing_p6_html") %></p>
 
-  <p>There is a more concise representation of changes available:</p>
+  <p><%= t(".committing_p7_html") %></p>
 
   <table class="ccmd"><tr>
 
@@ -216,29 +149,20 @@
       <td>svn status</td>
   </tr></table>
 
-  <p>This will show the concise changes summary as well as list any files
-  that you haven't either ignored or told Git about. In addition,
-  it will also show at the top which branch you are in.</p>
+  <p><%= t(".committing_p8_html") %></p>
 
-  <p>While we are at the status command, over time plenty of the
-  "Untracked files" will get in there, denoting files not tracked by Git.
-  Wait a moment if you want to add them, run <code class="g">git clean</code>
-  if you want to get rid of all of them, or add them to the <code class="g">.gitignore</code>
+  <p><%= t(".committing_p9_html") %></p>
 
-  file if you want to keep them around untracked (works the same as the <code>svn:ignore</code>
-  property in SVN).</p>
-
-  <p>To restore a file from the last revision:</p>
+  <p><%= t(".committing_p10_html") %></p>
 
   <table class="ccmd"><tr>
       <td class="g">git checkout <em>path</em></td>
       <td>svn revert <em>path</em></td>
   </tr></table>
 
-  <p>You can restore everything or just specified files.</p>
+  <p><%= t(".committing_p11_html") %></p>
 
-  <p>So, just like in SVN, you need to tell Git when you add, move or
-  remove any files:</p>
+  <p><%= t(".committing_p12_html") %></p>
 
   <table class="ccmd"><tr>
       <td class="g">git add <em>file</em>
@@ -247,69 +171,37 @@
         <br />git mv <em>file</em></td>
   <td>svn add <em>file</em><br />svn rm <em>file</em><br />svn mv <em>file</em></td></tr></table>
 
-  <p>You can also recursively add/remove whole directories and so on;
-  Git's cool!</p>
+  <p><%= t(".committing_p13_html") %></p>
 
-  <p>So, it's about time we commit our changes. Big surprise
-  about the command:</p>
+  <p><%= t(".committing_p14_html") %></p>
 
   <table class="ccmd"><tr>
       <td class="g">git commit -a</td>
       <td>svn commit</td>
   </tr></table>
 
-  <p>to commit all the changes or, as with Subversion,
-  you can limit the commit only to specified files
-  and so on. A few words on the commit message: it is <em>customary</em>
-  to have a short commit summary as the first line of the message,
-  because various tools listing commits frequently show only the
-  first line of the message.  You can specify the commit message
-  using the <code>-m</code> parameter as you are used, but
-  you can pass several <code>-m</code> arguments and they will create
-  separate paragraphs in the commit message:</p>
+  <p><%= t(".committing_p15_html") %></p>
 
-  <p>If you don't pass any <code>-m</code> parameter or pass
-  the <code>-e</code> parameter, your favorite <code>$EDITOR</code>
-  will get run and you can compose your commit message there,
-  just as with Subversion. In addition, the list of files to be committed
-  is shown.</p>
+  <p><%= t(".committing_p16_html") %></p>
 
-  <p>And as a bonus, if you pass it the <code>-v</code> parameter
-  it will show the whole patch being committed in the editor
-  so that you can do a quick last-time review.</p>
+  <p><%= t(".committing_p17_html") %></p>
 
-  <p>By the way, if you screwed up committing, there's not much you
-  can do with Subversion, except using some enigmatic <code>svnadmin</code>
-  subcommands.  Git does it better - you can amend your latest commit
-  (re-edit the metadata as well as update the tree) using
-  <code class="g">git commit --amend</code>, or toss your latest
-  commit away completely using <code class="g">git reset HEAD^</code>,
-  this will not change the working tree.</p>
+  <p><%= t(".committing_p18_html") %></p>
 
-  <h2 id="browse">Browsing</h2>
+  <h2 id="browse"><%= t(".browsing") %></h2>
 
-  <p>Now that we have committed some stuff, you might want to review
-  your history:</p>
+  <p><%= t(".browsing_p1_html") %></p>
 
   <table class="ccmd"><tr>
       <td class="g">git log<br />git blame <em>file</em></td>
       <td>svn log | less<br />svn blame <em>file</em></td>
   </tr></table>
 
-  <p>The log command works quite similar in SVN and Git; again,
-  <code>git log</code> is quite powerful, please look through
-  its options to see some of the stuff it can do.</p>
+  <p><%= t(".browsing_p2_html") %></p>
 
-  <p>The blame command is more powerful as it can detect the movement of lines,
-  even with file copies and renames. But there is a
-  big chance that you probably want to do something different! Usually,
-  when using annotate you are looking for the origin of some piece of
-  code, and the so-called <em>pickaxe</em> of Git is much more comfortable
-  tool for that job (<code>git log -S<em>string</em></code> shows the
-  commits which add or remove any file data matching <em>string</em>).</p>
+  <p><%= t(".browsing_p3_html") %></p>
 
-  <p>You can see the contents of a file, the listing of a directory or
-  a commit with:</p>
+  <p><%= t(".browsing_p4_html") %></p>
 
   <table class="ccmd"><tr>
 
@@ -324,19 +216,9 @@
 
   </tr></table>
 
-  <h2 id="branch">Tagging and branching</h2>
+  <h2 id="branch"><%= t(".tagging_and_branching") %></h2>
 
-  <p>Subversion marks certain checkpoints in history through copies, the copy is
-  usually placed in a directory named tags.  Git tags are much more powerful.
-  The Git tag can have an arbitrary description attached (the first
-  line is special as in the commit case), some people actually store
-  the whole release announcements in the tag descriptions. The identity
-  of the person who tagged is stored (again following the same rules
-  as identity of the committer). You can tag other objects than commits (but
-  that is conceptually rather low-level operation).
-  And the tag can be cryptographically PGP signed to verify the identity
-  (by Git's nature of working, that signature also confirms the validity
-  of the associated revision, its history and tree). So, let's do it:</p>
+  <p><%= t(".branching_p1_html") %></p>
 
   <table class="ccmd"><tr>
       <td class="g">git tag -a <em>name</em></td>
@@ -345,7 +227,7 @@
 
   </tr></table>
 
-  <p>To list tags and to show the tag message:</p>
+  <p><%= t(".branching_p2_html") %></p>
 
   <table class="ccmd"><tr>
       <td class="g">git tag -l<br />git show <em>tag</em></td>
@@ -354,9 +236,7 @@
       <br />svn&nbsp;log --limit&nbsp;1&nbsp;http://example.com/svn/tags/<em>tag</em></td>
   </tr></table>
 
-  <p>Like Subversion, Git can do branches (surprise surprise!). In Subversion,
-  you basically copy your project to a subdirectory. In Git, you tell it,
-  well, to create a branch.</p>
+  <p><%= t(".branching_p3_html") %></p>
 
   <table class="ccmd"><tr>
       <td class="g">git branch <em>branch</em>
@@ -368,21 +248,16 @@
         http://example.com/svn/branches/<em>branch</em></td>
   </tr></table>
 
-  <p>The first command creates a branch, the second command switches
-  your tree to a certain branch. You can pass an extra argument to
-  <code>git branch</code> to base your new branch on a different
-  revision than the latest one.</p>
+  <p><%= t(".branching_p4_html") %></p>
 
-  <p>You can list your branches conveniently using the aforementioned
-  <code>git-branch</code> command without arguments the listing of branches.
-  The current one is denoted by an "*".</p>
+  <p><%= t(".branching_p5_html") %></p>
 
   <table class="ccmd"><tr>
       <td class="g">git branch</td>
       <td>svn list http://example.com/svn/branches/</td>
   </tr></table>
 
-  <p>To move your tree to some older revision, use:</p>
+  <p><%= t(".branching_p6_html") %></p>
 
   <table class="ccmd"><tr>
       <td class="g">git checkout <em>rev</em>
@@ -390,42 +265,25 @@
       <td>svn update -r <em>rev</em><br />svn update</td>
   </tr></table>
 
-  <p>or you could create a temporary branch. In Git you can make commits on
-  top of the older revision and use it as another branch.</p>
+  <p><%= t(".branching_p7_html") %></p>
 
-  <h2 id="merge">Merging</h2>
+  <h2 id="merge"><%= t(".merging") %></h2>
 
-  <p>Git supports merging between branches much better than Subversion - history
-  of both branches is preserved over the merges and repeated merges
-  of the same branches are supported out-of-the-box. Make sure you are on
-  one of the to-be-merged branches and merge the other one now:</p>
+  <p><%= t(".merging_p1_html") %></p>
 
   <table class="ccmd"><tr>
       <td class="g">git merge <em>branch</em></td>
       <td>
         svn merge -r 20:HEAD
         http://example.com/svn/branches/<em>branch</em>
-        <br /><em>(assuming the branch was created in revision 20 and
-          you are inside a working copy of trunk)</em>
+        <br /><em><%= t(".merging_ccmd_note") %></em>
       </td>
 
   </tr></table>
 
-  <p>If changes were made on only one of the branches since the last merge,
-  they are simply replayed on your other branch (so-called <em>fast-forward merge</em>).
-  If changes were made on both branches, they are merged intelligently
-  (so-called <em>three-way merge</em>): if any changes conflicted, <code>git merge</code>
-  will report them and let you resolve them, updating the rest of the tree
-  already to the result state; you can <code>git commit</code> when you resolve
-  the conflicts. If no changes conflicted, a commit is made automatically with
-  a convenient log message (or you can do
+  <p><%= t(".merging_p2_html") %></p>
 
-  <code class="g">git merge --no-commit <em>branch</em></code> to review the merge
-  result and then do the commit yourself).</p>
-
-  <p>Aside from merging, sometimes you want to just pick one commit from
-  a different branch. To apply the changes in revision <em>rev</em> and commit
-  them to the current branch use:</p>
+  <p><%= t(".merging_p3_html") %></p>
 
   <table class="ccmd"><tr>
       <td class="g">git cherry-pick <em>rev</em></td>
@@ -433,33 +291,20 @@
       <td>svn merge -c <em>rev</em> <em>url</em></td>
   </tr></table>
 
-  <h2 id="remote">Going Remote</h2>
+  <h2 id="remote"><%= t(".going_remote") %></h2>
 
-  <p>So far, we have neglected that Git is a <em>distributed</em> version
-  control system. It is time for us to set the record straight - let's grab
-  some stuff from remote sites.</p>
+  <p><%= t(".remote_p1_html") %></p>
 
-  <p>If you are working on someone else's project, you usually want to <em>clone</em>
-  its repository instead of starting your own. We've already mentioned that at the top
-  of this document:</p>
+  <p><%= t(".remote_p2_html") %></p>
 
   <table class="ccmd"><tr>
       <td class="g">git clone <em>url</em></td>
       <td>svn&nbsp;checkout&nbsp;<em>url</em></td>
   </tr></table>
 
-  <p>Now you have the default branch (normally <code>master</code>),
-  but in addition you got all the remote branches and tags.
-  In clone's default setup, the default local branch tracks
-  the <em>origin</em> remote, which represents the default branch in the
-  remote repository.</p>
+  <p><%= t(".remote_p3_html") %></p>
 
-  <p><em>Remote branch</em>, you ask? Well, so far we have worked
-  only with local branches. Remote branches are a mirror image of branches
-  in remote repositories and you don't ever switch to them directly or write
-  to them. Let me repeat - you never mess with remote branches. If you want
-  to switch to a remote branch, you need to create a corresponding local
-  branch which will "track" the remote branch:</p>
+  <p><%= t(".remote_p4_html") %></p>
 
   <table class="ccmd"><tr>
       <td class="g">
@@ -467,69 +312,26 @@
 
       <td>svn&nbsp;switch&nbsp;<em>url</em></td></tr></table>
 
-  <p>You can add more remote branches to a cloned repository, as well as just
-  an initialized one, using <code class="g">git remote add <em>remote</em> <em>url</em></code>.
-  The command <code class="g">git remote</code> lists all the remotes
-  repositories and <code class="g">git remote show <em>remote</em></code> shows
-  the branches in a remote repository.</p>
+  <p></p>
 
-  <p>Now, how do you get any new changes from a remote repository?
-  You fetch them: <code class="g">git fetch</code>.
-  At this point they are in your repository and you can examine them using
-  <code>git log <em>origin</em></code> (<code>git log HEAD..<em>origin</em></code>
-  to see just the changes you don't have in your branch), diff them, and obviously, merge them - just do
-  <code>git merge <em>origin</em></code>. Note that if you don't specify a branch
-  to fetch, it will conveniently default to the tracking remote.</p>
+  <p><%= t(".remote_p6_html") %></p>
 
-  <p>Since you frequently just fetch + merge the tracking remote branch,
-  there is a command to automate that:</p>
+  <p><%= t(".remote_p7_html") %></p>
 
   <table class="ccmd"><tr>
       <td class="g">git pull</td>
       <td>svn update</td>
   </tr></table>
 
-  <h2 id="share">Sharing the Work</h2>
+  <h2 id="share"><%= t(".sharing_the_work") %></h2>
 
-  <p>Your local repository can be used by others to <em>pull</em> changes, but
-  normally you would have a private repository and a public repository.
-  The public repository is where everybody pulls and you... do the
-  opposite? <em>Push</em> your changes? Yes!
-  We do <code class="g">git push <em>remote</em></code> which will push
-  all the local branches with a corresponding remote branch - note that this works
-  generally only over SSH (or HTTP but with special webserver setup).
-  It is highly recommended to setup a SSH key and an SSH agent mechanism
-  so that you don't have to type in a password all the time.</p>
+  <p><%= t(".sharing_p1_html") %></p>
 
-  <p>One important thing is that you should push only to remote branches
-  that are not currently checked out on the other side (for the same
-  reasons you never switch to a remote branch locally)! Otherwise the
-  working copy at the remote branch will get out of date and confusion
-  will ensue. The best way to avoid that is to push only to remote
-  repositories with no working copy at all - so called <em>bare</em>
-  repositories which are commonly used for public access or developers'
-  meeting point - just for exchange of history where a checked out copy
-  would be a waste of space anyway. You can create such a repository.
-  See <a href="/docs/user-manual.html#setting-up-a-public-repository">Setting up a public repository</a> for details.</p>
+  <p><%= t(".sharing_p2_html") %></p>
 
-  <p>Git can work with the same workflow as Subversion, with a group of developers
-  using a single repository for exchange of their work. The only change
-  is that their changes aren't submitted automatically but they have
-  to push (however, you can setup a post-commit hook that will push for you
-  every time you commit; that loses the flexibility to fix up a screwed
-  commit, though). The developers must have either an entry in htaccess
-  (for HTTP DAV) or a UNIX account (for SSH). You can restrict their
-  shell account only to Git pushing/fetching by using the
-  <code class="g">git-shell</code> login shell.</p>
+  <p><%= t(".sharing_p3_html") %></p>
 
-  <p>You can also exchange patches by mail. Git has very good support
-  for patches incoming by mail. You can apply them by feeding mailboxes
-  with patch mails to <code class="g">git am</code>. If you
-  want to <em>send</em> patches use <code class="g">git format-patch</code> and
-  possibly <code class="g">git send-email</code>.
+  <p><%= t(".sharing_p4_html") %></p>
 
-  <p>If you have any questions or problems which are not obvious from
-  the documentation, please contact us at the <strong>Git mailing list</strong>
-  at <a href="mailto:git@vger.kernel.org">git@vger.kernel.org</a>.
-  We hope you enjoy using Git!</p>
+  <p><%= t(".sharing_p5_html") %></p>
 </div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -30,8 +30,9 @@ module Gitscm
     # config.time_zone = 'Central Time (US & Canada)'
 
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
-    # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
-    # config.i18n.default_locale = :de
+    config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}')]
+    puts config.i18n.load_path
+    config.i18n.default_locale = :en
 
     # Configure the default encoding used in templates for Ruby 1.9.
     config.encoding = "utf-8"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,5 +1,0 @@
-# Sample localization file for English. Add more files in this directory for other locales.
-# See https://github.com/svenfuchs/rails-i18n/tree/master/rails%2Flocale for starting points.
-
-en:
-  hello: "Hello world"

--- a/config/locales/en/en.yml
+++ b/config/locales/en/en.yml
@@ -1,0 +1,16 @@
+en:
+  common:
+    home: Home
+    about: About
+    documentation: Documentation
+    downloads: Downlaods
+    community: Community
+    reference: Reference
+    book: Book
+    videos: Videos
+    external_links: External Links
+    blog: Blog
+    gui_clients: GUI Clients
+    logos: Logos
+    search: search
+    submit: submit

--- a/config/locales/en/views/about/branching_and_merging.yml
+++ b/config/locales/en/views/about/branching_and_merging.yml
@@ -1,0 +1,18 @@
+en:
+  about:
+    branching_and_merging:
+      branching_and_merging: Branching and Merging
+      p1: The Git feature that really makes it stand apart from nearly every other SCM out there is its branching model.
+      p2: Git allows and encourages you to have multiple local branches that can be entirely independent of each other. The creation, merging, and deletion of those lines of development takes seconds.
+      p3: "This means that you can do things like:"
+      # begin bullet list
+      ul_li1_html: <strong>Frictionless Context Switching</strong>. Create a branch to try out an idea, commit a few times, switch back to where you branched from, apply a patch, switch back to where you are experimenting, and merge it in.
+      ul_li2_html: <strong>Role-Based Codelines</strong>. Have a branch that always contains only what goes to production, another that you merge work into for testing, and several smaller ones for day to day work.
+      ul_li3_html: <strong>Feature Based Workflow</strong>. Create new branches for each new feature you're working on so you can seamlessly switch back and forth between them, then delete each branch when that feature gets merged into your main line.
+      ul_li4_html: <strong>Disposable Experimentation</strong>. Create a branch to experiment in, realize it's not going to work, and just delete it - abandoning the work—with nobody else ever seeing it (even if you've pushed other branches in the meantime).
+      # end
+      p4: Notably, when you push to a remote repository, you do not have to push all of your branches. You can choose to share just one of your branches, a few of them, or all of them. This tends to free people to try new ideas without worrying about having to plan how and when they are going to merge it in or share it with others.
+      p5: There are ways to accomplish some of this with other systems, but the work involved is much more difficult and error-prone. Git makes this process incredibly easy and it changes the way most developers work when they learn it.
+      small_and_fast: "Small and Fast →"
+
+        

--- a/config/locales/en/views/about/data_assurance.yml
+++ b/config/locales/en/views/about/data_assurance.yml
@@ -1,0 +1,16 @@
+en:
+  about:
+    data_assurance:
+      data_assurance: Data Assurance
+      p1_html: "The data model that Git uses ensures the cryptographic integrity of every bit
+        of your project.  Every file and commit is checksummed and retrieved by its
+        checksum when checked back out. It's impossible to get anything out of Git
+        other than the <strong>exact bits you put in</strong>."
+      p2: It is also impossible to change any file, date, commit message, or any other
+        data in a Git repository without changing the IDs of everything after it.
+        This means that if you have a commit ID, you can be assured not only that
+        your project is exactly the same as when it was committed, but
+        that nothing in its history was changed.
+      p3: Most centralized version control systems provide no such integrity by default.
+      distributed: "← Distributed"
+      staging_area: "Staging Area →"

--- a/config/locales/en/views/about/distributed.yml
+++ b/config/locales/en/views/about/distributed.yml
@@ -1,0 +1,21 @@
+en:
+  about:
+    distributed:
+      distributed: Distributed
+      p1: One of the nicest features of any Distributed SCM, Git included, is that it's distributed. This means that instead of doing a "checkout" of the current tip of the source code, you do a "clone" of the entire repository.
+      multiple_backups: Multiple Backups
+      p2: This means that even if you're using a centralized workflow, every user essentially has a full backup of the main server. Each of these copies could be pushed up to replace the main server in the event of a crash or corruption. In effect, there is no single point of failure with Git unless there is only a single copy of the repository.
+      any_workflow: Any Workflow
+      p3: Because of Git's distributed nature and superb branching system, an almost endless number of workflows can be implemented with relative ease.
+      subversion_style: Subversion-Style Workflow
+      p4: A centralized workflow is very common, especially from people transitioning from a centralized system. Git will not allow you to push if someone has pushed since the last time you fetched, so a centralized model where all developers push to the same server works just fine.
+      img_alt_workflow_a: Workflow A
+      integration_manager: Integration Manager Workflow
+      p5: Another common Git workflow involves an integration manager — a single person who commits to the 'blessed' repository. A number of developers then clone from that repository, push to their own independent repositories, and ask the integrator to pull in their changes. This is the type of development model often seen with open source or GitHub repositories.
+      img_alt_workflow_b: Workflow b
+      dictator_and_lieutenants: Dictator and Lieutenants Workflow
+      p6: For more massive projects, a development workflow like that of the Linux kernel is often effective.
+        In this model, some people ('lieutenants') are in charge of a specific subsystem of the project and they merge in all changes related to that subsystem. Another integrator (the 'dictator') can pull changes from only his/her lieutenants and then push to the 'blessed' repository that everyone then clones from again.
+      small_and_fast: "← Small and Fast"
+      data_assurance: "Data Assurance →"
+      

--- a/config/locales/en/views/about/free_and_open_source.yml
+++ b/config/locales/en/views/about/free_and_open_source.yml
@@ -1,0 +1,21 @@
+en:
+  about:
+    free_and_open_source:
+      free_and_open_source: About
+      p1_html: Git is released under the <a href="https://github.com/git/git/blob/master/COPYING">GPLv2</a> <a href="http://www.opensource.org/docs/osd">open source license</a>.  This means that you are free to <a href="https://github.com/git/git">inspect the source code</a> at any time or <a href="https://github.com/git/git/blob/master/Documentation/SubmittingPatches">contribute</a> to the project yourself.
+      p2_html: "Under Git's GPLv2 software license, you <strong>may</strong>:"
+      # begin first bullet list
+      ul1_li1: Use Git on open or proprietary projects for free, forever
+      ul1_li2: Download, inspect and modify the source code to Git
+      ul1_li3: Make proprietary changes to Git that you do not redistribute publicly
+      ul1_li4: Call Git binaries from your open or proprietary programs
+      ul1_li5: "Publicly redistribute Git binaries with open or proprietary programs, given that they are unmodified or the modifications are public"
+      # end
+      p3_html: "Under this license you <strong>may not</strong>:"
+      # begin second bullet list
+      ul2_li1: Make proprietary changes to Git and publicly redistribute it without sharing the changes
+      ul2_li2: Make and publicly distribute changes to Git under a different license
+      ul2_li3: Use source code from the Git repository in a project under a different license without permission
+      # end
+      staging_area: "← Staging Area"
+      

--- a/config/locales/en/views/about/index.yml
+++ b/config/locales/en/views/about/index.yml
@@ -1,0 +1,11 @@
+en:
+  about:
+    index:
+      about: About
+      branching_and_merging: Branching and Merging
+      small_and_fast: Small and Fast
+      distributed: Distributed
+      data_assurance: Data Assurance
+      stating_area: Staging Area
+      free_and_open_source: Free and Open Source
+        

--- a/config/locales/en/views/about/small_and_fast.yml
+++ b/config/locales/en/views/about/small_and_fast.yml
@@ -1,0 +1,66 @@
+en:
+  about:
+    small_and_fast:
+      small_and_fast: Small and Fast
+      p1_html: '<strong>Git is fast</strong>. With Git, nearly all operations are performed locally, giving it a huge speed advantage on centralized systems that constantly have to communicate with a server somewhere.'
+      p2: "Git was built to work on the Linux kernel, meaning that it has had to effectively handle large repositories from day one. Git is written in C, reducing the overhead of runtimes associated with higher-level languages. Speed and performance has been a primary design goal of the Git from the start."
+      benchmarks: Benchmarks
+      p3_html: "Let's see how common {operations} stack up against Subversion, a common centralized version control system that is similar to CVS or Perforce. <em>Smaller is faster.</em>"
+      img_alt_init_benchmarks: init benchmarks
+      p4: For testing, large AWS instances were set up in the same availability zone.
+        Git and SVN were installed on both machines, the Ruby repository was copied to
+        both Git and SVN servers, and common operations were performed on both.
+      p5: "In some cases the commands don't match up exactly. Here, matching on the lowest
+        common denominator was attempted. For example, the 'commit' tests also include
+        the time to push for Git, though most of the time you would not actually be pushing
+        to the server immediately after a commit where the two commands cannot be separated
+        in SVN."
+      p6: All of these times are in seconds.
+      # <table>
+      operation: Operation
+      table_row_1: Commit Files (A)
+      table_row_1_desc: "Add, commit and push 113 modified files (2164+, 2259-)"
+      table_row_2: Commit Images (B)
+      table_row_2_desc: "Add, commit and push 1000 1k images"
+      table_row_3: Diff Current
+      table_row_3_desc: "Diff 187 changed files (1664+, 4859-) against last commit"
+      table_row_4: Diff Recent
+      table_row_4_desc: "Diff against 4 commits back (269 changed/3609+,6898-)"
+      table_row_5: Diff Tags
+      table_row_5_desc: "Diff two tags against each other (v1.9.1.0/v1.9.3.0 )"
+      table_row_6: Log (50)
+      table_row_6_desc: "Log of the last 50 commits (19k of output)"
+      table_row_7: Log (All)
+      table_row_7_desc: "Log of all commits (26,056 commits - 9.4M of output)"
+      table_row_8: Log (File)
+      table_row_8_desc: "Log of the history of a single file (array.c - 483 revs)"
+      table_row_9: Update
+      table_row_9_desc: "Pull of Commit A scenario (113 files changed, 2164+, 2259-)"
+      table_row_10: Blame
+      table_row_10_desc: "Line annotation of a single file (array.c)"
+      # </table>
+      p7: Note that this is the best case scenario for SVN - a server with no load with an
+        80MB/s bandwidth connection to the client machine.  Nearly all of these
+        times would be even worse for SVN if that connection was slower, while
+        many of the Git times would not be affected.
+      p8_html: Clearly, in many of these common version control operations, <strong>Git is
+        one or two orders of magnitude faster than SVN</strong>, even under ideal conditions
+        for SVN.
+      p9: "One place where Git is slower is in the initial clone operation.
+        Here, Git is downloading the entire history rather than only the latest
+        version. As seen in the above charts, it's not considerably slower for an operation
+        that is only performed once."
+      operation: Operation
+      clone: Clone
+      clone_desc: Clone and shallow clone(*) in Git vs checkout in SVN
+      size_m: Size (M)
+      size_m_desc: Size of total client side data and files after clone/checkout (in M)
+      p10: "It's also interesting to note that the size of the data on the client side
+        is very similar even though Git also has every version of every file for the
+        entire history of the project. This illustrates how efficient it is at compressing
+        and storing data on the client side."
+      # bottom links
+      branching_and_merging: "← Branching and Merging"
+      distributed: "Distributed →"
+        
+        

--- a/config/locales/en/views/about/staging_area.yml
+++ b/config/locales/en/views/about/staging_area.yml
@@ -1,0 +1,12 @@
+en:
+  about:
+    staging_area:
+      staging_area: Staging Area
+      p1: 'Unlike the other systems, Git has something called the "staging area" or "index". This is an intermediate area where commits can be formatted and reviewed before completing the commit.'
+      img1_alt: Index 2
+      p2: "One thing that sets Git apart from other tools is that it's possible to quickly stage some of your files and commit them without committing all of the other modified files in your working directory or having to list them on the command line during the commit."
+      p3: "This allows you to stage only portions of a modified file. Gone are the days of making two logically unrelated modifications to a file before you realized that you forgot to commit one of them. Now you can just stage the change you need for the current commit and stage the other change for the next commit. This feature scales up to as many different changes to your file as needed."
+      p4: "Of course, Git also makes it easy to ignore this feature if you don't want that kind of control — just add a '-a' to your commit command in order to add all changes to all files to the staging area."
+      img2_alt: ""
+      data_assurance: "← Data Assurance"
+      free_and_open_source: "Free and Open Source →"

--- a/config/locales/en/views/books/chapters.yml
+++ b/config/locales/en/views/books/chapters.yml
@@ -1,0 +1,5 @@
+en:
+  books:
+    chapters:
+      chapters: "Chapters ▾"
+      index_of_commands: Index of Commands

--- a/config/locales/en/views/books/commands.yml
+++ b/config/locales/en/views/books/commands.yml
@@ -1,0 +1,4 @@
+en:
+  books:
+    commands:
+      index_of_commands: Index of Commands

--- a/config/locales/en/views/books/ebooks.yml
+++ b/config/locales/en/views/books/ebooks.yml
@@ -1,0 +1,4 @@
+en:
+  books:
+    ebooks:
+      p1_html: '<p>Download this book in <a href="https://github.s3.amazonaws.com/media/progit.en.pdf">PDF</a>, <a href="https://github.s3.amazonaws.com/media/pro-git.en.mobi">mobi</a>, or <a href="https://github.s3.amazonaws.com/media/progit.epub">ePub</a> form for free.</p>'

--- a/config/locales/en/views/books/show.yml
+++ b/config/locales/en/views/books/show.yml
@@ -1,0 +1,6 @@
+en:
+  books:
+    show:
+      page_title: "Git - Book"
+      main_p1_html: 'The entire Pro Git book, written by Scott Chacon and published by Apress, is available here. All content is licensed under the <a href="http://creativecommons.org/licenses/by-nc-sa/3.0/">Creative Commons Attribution Non Commercial Share Alike 3.0 license</a>.  Print versions of the book are available on <a href="http://www.amazon.com/gp/product/1430218339?ie=UTF8&camp=1789&creative=9325&creativeASIN=1430218339&linkCode=as2&tag=git-sfconservancy-20">Amazon.com</a>.</>'
+      index_of_commands: Index of Commands

--- a/config/locales/en/views/books/translations.yml
+++ b/config/locales/en/views/books/translations.yml
@@ -1,0 +1,7 @@
+en:
+  books:
+    translations:
+      translated_into: This book is translated into
+      partial_tanslations: Partial translations available in
+      translations_started_for: Translations started for 
+      p1_html: 'The source of this book and the translations are <a href="https://github.com/progit/progit">hosted on GitHub.</a></br> Patches, suggestions, and comments are welcome.'

--- a/config/locales/en/views/community/index.yml
+++ b/config/locales/en/views/community/index.yml
@@ -1,0 +1,17 @@
+en:
+  community:
+    index:
+      page_title: "Git - Community"
+      main_h1: Community
+      main_h2_mailing: Mailing List
+      main_p1_html: 'Questions or comments for the Git community can be sent to the mailing list by using the email address <a href="mailto:git@vger.kernel.org">git@vger.kernel.org</a>. <strong>Bug reports should be sent to this mailing list.</strong>'
+      main_p2: 'You do not need to subscribe: you will be Cc&apos;d in replies. Please keep the Cc list intact when replying (use &quot;Reply to all&quot;). Greylisting may delay your first post for a few hours.'
+      main_p3_html: 'The <a href="http://dir.gmane.org/gmane.comp.version-control.git">archive</a> can be found on Gmane.  Click <a href="mailto:majordomo@vger.kernel.org?body=subscribe git">here</a> to subscribe.'
+      main_p4_html: 'There is also <a href="https://groups.google.com/forum/?fromgroups#!forum/git-users">Git user mailing list</a> on Google Groups which is a nice place for beginners to ask about anything.'
+      main_h2_irc: 'IRC Channel'
+      main_p5_html: 'If the manpages and this book aren’t enough and you need in-person help, you can try the <span class="highlight fixed">#git</span> channel on the Freenode IRC server (<strong>irc.freenode.net</strong>). These channels are regularly filled with hundreds of people who are all very knowledgeable about Git and are often willing to help.'
+      main_p6_html: 'If you need specific help about one of the for-profit Git hosting sites, you might try their own IRC channels (such as <span class="highlight fixed">#github</span> or <span class="highlight fixed">#gitorious</span>) on the same IRC server.'
+      main_h2_contributing: 'Contributing to Git'
+      main_p7_html: 'The <a href="https://github.com/git/git/tree/master/Documentation">Documentation directory</a> in the Git source code has several files of interest to developers who are looking to help contribute. After reading the <a href="https://github.com/git/git/blob/master/Documentation/CodingGuidelines">coding guidelines</a>, you can learn <a href="https://github.com/git/git/blob/master/Documentation/SubmittingPatches">how to submit patches</a>. For those looking to get more deeply involved, there is a <a href="https://github.com/git/git/blob/master/Documentation/howto/maintain-git.txt">howto for Git maintainers</a>.'
+      
+        

--- a/config/locales/en/views/doc/ext.yml
+++ b/config/locales/en/views/doc/ext.yml
@@ -1,0 +1,46 @@
+en:
+  doc:
+    ext:
+      page_title: 'Git - External Links'
+      external_links: "External Links"
+      tutorials: Tutorials
+      short_and_sweet_html: "Short &amp; Sweet"
+      introductory_reference: "Introductory Reference &amp; Tutorial"
+      introductory_ref_description: "This introductory walkthrough acts as a nice tutorial."
+      official_git_tut: "Official Git Tutorial"
+      official_git_tut_description: "The official gittutorial man page is a good place to start."
+      everyday_git: "Everyday Git"
+      everyday_git_description: "Learn the basics with 20 of the most common commands."
+      git_immersion: "Git Immersion"
+      git_immersion_description: "A guided tour that walks through the fundamentals of Git."
+      diving_deeper: "Diving Deeper"
+      rys_git_tutorial_html: 'Ry&rsquo;s Git Tutorial'
+      rys_git_tut_description: "A hands-on introduction to the entire Git porcelain."
+      git_for_designers: "Git for Designers"
+      git_for_designers_description: "No knowledge of version control? No problem."
+      git_for_computer_scientists: "Git for Computer Scientists"
+      git_for_computer_scientists_desc: "A quick introduction to Git internals for people who aren't scared by words like Directed Acyclic Graph."
+      git_magic: "Git Magic"
+      git_magic_description_html: 'An alternative book with the source <a href="http://github.com/blynn/gitmagic/tree/master">online</a>.'
+      help_github: "Help.GitHub"
+      help_github_description: "Guides on a variety of Git and GitHub related topics."
+      books: Books
+      pragmatic_git: Pragmatic Version Control Using Git
+      pragmatic_git_description: By Travis Swicegood
+      pro_git: Pro Git
+      pro_git_description: By Scott Chacon
+      git_internals: Git Internals Peepcode PDF
+      git_internals_description: By Scott Chacon
+      git_in_trenches: Git in the Trenches
+      git_in_trenches_description: By Peter Savage
+      version_control: "Version Control with Git, 2nd ed."
+      version_control_description: "By Jon Loeliger &amp; Matthew McCullough"
+      pragmatic_guide: Pragmatic Guide to Git
+      pragmatic_guide_description: By Travis Swicegood
+      git_for_everyone: "Git: Version Control for Everyone"
+      git_for_everyone_description: By Ravishankar Somasundaram
+      videos: Videos
+      tech_talk: "Tech Talk: Linus Torvalds on Git"
+      tech_talk_description: "Linus Torvalds visits Google to share his thoughts on Git, the SCM system he created."
+      introduction_to_git: "Introduction to Git: Scott Chacon"
+      introduction_to_git_description: "This talk introduces the Git Version Control System by looking at what Git is doing when you run the commands you need to do basic version control with it."

--- a/config/locales/en/views/doc/index.yml
+++ b/config/locales/en/views/doc/index.yml
@@ -1,0 +1,21 @@
+en:
+  doc:
+    index:
+      page_title: "Git - Documentation"
+      documentation: Documentation
+      reference: Reference
+      reference_manual: "Reference Manual"
+      callout_p1: "The official and comprehensive <strong>man pages</strong> that are included in the Git package itself."
+      quick_reference: "Quick reference guides:"
+      heroku_cheat_sheet: "Heroku Cheat Sheet"
+      visual_git_cheat_sheet: "Visual Git Cheat Sheet"
+      book: "Book"
+      book_intro_p1: "Pro Git is written by Scott Chacon and published by Apress."
+      book_intro_p2_html: 'Print copies can be purchased from <a href="http://www.amazon.com/gp/product/1430218339?ie=UTF8&camp=1789&creative=9325&creativeASIN=1430218339&linkCode=as2&tag=git-sfconservancy-20">Amazon</a> and <a href="https://github.s3.amazonaws.com/media/progit.en.pdf">PDF</a>, <a href="https://github.s3.amazonaws.com/media/pro-git.en.mobi">mobi</a>, and <a href="https://github.s3.amazonaws.com/media/progit.epub">ePub</a> versions are available for free.'
+      back_to_book: "Back to book →"
+      creative_commons: "All content under the Creative Commons Attribution Non Commercial Share Alike 3.0 license."
+      index_of_commands: "Index of Commands"
+      book_information: "Book information and downloads"
+      videos: "Videos"
+      external_links: "External Links"
+      external_links_p1_html: 'The <a href="/documentation/external-links">External Links section</a> is a curated, ever-evolving collection of tutorials, books, videos, and other Git resources.'

--- a/config/locales/en/views/doc/ref.yml
+++ b/config/locales/en/views/doc/ref.yml
@@ -1,0 +1,8 @@
+en:
+  doc:
+    ref:
+      page_title: "Git - Reference"
+      reference: Reference
+      quick_reference: "Quick reference guides:"
+      heroku_cheat_sheet: "Heroku Cheat Sheet"
+      visual_git_cheat_sheet: "Visual Git Cheat Sheet"

--- a/config/locales/en/views/doc/videos.yml
+++ b/config/locales/en/views/doc/videos.yml
@@ -1,0 +1,6 @@
+en:
+  doc:
+    videos:
+      page_title: "Git - Videos"
+      videos: "Videos"
+      length: "Length:"

--- a/config/locales/en/views/downloads/download_linux.yml
+++ b/config/locales/en/views/downloads/download_linux.yml
@@ -1,0 +1,5 @@
+en:
+  downloads:
+    download_linux:
+      main_h1: "Download for Linux and Unix"
+      main_p1: "It is easiest to install Git on Linux using the preferred package manager of your Linux distribution."

--- a/config/locales/en/views/downloads/downloading.yml
+++ b/config/locales/en/views/downloads/downloading.yml
@@ -1,0 +1,17 @@
+en:
+  downloads:
+    downloading:
+      page_title: Git - Downloading Package
+      main_h1: Downloading Git
+      callout_h3: Your download is starting…
+      callout_p1_html: "You are downloading version <strong>%{download_version_name}</strong> of Git for the <strong>%{platform_capitalized}</strong> platform. This is the most recent <a href='%{project_url}'>maintained build</a> for this platform. It was released <strong>%{released_time_ago} ago</strong>, on %{download_release_date}."
+      callout_p2_html: "<strong>If your download hasn't started, <a href='%{download_url}''>click here to download manually</a>.</strong>"
+      callout_p3_html: "The current source code release is version <strong>%{latest_name}</strong>. If you want the newer version, you can build it from <a href='%{source_url}'>the source code</a>."
+      now_what: Now What?
+      now_what_p1: "Now that you have downloaded Git, it's time to start using it."
+      next_steps_li_1_h3: "Read the Book"
+      next_steps_li_1_p1: "Dive into the Pro Git book and learn at your own pace."
+      next_steps_li_2_h3: "Download a GUI"
+      next_steps_li_2_p1: "Several free and commercial GUI tools are available for the %{platform_capitalized} platform."
+      next_steps_li_3_h3: "Get Involved"
+      next_steps_li_3_p1: "A knowledgeable Git community is available to answer your questions."

--- a/config/locales/en/views/downloads/guis/index.yml
+++ b/config/locales/en/views/downloads/guis/index.yml
@@ -1,0 +1,18 @@
+en:
+  downloads:
+    guis:
+      index:
+        page_title: "Git - GUI Clients"  
+        main_h1: "GUI Clients"
+        main_p1_html: 'Git comes with built-in GUI tools for committing (<a href="/docs/git-gui">git-gui</a>) and browsing (<a href="/docs/giasasastk">gitk</a>), but there are several third-party tools for users looking for platform-specific experience.'
+        main_p2_link: "Only show GUIs for my OS (Linux)"
+        main_p2_highlighted: "GUIs are highlighted below ↓"
+        clients_platforms: "Platforms:"
+        clients_price: "Price:"
+        clients_price_free: "Free"
+        clients_github_for_mac: "GitHub for Mac"
+        clients_github_for_windows: "GitHub for Windows"
+        callout_p1_html: 'There are other great GUI tools available as well. Have a look at the list of <a href="https://git.wiki.kernel.org/index.php/InterfacesFrontendsAndTools">interfaces, frontends and tools</a> in the Git Wiki.'
+      
+      
+      

--- a/config/locales/en/views/downloads/index.yml
+++ b/config/locales/en/views/downloads/index.yml
@@ -1,0 +1,15 @@
+en:
+  downloads:
+    index:
+      page_title: Git - Downloads
+      downloads: Downloads
+      older_releases_html: <a href="http://code.google.com/p/git-core/downloads/list">Older releases</a> are available and the <a href="https://github.com/git/git">Git source repository</a> is on GitHub.
+      gui_clients: GUI Clients
+      gui_clients_p1_html: 'Git comes with built-in GUI tools (<strong>git-gui</strong>, <strong>gitk</strong>), but there are several third-party tools for users looking for a platform-specific experience.'
+      gui_clients_p2: View GUI Clients →
+      logos: Logos
+      logos_p1: Various Git logos in PNG (bitmap) and EPS (vector) formats are available for use in online and print projects.
+      logos_p2: View logos →
+      git_via_git: Git via Git 
+      git_via_git_p1: "If you already have Git installed, you can get the latest development version via Git itself:"
+      git_via_git_p2_html: 'You can also always browse the current contents of the git repository using the <a href="https://github.com/git/git">web interface</a>.'

--- a/config/locales/en/views/downloads/logos/index.yml
+++ b/config/locales/en/views/downloads/logos/index.yml
@@ -1,0 +1,14 @@
+en:
+  downloads:
+    logos:
+      index:
+        page_title: "Git - Logo Downloads"
+        column_left_li1_h4: Full color Git logo for light backgrounds
+        column_left_li2_h4: Orange Git logo for light backgrounds
+        column_left_li3_h4: One color Git logo for light backgrounds
+        column_left_li4_h4: One color Git logo for dark backgrounds
+        column_right_li1_h4: Orange logomark for light backgrounds
+        column_right_li2_h4: Black logomark for light backgrounds
+        column_right_li3_h4: White logomark for dark backgrounds
+        logo_license_p1_html: 'Git Logo by <a href="http://twitter.com/jasonlong">Jason Long</a> is licensed under the <a href="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 Unported License</a>.'
+        logo_license_p2: 'This license lets others distribute, remix, tweak, and build upon your work, even commercially, as long as they credit you for the original creation. This is the most accommodating of the CC licenses offered. Recommended for maximum dissemination and use of licensed materials.'

--- a/config/locales/en/views/shared/book.yml
+++ b/config/locales/en/views/shared/book.yml
@@ -1,0 +1,6 @@
+en:
+  shared:
+    book:
+      book_callout_html: <p>The entire <strong><a href="/book">Pro Git book</a></strong> written by 
+        Scott Chacon is available to <a href="/book">read online for free</a>. Dead tree versions are 
+        available on <a href="http://www.amazon.com/gp/product/1430218339?ie=UTF8&camp=1789&creative=9325&creativeASIN=1430218339&linkCode=as2&tag=git-sfconservancy-20">Amazon.com</a>.

--- a/config/locales/en/views/shared/footer.yml
+++ b/config/locales/en/views/shared/footer.yml
@@ -1,0 +1,6 @@
+en:
+  shared:
+    footer:
+      site_source_html: This <a href="https://github.com/github/gitscm-next/blob/master/README.md#license">open sourced</a> 
+        site is <a href="https://github.com/github/gitscm-next">hosted on GitHub.</a><br> Patches, suggestions, and comments are welcome.
+      sfc_member_html: Git is a member of <a href="/sfc">Software Freedom Conservancy</a>

--- a/config/locales/en/views/shared/header.yml
+++ b/config/locales/en/views/shared/header.yml
@@ -1,0 +1,4 @@
+en:
+  shared:
+    header:
+      search_placeholder: Search entire site…

--- a/config/locales/en/views/shared/masthead.yml
+++ b/config/locales/en/views/shared/masthead.yml
@@ -1,0 +1,14 @@
+en:
+  shared:
+    masthead:
+      free_and_open_source: free and open source
+      git_masthead_p1_html: Git is a %{link} distributed version control system designed to handle everything 
+        from small to very large projects with speed and efficiency.
+      easy_to_learn: easy to learn
+      tiny_footprint: tiny footprint with lightning fast performance
+      cheap_local_branching: cheap local branching
+      staging_areas: staging areas
+      multiple_workflows: multiple workflows
+      git_masthead_p2_html: Git is %{link_01} and has a %{link_02}. It outclasses SCM tools like Subversion, CVS, Perforce, and ClearCase
+        with features like %{link_03}, convenient %{link_04}, and %{link_05}.
+      learn_git_html: Learn Git in your browser for free with <a href="http://try.github.com">Try Git</a>.

--- a/config/locales/en/views/shared/monitor.yml
+++ b/config/locales/en/views/shared/monitor.yml
@@ -1,0 +1,6 @@
+en:
+  shared:
+    monitor:
+      latest_stable: "Latest stable release"
+      release_notes: Release Notes
+      download_source: Download Source Code

--- a/config/locales/en/views/shared/ref/ref.yml
+++ b/config/locales/en/views/shared/ref/ref.yml
@@ -1,0 +1,16 @@
+en:
+  shared:
+    ref:
+      administration: Administration
+      branching_and_mergin: Branching and Merging
+      creating: Getting and Creating Projects
+      debugging: Debugging
+      email: Email
+      external_systems: External Systems
+      inspection_and_comparison: Inspection and Comparison
+      patching: Patching
+      plumbing: Plumbing Commands
+      server_admin: Server Admin
+      setup_and_config: Setup and Config
+      sharing_and_updating: Sharing and Updating Projects
+      basic_snapshotting: Basic Snapshotting

--- a/config/locales/en/views/shared/related.yml
+++ b/config/locales/en/views/shared/related.yml
@@ -1,0 +1,7 @@
+en:
+  shared:
+    related:
+      related_material: Related Material
+      reference: Reference
+      books: Books
+      videos: Videos

--- a/config/locales/en/views/shared/search.yml
+++ b/config/locales/en/views/shared/search.yml
@@ -1,0 +1,4 @@
+en:
+  shared:
+    search:
+      show_all_results: Show all results...

--- a/config/locales/en/views/shared/sidebar.yml
+++ b/config/locales/en/views/shared/sidebar.yml
@@ -1,0 +1,4 @@
+en:
+  shared:
+    sidebar:
+      sidebar: Sidebar

--- a/config/locales/en/views/site/404.yml
+++ b/config/locales/en/views/site/404.yml
@@ -1,0 +1,5 @@
+en:
+  site:
+    404:
+      page_does_not_exist: "That page doesn't exist!"
+      recent_redesign_notice: We recently redesigned the site and older URLs may now lead to missing pages. We apologize for the inconvenience.

--- a/config/locales/en/views/site/500.yml
+++ b/config/locales/en/views/site/500.yml
@@ -1,0 +1,5 @@
+en:
+  site:
+    500:
+      page_does_not_exist: "That page doesn't exist!"
+      recent_redesign_notice: We recently redesigned the site and older URLs may now lead to missing pages. We apologize for the inconvenience.

--- a/config/locales/en/views/site/admin.yml
+++ b/config/locales/en/views/site/admin.yml
@@ -1,0 +1,4 @@
+en:
+  site:
+    admin:
+      admin_page: Admin Page

--- a/config/locales/en/views/site/index.yml
+++ b/config/locales/en/views/site/index.yml
@@ -1,0 +1,15 @@
+en:
+  site:
+    index:
+      about_intro: "The advantages of Git compared to other source control systems."
+      documentation_intro: "Command reference pages, Pro Git book content, videos and other material."
+      downloads_intro: "GUI clients and binary releases for all major platforms."
+      community_intro: "Get involved! Mailing list, chat, development and more."
+      pro_git_promo_html: <strong><a href="/book">Pro Git</a></strong> by Scott Chacon is available to <a href="/book">read online for free</a>.
+        Dead tree versions are available on <a href="http://www.amazon.com/gp/product/1430218339?ie=UTF8&camp=1789&creative=9325&creativeASIN=1430218339&linkCode=as2&tag=git-sfconservancy-20">Amazon.com</a>.
+      graphical_uis: Graphical UIs
+      tarballs: Tarballs
+      windows_build: Windows Build
+      source_code: Source Code
+      git_users_shout_out_html: "Companies &amp; Projects Using Git"
+

--- a/config/locales/en/views/site/results.yml
+++ b/config/locales/en/views/site/results.yml
@@ -1,0 +1,6 @@
+en:
+  site:
+    results:
+      search_results: "Search results for %{term}"
+      search_results_html: "Search results for <strong>%{term}</strong>"
+      sorry: "Sorry, no search matches"

--- a/config/locales/en/views/site/sfc.yml
+++ b/config/locales/en/views/site/sfc.yml
@@ -1,0 +1,37 @@
+en:
+  site:
+    sfc:
+      git_and_sfc: Git and Software Freedom Conservancy
+      donation: Donation
+      check_or_wire: Check or Wire
+      to_donate_via_paypal: "To donate to Git via PayPal:"
+      p1_html: 'Git is a member project of <a href="http://sfconservancy.org/">Software
+        Freedom Conservancy</a>.  Conservancy is a not-for-profit organization that
+        provides financial and administrative assistance to open source projects.'
+      p2_html: Conservancy accepts donations on git's behalf. In the past, project money has
+        typically gone to defraying travel costs for developers to come to our annual
+        <a href="https://git.wiki.kernel.org/index.php/GitTogether">GitTogether</a>
+        mini-conference.  A portion of the money goes to Conservancy to cover their
+        operating expenses. You can also donate <a
+        href="http://sfconservancy.org/donate">directly</a> to Software
+        Freedom Conservancy's general fund.
+      p3_html: 'We can also accept donations drawn in USD from banks in the USA
+        (donations from banks outside of the US or not in USD should be handled
+        by wire). Make checks payable to "Software Freedom Conservancy, Inc."
+        and place "Directed donation: Git" in the memo field. Checks should be
+        mailed to:
+        <div class="center">
+        <pre>
+        Software Freedom Conservancy, Inc.<br/>
+        137 Montague ST STE 380<br/>
+        BROOKLYN, NY 11201 USA<br/>
+        </pre>
+        </div>'
+      p4_html: Conservancy can accept wire donations, but the instructions vary
+        depending on the country of origin. Please contact <a
+          href="mailto:accounting@sfconservancy.org">accounting@sfconservancy.org</a>
+        for instructions.
+      p5_html: Conservancy also accepts stock donations on behalf of the Git
+        project. If you would like to donate stock, please contact <a
+          href="mailto:accounting@sfconservancy.org">accounting@sfconservancy.org</a>
+        for instructions on how to initiate the transfer.

--- a/config/locales/en/views/site/svn.yml
+++ b/config/locales/en/views/site/svn.yml
@@ -1,0 +1,301 @@
+en:
+  site:
+    svn:
+      git_svn_crash_course: Git - SVN Crash Course
+      intro_p1_html: Welcome to the Git version control system! Here we will briefly
+        introduce you to Git usage based on your current Subversion knowledge. You will
+        need the latest <a href="http://git.or.cz/">Git</a> installed;
+        There is also a potentially useful
+        <a href="http://www.kernel.org/pub/software/scm/git/docs/gittutorial.html">
+        tutorial</a> in the Git documentation.
+      how_to_read_me: How to Read Me
+      things_to_know: Things To Know
+      committing: Committing
+      browsing: Browsing
+      tagging_and_branching: Tagging and Branching
+      merging: Merging
+      going_remote: Going Remote
+      sharing_the_work: Sharing the Work
+      quick_start_p1: "If you are just after tracking someone else's project,
+        this get you started quickly:"
+      #
+      # How to Read Me
+      #
+      how_to_read_me_p1: In those small tables, at the left we always list the Git commands
+        for the task, while at the right the corresponding Subversion commands you would use
+        for the job are listed.  If you are in hurry, just skimming over them should
+        give you a good idea about the Git usage basics.
+      how_to_read_me_p2: Before running any command the first time, it's recommended that you
+        at least quickly skim through its manual page. Many of the commands have
+        very useful and interesting features (that we won't list here) and sometimes
+        there are some extra notes you might want to know. There's a quick usage
+        help available for the Git commands if you pass them the <code>-h</code>
+        switch.
+      #
+      # Things to Know
+      #
+      things_you_should_know: Things You Should Know
+      things_to_know_p1: There are couple important concepts it is good to know when
+        starting with Git. If you are in hurry though, you can skip this
+        section and only get back to it when you get seriously confused;
+        it should be possible to pick up with just using your intuition.
+      repositories: Repositories.
+      repositories_brief_html: With Subversion, for each project there is a single repository at some
+        detached central place where all the history is and which you checkout
+        and commit into. Git works differently, each copy of the project tree
+        (we call that the <em>working copy</em>) carries its own repository
+        around (in the <code>.git</code> subdirectory in the project tree root).
+        So you can have local and remote branches.
+        You can also have a so-called <em>bare repository</em> which is not
+        attached to a working copy; that is useful especially when you want
+        to publish your repository. We will get to that.
+      url: URL.
+      url_brief_html: In Subversion the <em>URL</em> identifies the location of the repository
+        and the path inside the repository, so you organize the layout of the
+        repository and its meaning. Normally you would have <code>trunk/</code>,
+
+        <code>branches/</code> and <code>tags/</code> directories. In Git
+        the <em>URL</em> is just the location of the repository, and it always
+        contains branches and tags. One of the branches is the default (normally named
+        master).
+      revisions: Revisions.
+      revisions_brief_html: Subversion identifies revisions with ids of decimal numbers growing
+        monotonically which are typically small (although they can get quickly
+        to hundreds of thousands for large projects).  That is impractical in distributed systems like Git. Git
+        identifies revisions with SHA1 ids, which are long 160-bit numbers
+        written in hexadecimal. It may look scary at first, but in practice it is
+        not a big hurdle - you can refer to the latest revision by <code>HEAD</code>,
+        its parent as <code>HEAD^</code> and its parent as <code>HEAD^^ = HEAD~2</code>
+
+        (you can go on adding carrets),
+        cut'n'paste helps a lot and you can write only the few leading digits
+        of a revision - as long as it is unique, Git will guess the rest.
+        (You can do even more advanced stuff with revision specifiers, see the
+        <a href="http://www.kernel.org/pub/software/scm/git/docs/git-rev-parse.html">git-rev-parse manpage</a> for details.)
+      commits: Commits.
+      commits_brief_html: 'Each commit has an <em>author</em> and a <em>committer</em> field,
+        which record who and when <em>created</em> the change and who <em>committed</em> it
+        (Git is designed to work well with patches coming by mail - in that case,
+        the author and the committer will be different). Git will try to guess
+        your realname and email, but especially with email it is likely to get it wrong.
+        You can check it using <code class="g">git config -l</code> and set them with:'
+      your_name_here: Your Name Comes Here
+      fake_email: you@yourdomain.example.com
+      commands: Commands.
+      commands_brief_html: The Git commands are in the form <code>git command</code>.
+        You can interchangeably use the <code>git-command</code>
+        form as well.
+      colors: Colors.
+      colors_brief: 'Git can produce colorful output with some commands; since
+        some people hate colors way more than the rest likes them, by default
+        the colors are turned off. If you would like to have colors in your
+        output:'
+      visualize: Visualize.
+      visualize_brief_html: 'You may find it convenient to watch your repository using
+        the <code class="g">gitk</code> repository as you go.'
+      #
+      # Committing
+      #
+      committing_p1_html: "For the first introduction, let's make your project tracked by Git
+        and see how we get around to do daily development in it. Let's
+        <code>cd</code> to the directory with your project and initialize
+        a brand new Git repository with it:"
+      committing_p2_html: <code>git init</code> will initialize the repository,
+        <code>git add .</code> will add all the files under the current directory
+        and <code>git commit</code> will create the
+        initial import, given that repositories are coupled with working copies.
+      committing_p3_html: "Now your tree is officially tracked by Git. You can explore the
+        <code class='g'>.git</code> subdirectory a bit if you want, or don't if you
+        don't care. Do some random changes to your tree now - poke into few
+        files or such. Let's check what we've done:"
+      committing_p4_html: "That's it. This is one of the more powerful commands. To get a diff with an
+  specific revision and path do:"
+      committing_p5_html: "Git embeds special information in the diffs about adds, 
+        removals and mode changes:"
+      committing_p6_html: 'That will apply the patch while telling Git about and performing
+  those "meta-changes".'
+      committing_p7_html: 'There is a more concise representation of changes available:'
+      committing_p8_html: This will show the concise changes summary as well as list any files
+        that you haven't either ignored or told Git about. In addition,
+        it will also show at the top which branch you are in.
+      committing_p9_html: 'While we are at the status command, over time plenty of the
+        "Untracked files" will get in there, denoting files not tracked by Git.
+        Wait a moment if you want to add them, run <code class="g">git clean</code>
+        if you want to get rid of all of them, or add them to the <code class="g">.gitignore</code>
+
+        file if you want to keep them around untracked (works the same as the <code>svn:ignore</code>
+        property in SVN).'
+      committing_p10_html: 'To restore a file from the last revision:'
+      committing_p11_html: You can restore everything or just specified files.
+      committing_p12_html: 'So, just like in SVN, you need to tell Git when you add, move or
+        remove any files:'
+      committing_p13_html: You can also recursively add/remove whole directories and so on;
+        Git's cool!
+      committing_p14_html: "So, it's about time we commit our changes. Big surprise
+        about the command:"
+      committing_p15_html: 'to commit all the changes or, as with Subversion,
+        you can limit the commit only to specified files
+        and so on. A few words on the commit message: it is <em>customary</em>
+        to have a short commit summary as the first line of the message,
+        because various tools listing commits frequently show only the
+        first line of the message.  You can specify the commit message
+        using the <code>-m</code> parameter as you are used, but
+        you can pass several <code>-m</code> arguments and they will create
+        separate paragraphs in the commit message:'
+      committing_p16_html: If you don't pass any <code>-m</code> parameter or pass
+        the <code>-e</code> parameter, your favorite <code>$EDITOR</code>
+        will get run and you can compose your commit message there,
+        just as with Subversion. In addition, the list of files to be committed
+        is shown.
+      committing_p17_html: And as a bonus, if you pass it the <code>-v</code> parameter
+        it will show the whole patch being committed in the editor
+        so that you can do a quick last-time review.
+      committing_p18_html: By the way, if you screwed up committing, there's not much you
+        can do with Subversion, except using some enigmatic <code>svnadmin</code>
+        subcommands.  Git does it better - you can amend your latest commit
+        (re-edit the metadata as well as update the tree) using
+        <code class="g">git commit --amend</code>, or toss your latest
+        commit away completely using <code class="g">git reset HEAD^</code>,
+        this will not change the working tree.
+      #
+      # Browsing
+      #
+      browsing_p1_html: 'Now that we have committed some stuff, you might want to review
+        your history:'
+      browsing_p2_html: 'The log command works quite similar in SVN and Git; again,
+        <code>git log</code> is quite powerful, please look through
+        its options to see some of the stuff it can do.'
+      browsing_p3_html: The blame command is more powerful as it can detect the movement of lines,
+        even with file copies and renames. But there is a
+        big chance that you probably want to do something different! Usually,
+        when using annotate you are looking for the origin of some piece of
+        code, and the so-called <em>pickaxe</em> of Git is much more comfortable
+        tool for that job (<code>git log -S<em>string</em></code> shows the
+        commits which add or remove any file data matching <em>string</em>).
+      browsing_p4_html: 'You can see the contents of a file, the listing of a directory or
+        a commit with:'
+      #
+      # Tagging and branching
+      #
+      branching_p1_html: "ubversion marks certain checkpoints in history through copies, the copy is
+        usually placed in a directory named tags.  Git tags are much more powerful.
+        The Git tag can have an arbitrary description attached (the first
+        line is special as in the commit case), some people actually store
+        the whole release announcements in the tag descriptions. The identity
+        of the person who tagged is stored (again following the same rules
+        as identity of the committer). You can tag other objects than commits (but
+        that is conceptually rather low-level operation).
+        And the tag can be cryptographically PGP signed to verify the identity
+        (by Git's nature of working, that signature also confirms the validity
+        of the associated revision, its history and tree). So, let's do it:"
+      branching_p2_html: 'To list tags and to show the tag message:'
+      branching_p3_html: Like Subversion, Git can do branches (surprise surprise!). In Subversion,
+        you basically copy your project to a subdirectory. In Git, you tell it,
+        well, to create a branch.
+      branching_p4_html: The first command creates a branch, the second command switches
+        your tree to a certain branch. You can pass an extra argument to
+        <code>git branch</code> to base your new branch on a different
+        revision than the latest one.
+      branching_p5_html: You can list your branches conveniently using the aforementioned
+        <code>git-branch</code> command without arguments the listing of branches.
+        The current one is denoted by an "*".
+      branching_p6_html: 'To move your tree to some older revision, use:'
+      branching_p7_html: or you could create a temporary branch. In Git you can make commits on
+        top of the older revision and use it as another branch.
+      #
+      # Tagging and branching
+      #
+      merging_p1_html: 'Git supports merging between branches much better than Subversion - history
+        of both branches is preserved over the merges and repeated merges
+        of the same branches are supported out-of-the-box. Make sure you are on
+        one of the to-be-merged branches and merge the other one now:'
+      merging_ccmd_note: (assuming the branch was created in revision 20 and
+          you are inside a working copy of trunk)
+      merging_p2_html: 'If changes were made on only one of the branches since the last merge,
+        they are simply replayed on your other branch (so-called <em>fast-forward merge</em>).
+        If changes were made on both branches, they are merged intelligently
+        (so-called <em>three-way merge</em>): if any changes conflicted, <code>git merge</code>
+        will report them and let you resolve them, updating the rest of the tree
+        already to the result state; you can <code>git commit</code> when you resolve
+        the conflicts. If no changes conflicted, a commit is made automatically with
+        a convenient log message (or you can do
+
+        <code class="g">git merge --no-commit <em>branch</em></code> to review the merge
+        result and then do the commit yourself).'
+      merging_p3_html: 'Aside from merging, sometimes you want to just pick one commit from
+        a different branch. To apply the changes in revision <em>rev</em> and commit
+        them to the current branch use:'
+      #
+      # Going Remote
+      #
+      remote_p1_html: So far, we have neglected that Git is a <em>distributed</em> version
+        control system. It is time for us to set the record straight - let's grab
+        some stuff from remote sites.
+      remote_p2_html: "If you are working on someone else's project, you usually want to <em>clone</em>
+        its repository instead of starting your own. We've already mentioned that at the top
+        of this document:"
+      remote_p3_html: Now you have the default branch (normally <code>master</code>),
+        but in addition you got all the remote branches and tags.
+        In clone's default setup, the default local branch tracks
+        the <em>origin</em> remote, which represents the default branch in the
+        remote repository.
+      remote_p4_html: <em>Remote branch</em>, you ask? Well, so far we have worked
+        only with local branches. Remote branches are a mirror image of branches
+        in remote repositories and you don't ever switch to them directly or write
+        to them. Let me repeat - you never mess with remote branches. If you want
+        to switch to a remote branch, you need to create a corresponding local
+        branch which will "track" the remote branch':'
+      remote_p5_html: You can add more remote branches to a cloned repository, as well as just
+        an initialized one, using <code class="g">git remote add <em>remote</em> <em>url</em></code>.
+        The command <code class="g">git remote</code> lists all the remotes
+        repositories and <code class="g">git remote show <em>remote</em></code> shows
+        the branches in a remote repository.
+      remote_p6_html: "Now, how do you get any new changes from a remote repository?
+        You fetch them: <code class='g'>git fetch</code>.
+        At this point they are in your repository and you can examine them using
+        <code>git log <em>origin</em></code> (<code>git log HEAD..<em>origin</em></code>
+        to see just the changes you don't have in your branch), diff them, and obviously, merge them - just do
+        <code>git merge <em>origin</em></code>. Note that if you don't specify a branch
+        to fetch, it will conveniently default to the tracking remote."
+      remote_p7_html: 'Since you frequently just fetch + merge the tracking remote branch,
+        there is a command to automate that:'
+      #
+      # Sharing the Work
+      #
+      sharing_p1_html: Your local repository can be used by others to <em>pull</em> changes, but
+        normally you would have a private repository and a public repository.
+        The public repository is where everybody pulls and you... do the
+        opposite? <em>Push</em> your changes? Yes!
+        We do <code class="g">git push <em>remote</em></code> which will push
+        all the local branches with a corresponding remote branch - note that this works
+        generally only over SSH (or HTTP but with special webserver setup).
+        It is highly recommended to setup a SSH key and an SSH agent mechanism
+        so that you don't have to type in a password all the time.
+      sharing_p2_html: One important thing is that you should push only to remote branches
+        that are not currently checked out on the other side (for the same
+        reasons you never switch to a remote branch locally)! Otherwise the
+        working copy at the remote branch will get out of date and confusion
+        will ensue. The best way to avoid that is to push only to remote
+        repositories with no working copy at all - so called <em>bare</em>
+        repositories which are commonly used for public access or developers'
+        meeting point - just for exchange of history where a checked out copy
+        would be a waste of space anyway. You can create such a repository.
+        See <a href="/docs/user-manual.html#setting-up-a-public-repository">Setting up a public repository</a> for details.
+      sharing_p3_html: Git can work with the same workflow as Subversion, with a group of developers
+        using a single repository for exchange of their work. The only change
+        is that their changes aren't submitted automatically but they have
+        to push (however, you can setup a post-commit hook that will push for you
+        every time you commit; that loses the flexibility to fix up a screwed
+        commit, though). The developers must have either an entry in htaccess
+        (for HTTP DAV) or a UNIX account (for SSH). You can restrict their
+        shell account only to Git pushing/fetching by using the
+        <code class="g">git-shell</code> login shell.
+      sharing_p4_html: You can also exchange patches by mail. Git has very good support
+        for patches incoming by mail. You can apply them by feeding mailboxes
+        with patch mails to <code class="g">git am</code>. If you
+        want to <em>send</em> patches use <code class="g">git format-patch</code> and
+        possibly <code class="g">git send-email</code>.
+      sharing_p5_html: If you have any questions or problems which are not obvious from
+        the documentation, please contact us at the <strong>Git mailing list</strong>
+        at <a href="mailto:git@vger.kernel.org">git@vger.kernel.org</a>.
+        We hope you enjoy using Git!


### PR DESCRIPTION
This pull request is, of course, not ready to be merged. It is meant to restart the conversation around translating the site and to ask for feedback on the work I've been doing.

Using the default rails way of internationalizing an app poses a few challenges, specially when we have large static files. 

Simpler files like the [homepage](https://github.com/DiogoAndre/gitscm-next/blob/i18n/app/views/site/index.html.haml) are easy to process, and the [resulting yaml file](https://github.com/DiogoAndre/gitscm-next/blob/i18n/config/locales/en/views/site/index.yml) look relatively neat. Things are totally different with long files like the [svn crash course](https://github.com/DiogoAndre/gitscm-next/blob/i18n/app/views/site/svn.html.erb), and the [associated yaml file](https://github.com/DiogoAndre/gitscm-next/blob/i18n/config/locales/en/views/site/svn.yml), which is long and a bit confusing.

YAML files may not be too inviting for people willing to help translate the site, but maybe it can serve as a starting point for a more user-friendly method for translating the content. I'm thinking on something similar to [Amara](http://amara.org/), the service GitHub is using to crowd-source the [translation of GitHub's videos](http://amara.org/en/teams/github/).

I think it is also worth mentioning that I already have most of the content [translated to Brazilian Portuguese ](https://github.com/DiogoAndre/gitscm-next/tree/pt-br). So, when we get the i18n infrastructure ready, we'll have at least one language to show off! 

Please, share your comments! Be honest, but be gentle. ;-)
