### PR TITLE
External Links: add Git In Practice.

### DIFF
--- a/app/views/doc/ext.html.erb
+++ b/app/views/doc/ext.html.erb
@@ -119,6 +119,13 @@
             <img class="creative-commons" src="/images/creative-commons@2x.png" width="115" height="28" />
           </p>
         </li>
+        <li>
+          <a href="http://www.manning.com/mcquaid/?a_aid=MikeMcQuaid&a_bid=5688bbf4"><img src="http://www.manning.com/mcquaid/mcquaid_cover150.jpg" width="107"></a>
+          <h4><a href="http://www.manning.com/mcquaid/?a_aid=MikeMcQuaid&a_bid=5688bbf4">Git in Practice</a></h4>
+          <p class='description'>
+            By Mike McQuaid
+          </p>
+        </li>
       </ul>
     </div>
     <div class='column-right'>


### PR DESCRIPTION
Published by Manning in 2014. Feels a bit grubby submitting my own book but @schacon wrote the foreword so I guess it's fair game :wink:.
