### PR TITLE
add "Git Beginner's Guide for Dummies" to external-links page

### DIFF
--- a/app/views/doc/ext.html.erb
+++ b/app/views/doc/ext.html.erb
@@ -33,6 +33,12 @@
             A guided tour that walks through the fundamentals of Git.
           </p>
         </li>
+        <li>
+          <h4><a href="http://backlogtool.com/git-guide/en/">Git Beginner's Guide for Dummies</a></h4>
+          <p class='description'>
+            This guide includes an introduction for complete beginners as well as hands-on tutorials for intermediate learners.
+          </p>
+        </li>
       </ul>
     </div>
     <div class='column-right'>


### PR DESCRIPTION
Hi,

We are writing and maintaining a Git tutorial for beginners called the Git Beginner's Guide for Dummies.

In this pull request, I would like to add our guide to the "Short & Sweet" section on the ["external-links"](http://git-scm.com/documentation/external-links) page.

This guide was originally developed in Japanese and proved to be hugely popular not just with developers but also designers and front-end engineers who seem to have a growing interest in Git recently. If you search "Git" on Google Japan, you will be able to find our guide at the top of the search results. The guide is also currently third place on Bing search (see attached images).

![git_guide_google_search](https://cloud.githubusercontent.com/assets/76630/3793742/d95294b2-1b9f-11e4-8ff2-e4abdab54407.png)
![git_guide_bing_search](https://cloud.githubusercontent.com/assets/76630/3793743/d9533214-1b9f-11e4-87fe-eb3eb79854de.png)

With the success of the guide, we have decided to translate it to other languages to benefit other users. Currently, we have four translations of this guide:
- http://backlogtool.com/git-guide/en/ ( English )
- http://backlogtool.com/git-guide/kr/ ( Korean )
- http://backlogtool.com/git-guide/cn/ ( Simplified Chinese )
- http://www.backlog.jp/git-guide/ ( Japanese )

At the moment, we are also working on translating the guide into Traditional Chinese and Vietnamese and will be publishing them in the near future.

We believe that this guide will help many Git beginners to understand Git and encourage them to start using Git. We think it will make a great resource if it's added on git-scm.com.

If you require more information or materials please don't hesitate to let me know. Thanks!
