### PR TITLE
Correct example commit hash.

### DIFF
--- a/app/views/blog/posts/2011-07-11-reset.html
+++ b/app/views/blog/posts/2011-07-11-reset.html
@@ -206,8 +206,8 @@ way.  It does up to three basic operations.</p>
 The first thing <code>reset</code> will do is move what HEAD points to.  Unlike
 <code>checkout</code> it does not move what branch HEAD points to, it directly
 changes the SHA of the reference itself.  This means if HEAD is pointing to the
-'master' branch, running <code>git reset 9e5e64a</code> will first of all make
-'master' point to <code>9e5e64a</code> before it does anything else.
+'master' branch, running <code>git reset 9e5e6a4</code> will first of all make
+'master' point to <code>9e5e6a4</code> before it does anything else.
 </p>
 
 <center><img width="500px" src="/images/reset/reset-soft.png"/></center><br/>


### PR DESCRIPTION
Change example commit hash in lines 209 and 210 to match hash in image.
