### PR TITLE
Pro Git: adjust padding in code samples

### DIFF
--- a/app/assets/stylesheets/book2.css.scss
+++ b/app/assets/stylesheets/book2.css.scss
@@ -487,7 +487,7 @@
 
   code { /* inline code */
     border: 1px solid #f5f5f5;
-    padding: 3px;
+    padding: 0px;
     background: #eee;
     color: #333;
   }


### PR DESCRIPTION
Reported in progit/progit2#175. This adjusts the code-sample padding in [C code](http://git-scm.com/book/en/v2/Embedding-Git-in-your-Applications-Libgit2) from this:

![code_padding](https://cloud.githubusercontent.com/assets/175128/5043861/6d672a1a-6bea-11e4-8095-444c1848f557.png)

To this:
![code_padding_0](https://cloud.githubusercontent.com/assets/175128/5043882/c4494ab6-6bea-11e4-8b67-b2a0214efd10.png)

For [shell code](http://git-scm.com/book/en/v2/Git-Internals-Git-Objects), it changes from this:

![image](https://cloud.githubusercontent.com/assets/39902/5050484/59f5d35c-6be3-11e4-9d6a-91d56a7af915.png)

To this:

![image](https://cloud.githubusercontent.com/assets/39902/5050493/6bc265fa-6be3-11e4-8346-2d1361da7a72.png)
