### PR TITLE
Update Git Cheat Sheet PDF URL in Quick Reference links

### DIFF
--- a/app/views/doc/ref.html.erb
+++ b/app/views/doc/ref.html.erb
@@ -7,7 +7,7 @@
   <div class='callout quickref'>
     <p>
       Quick reference guides:
-      <a href=" https://na1.salesforce.com/help/doc/en/salesforce_git_developer_cheatsheet.pdf">Heroku Cheat Sheet</a>
+      <a href="https://training.github.com/kit/downloads/github-git-cheat-sheet.pdf">GitHub Cheat Sheet</a>
       <small class='light'>(PDF) &nbsp;|&nbsp;</small>
       <a href="http://ndpsoftware.com/git-cheatsheet.html">Visual Git Cheat Sheet</a>
       <small class='light'>(SVG | PNG)</small>


### PR DESCRIPTION
On the heels of https://github.com/git/git-scm.com/pull/389 which updated the _[Documentation](http://git-scm.com/doc)_ cheat sheet link, this PR includes the same PDF link on the _[Reference](http://git-scm.com/docs)_ page as well.
