### PR TITLE
doc/ext: add link to Git Version Control Cookbook

### DIFF
--- a/app/views/doc/ext.html.erb
+++ b/app/views/doc/ext.html.erb
@@ -142,7 +142,14 @@
           <p class='description'>
             By Ravishankar Somasundaram
           </p>
-        </li>
+	  </li>
+	  <li>
+	  <a href="https://www.packtpub.com/application-development/git-version-control-cookbook"><img src="https://dgdsbygo8mp3h.cloudfront.net/sites/default/files/imagecache/ppv4_main_book_cover/8454OS_cov.jpg" width="107"></a>
+	  <h4><a href="https://www.packtpub.com/application-development/git-version-control-cookbook">Git Version Control Cookbook</a></h4>
+	  <p class='description'>
+	    By Aske Olsson and Rasmus Voss
+	  </p>
+	  </li>
       </ul>
     </div>
   </div>


### PR DESCRIPTION
This is newly published. I haven't read it, but our general
strategy seems to be to link to as many books as possible
from the external links page.
