### PR TITLE
Pointing Mac downloads to Sourceforge instead of Google Code

### DIFF
--- a/app/controllers/downloads_controller.rb
+++ b/app/controllers/downloads_controller.rb
@@ -30,7 +30,7 @@ class DownloadsController < ApplicationController
         @project_url  = "http://msysgit.github.com/"
         @source_url   = "https://github.com/msysgit/git/"
       else
-        @project_url = "http://code.google.com/p/git-osx-installer/"
+        @project_url = "http://sourceforge.net/projects/git-osx-installer/"
         @source_url   = "https://github.com/git/git/"
       end
 

--- a/app/views/downloads/installers/index.html.haml
+++ b/app/views/downloads/installers/index.html.haml
@@ -33,7 +33,7 @@
             %td
               %strong Mac
             %td 
-              =link_to "Stable", "http://code.google.com/p/git-osx-installer/downloads/list?can=3"
+              =link_to "Stable", "http://sourceforge.net/projects/git-osx-installer/files/"
           %tr
             %td 
               %strong Solaris


### PR DESCRIPTION
The downloads for the Mac installers moved to Sourceforge, so I've
updated the downloads.rake and the downloads controller and haml file
to point to the new location. Note that SF doesn't allow deep linking,
so the iframe trick doesn't work here (you'll always need to manually
download it, the browser won't force a download).
