### PR TITLE
Add missing "Free & Open Source" section

### DIFF
--- a/app/views/about/index.html.erb
+++ b/app/views/about/index.html.erb
@@ -28,6 +28,7 @@
   <%= render partial: "distributed" %>
   <%= render partial: "data_assurance" %>
   <%= render partial: "staging_area" %>
+  <%= render partial: "free_and_open_source" %>
   
 </div>
 


### PR DESCRIPTION
This was in the full set of content before it was split into individual files. It simply got omitted in the list of fragments to include.
