### PR TITLE
layouts: only use "site" layout for site#index

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -32,7 +32,7 @@
     <%= render partial: "shared/header" %>
   </div> <!-- .inner -->
 
-  <% if controller_name == "site" %>
+  <% if controller_name == "site" && action_name == "index" %>
     <%= render partial: "shared/masthead" %>
     <div id="content-wrapper">
       <div class="inner">


### PR DESCRIPTION
The `/sfc` page is rendered with the masthead and no navbar, just like the main page. This makes it hard to read, and hard to navigate away from. This is likely an unintended consequence of c575cbd.

Let's only use that layout for the index page. All of the other pages handled by the site controller (`/sfc`, `/courses/svn`, and the search results page) probably want to be treated more like "regular" pages.

Fixes #388.
