### PR TITLE
sfc: split donation types with headers

### DIFF
--- a/app/views/site/sfc.html.erb
+++ b/app/views/site/sfc.html.erb
@@ -30,7 +30,7 @@
     </form>
   </div>
 
-  <h3 class="title">Check or Wire</h3>
+  <h3 class="title">Check</h3>
   <p>We can also accept donations drawn in USD from banks in the USA
   (donations from banks outside of the US or not in USD should be handled
   by wire). Make checks payable to "Software Freedom Conservancy, Inc."
@@ -44,11 +44,13 @@
   </pre>
   </div>
 
+  <h3 class="title">Wire</h3>
   <p>Conservancy can accept wire donations, but the instructions vary
   depending on the country of origin. Please contact <a
     href="mailto:accounting@sfconservancy.org">accounting@sfconservancy.org</a>
   for instructions.
 
+  <h3 class="title">Stock</h3>
   <p>Conservancy also accepts stock donations on behalf of the Git
   project. If you would like to donate stock, please contact <a
     href="mailto:accounting@sfconservancy.org">accounting@sfconservancy.org</a>


### PR DESCRIPTION
Commit da3dfc0 (drop Google Checkout link from SFC donation
page, 2013-11-01) reformatted the list donation options into
a list. It probably should have split "Wire" into its
category. Later, a5866e6 (sfc: mention that we can take
stock donations, 2013-12-06) made this even worse as we
added a new type that should get its own heading.

This patch adds in separate headings for "Check", "Wire",
and "Stock".
