### PR TITLE
about:free-and-open-source: do not paraphrase GPL

### DIFF
--- a/app/views/about/_free_and_open_source.html.erb
+++ b/app/views/about/_free_and_open_source.html.erb
@@ -1,26 +1,11 @@
   <section class="about" id="free-and-open-source" style="display: none;">
     <h2>Free and Open Source</h2>
-    <p>
-    Git is released under the <a href="https://github.com/git/git/blob/master/COPYING">GPLv2</a> <a href="http://www.opensource.org/docs/osd">open source license</a>.  This means that you are free to <a href="https://github.com/git/git">inspect the source code</a> at any time or <a href="https://github.com/git/git/blob/master/Documentation/SubmittingPatches">contribute</a> to the project yourself.
-    </p>
-    <p>
-    Under Git's GPLv2 software license, you <strong>may</strong>:
-    </p><ul class="bullets">
-      <li>Use Git on open or proprietary projects for free, forever</li>
-      <li>Download, inspect and modify the source code to Git</li>
-      <li>Make proprietary changes to Git that you do not redistribute publicly</li>
-      <li>Call Git binaries from your open or proprietary programs</li>
-      <li>Publicly redistribute Git binaries with open or proprietary programs, given that they are unmodified or the modifications are public</li>
-    </ul>
-    <p></p>
-    <p>
-    Under this license you <strong>may not</strong>:
-    </p><ul class="bullets">
-      <li>Make proprietary changes to Git and publicly redistribute it without sharing the changes</li>
-      <li>Make and publicly distribute changes to Git under a different license</li>
-      <li>Use source code from the Git repository in a project under a different license without permission</li>
-    </ul>
-    <p></p>
+    <p>Git is released under the <a href="http://opensource.org/licenses/GPL-2.0"
+	>GNU General Public License version 2.0</a>, which is an
+	<a href="http://www.opensource.org/docs/osd">open source license</a>.
+	The Git project chose to use GPLv2 to guarantee your freedom to
+	share and change free software---to make sure the software is
+	free for all its users.</p>
     <div class="bottom-nav" style="display: block;">
       <a href="#staging-area" class="previous" data-section-id="staging-area">← Staging Area</a>
     </div>


### PR DESCRIPTION
Trying to summarize or paraphrase the GPL in laymans' terms may have
meant well, but it will invite legal issues later.  A carelessly
written paragraph that appears on the official home page of the Git
project can create a loophole to avoid license compliance, when there
is a contradiction between the loosely written version and the license
text itself, the latter of which must be the authoritative and single
source of truth.

We (the Git committee) were advised by a Software Freedom Conservancy
lawer to state the reason why the project chose to use GPL, namely, to
make sure our software will stay free, instead.

Signed-off-by: Junio C Hamano gitster@pobox.com
