### PR TITLE
Make where to report bugs more clear

### DIFF
--- a/app/views/community/index.html.erb
+++ b/app/views/community/index.html.erb
@@ -7,12 +7,12 @@
 <% end %>
 
 <div id="main">
-  <h1> Community</h2>
+  <h1> Community </h2>
 
-  <h2> Mailing List</h2>
+  <h2> Mailing List </h2>
 
   <p>
-    Questions or comments for the Git community can be sent to the mailing list by using the email address <a href="mailto:git@vger.kernel.org">git@vger.kernel.org</a>. <strong>Bug reports should be sent to this mailing list.</strong>
+    Questions or comments for the Git community can be sent to the mailing list by using the email address <a href="mailto:git@vger.kernel.org">git@vger.kernel.org</a>.
   </p>
 
   <p>
@@ -26,6 +26,10 @@
   <p>
     There is also <a href="https://groups.google.com/forum/?fromgroups#!forum/git-users">Git user mailing list</a> on Google Groups which is a nice place for beginners to ask about anything.
   <p>
+  
+  <h2> Reporting Bugs </h2>
+  
+  Bug reports should be sent to the mailing list <a href="mailto:git@vger.kernel.org">git@vger.kernel.org</a>.
 
   <h2> IRC Channel </h2>
 


### PR DESCRIPTION
If one is looking for where to report bugs, it is easy to dismiss a section with a heading "mailing list".