### PR TITLE
Update FreeBSD package install instructions

### DIFF
--- a/app/views/downloads/download_linux.html.erb
+++ b/app/views/downloads/download_linux.html.erb
@@ -22,7 +22,7 @@
   <code>$ zypper install git</code>
 
   <h3>FreeBSD</h3>
-  <code>$ cd /usr/ports/devel/git</code><br><code>$ make install</code>
+  <code>$ pkg install git</code>
   
   <h3>Solaris 9/10/11 (<a href="https://www.opencsw.org">OpenCSW</a>)</h3>
   <code>$ pkgutil -i git</code>


### PR DESCRIPTION
Use binary packages instead of building from the ports tree.  For most
users this is more convenient, and users who would rather build using
the ports tree are most likely already familiar with the steps.
