### PR TITLE
Redirect download links away from Google Code

### DIFF
--- a/app/views/downloads/index.html.haml
+++ b/app/views/downloads/index.html.haml
@@ -19,7 +19,7 @@
             %td= link_to "Solaris", "/download/linux", {:class => 'icon solaris'}
 
       %p
-        <a href="http://code.google.com/p/git-core/downloads/list">Older releases</a> are available and the <a href="https://github.com/git/git">Git source repository</a> is on GitHub.
+        <a href="https://www.kernel.org/pub/software/scm/git/">Older releases</a> are available and the <a href="https://github.com/git/git">Git source repository</a> is on GitHub.
 
 
     %div.column-right

--- a/app/views/downloads/installers/index.html.haml
+++ b/app/views/downloads/installers/index.html.haml
@@ -26,7 +26,7 @@
             %td 
               %strong Windows
             %td 
-              =link_to "Stable", "http://code.google.com/p/msysgit/downloads/list"
+              =link_to "Stable", "https://github.com/msysgit/msysgit/releases"
               <span class="light">|</span>
               =link_to "Cygwin", "http://www.cygwin.com/setup.exe"
           %tr
@@ -43,7 +43,7 @@
               =link_to "v9-10", "http://opencsw.org/packages/git/"
 
       %p
-        <a href="http://code.google.com/p/git-core/downloads/list">Older releases</a> are available and the <a href="https://github.com/gitster/git">Git source repository</a> is on GitHub.
+        <a href="https://www.kernel.org/pub/software/scm/git/">Older releases</a> are available and the <a href="https://github.com/gitster/git">Git source repository</a> is on GitHub.
 
       %p
         Daily snapshots of the main Git development branch are available at <a href="http://codemonkey.org">codemonkey.org</a>.

--- a/app/views/shared/_monitor.html.erb
+++ b/app/views/shared/_monitor.html.erb
@@ -11,5 +11,5 @@
     <%= latest_release_date %>
   </span>
 
-  <%= link_to "Download Source Code", "http://code.google.com/p/git-core/downloads/list", {:class => 'button', :id => 'download-link'} %>
+  <%= link_to "Download Source Code", "https://www.kernel.org/pub/software/scm/git/", {:class => 'button', :id => 'download-link'} %>
 </div>

--- a/app/views/site/index.html.haml
+++ b/app/views/site/index.html.haml
@@ -40,7 +40,7 @@
     %table
       %tr
         %td{:nowrap => true}= link_to "Graphical UIs", "/downloads/guis", {:class => 'icon gui', :id => 'gui-link'}
-        %td{:nowrap => true}= link_to "Tarballs", "http://code.google.com/p/git-core/downloads/list", {:class => 'icon older-releases'}
+        %td{:nowrap => true}= link_to "Tarballs", "https://www.kernel.org/pub/software/scm/git/", {:class => 'icon older-releases'}
       %tr
         %td{:nowrap => true}= link_to "Windows Build", "/download/win", {:class => 'icon windows', :id => 'alt-link'}
         %td{:nowrap => true}= link_to "Source Code", "https://github.com/git/git", {:class => 'icon source'}


### PR DESCRIPTION
Google Code has shut off its download service. Git release tarballs are
now only on kernel.org and Git for Windows releases are on GitHub.

This fixes #384.
