### PR TITLE
Update Git Cheat Sheet PDF to new resource

### DIFF
--- a/app/views/doc/index.html.haml
+++ b/app/views/doc/index.html.haml
@@ -16,7 +16,7 @@
 
   %p.quickref
     Quick reference guides:
-    =link_to "Heroku Cheat Sheet", "https://na1.salesforce.com/help/doc/en/salesforce_git_developer_cheatsheet.pdf"
+    =link_to "GitHub Cheat Sheet", "https://training.github.com/kit/downloads/github-git-cheat-sheet.pdf"
     %small.light (PDF) &nbsp;|&nbsp;
     =link_to "Visual Git Cheat Sheet", "http://ndpsoftware.com/git-cheatsheet.html"
     %small.light (SVG | PNG)
@@ -90,4 +90,3 @@
 
   %p
     The <a href="/documentation/external-links">External Links section</a> is a curated, ever-evolving collection of tutorials, books, videos, and other Git resources.
-


### PR DESCRIPTION
Per the [discussion](https://github.com/git/git-scm.com/issues/378) raised by @matthewmccullough, this new PDF cheat sheet serves as a Git-only focused document with the most frequently used commands in segments specific to actionable "chunks".
