### PR TITLE
Changed the link to fork the git-scm repo on GitHub.

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ To run the website for testing purposes, run:
 
 ## Contributing
 
-If you wish to contribute to this website, please [fork it on GitHub](https://github.com/git/git-scm.com), push your
+If you wish to contribute to this website, please [fork it on GitHub](https://github.com/git/git-scm.com/fork), push your
 change to a named branch, then send a pull request. If it is a big feature,
 you might want to start an Issue first to make sure it's something that will
 be accepted.  If it involves code, please also write tests for it.


### PR DESCRIPTION
Clicking on the previous link took us to the home page of the Repo. 

Now if one clicks on the new link, the user would be directly forking the repo and adding it to his/her profile or would be asked to login before the forking happens.
