### PR TITLE
preindex: don't hard-code a 'v1' prefix

### DIFF
--- a/lib/tasks/index.rake
+++ b/lib/tasks/index.rake
@@ -20,7 +20,7 @@ task :preindex => :environment do
   end
 
   # find all tags
-  tags = @octokit.tags( repo ).select { |tag| !tag.nil? && tag.name =~ /^v1[\d\.]+$/ }  # just get release tags
+  tags = @octokit.tags( repo ).select { |tag| !tag.nil? && tag.name =~ /v\d([\.\d])+$/ }  # just get release tags
 
   if rebuild
     tags = tags.select { |t| t.name == rebuild }


### PR DESCRIPTION
This task is using a different regex to the local one, and this one has
a hard-coded 'v1' prefix in it. This does not mix well with releasing
version 2.0 of git.

Copy the regex from local_index which removes the version number assumption.

This fixes #411.
