### PR TITLE
Added git-bundle to the doc categories

### DIFF
--- a/config/initializers/categories.rb
+++ b/config/initializers/categories.rb
@@ -20,7 +20,7 @@ module Gitscm
     ],['External Systems',
       ['git-svn', 'git-fast-import']
     ],['Administration',
-      ['git-clean', 'git-gc', 'git-fsck', 'git-reflog', 'git-filter-branch', 'git-instaweb', 'git-archive']
+      ['git-clean', 'git-gc', 'git-fsck', 'git-reflog', 'git-filter-branch', 'git-instaweb', 'git-archive', 'git-bundle']
     ],['Server Admin',
       ['git-daemon', 'git-update-server-info']
     ],['Plumbing Commands',


### PR DESCRIPTION
git-bundle was not listed at http://git-scm.com/docs/, so I added git-bundle to the "administration tools" (just as git-archive)
