### PR TITLE
Correct a link on index.html.erb

### DIFF
--- a/app/views/site/index.html.erb
+++ b/app/views/site/index.html.erb
@@ -76,7 +76,6 @@
     <li><%= link_to "Gnome", "http://git.gnome.org/browse/", class: 'gnome' %></li>
     <li><%= link_to "Eclipse", "http://git.eclipse.org/c/", class: 'eclipse' %></li>
     <li><%= link_to "KDE", "http://quickgit.kde.org/", class: 'kde' %></li>
-    <li><%= link_to "X", "http://www.x.org/wiki/Development/BuildingX?action=show&redirect=Development%2Fgit", class: 'x' %></li>
+    <li><%= link_to "X", "http://www.x.org/wiki/Development/BuildingX/?action=show&redirect=Development%2Fgit", class: 'x' %></li>
 </ul>
 </section>
-


### PR DESCRIPTION
I found :mag: a **REDIRECT link** :link: on _index.html.erb_ so I changed that to the current link adress.

Yours,
[**Suriyaa Kudo**](https://github.com/SuriyaaKudoIsc) :octocat:
