### PR TITLE
trademark policy: the Conservancy is the point of contact

### DIFF
--- a/app/views/site/trademark.html.erb
+++ b/app/views/site/trademark.html.erb
@@ -100,7 +100,7 @@ between you and the Git Project than actually exists.</p></li>
 "Git++" is not permitted).</p></li>
 <li><p>In any way that indicates that Git favors one distribution,
 platform, product, etc. over another except where explicitly
-indicated in writing by Git.</p></li>
+indicated in writing by Conservancy.</p></li>
 <li><p>In any other way that dilutes or otherwise infringes upon the
 trademark rights of Conservancy and the Git Project in the
 Marks.</p></li>
@@ -160,7 +160,7 @@ it to Conservancy's attention by contacting us at
 <p>If you have questions about using the Marks, or if you think you
 should be able to use the Marks for any purpose not allowed by
 this Policy and would like permission for that use, please contact
-Git by emailing
+Conservancy by emailing
 <a href="mailto:trademark@sfconservancy.org">TRADEMARK@SFCONSERVANCY.ORG</a>
 or by writing to Git Project c/o Software Freedom Conservancy, 137
 Montague St.  Ste 380, Brooklyn, NY 11201-3548.</p>


### PR DESCRIPTION
After another round of proof-reading with the lawyer at the
conservancy, it was decided that a few contact points in the text
should be "Conservancy", not "Git".
