### PR TITLE
https change for use.typekit.com and chart.apis.google.com

### DIFF
--- a/app/helpers/site_helper.rb
+++ b/app/helpers/site_helper.rb
@@ -43,7 +43,7 @@ module SiteHelper
     l = labels.join('|')
 
     scale = vals.max
-    c = "<img src=\"http://chart.apis.google.com/chart?"
+    c = "<img src=\"https://chart.googleapis.com/chart?"
     c += "chxt=x" + "&amp;"
     c += "cht=bvs" + "&amp;"
     c += "chl=#{l}" + "&amp;"

--- a/app/views/about/_small_and_fast.html.erb
+++ b/app/views/about/_small_and_fast.html.erb
@@ -22,42 +22,42 @@
       <tbody>
         <tr>
           <td>
-            <img src="http://chart.apis.google.com/chart?chxt=x&amp;cht=bvs&amp;chl=git|svn&amp;chd=t:0.649,2.6&amp;chds=0,2.6&amp;chs=100x125&amp;chco=E09FA0|E05F49&amp;chf=bg,s,fcfcfa&amp;chtt=Commit A" alt="init benchmarks">
+            <img src="https://chart.googleapis.com/chart?chxt=x&amp;cht=bvs&amp;chl=git|svn&amp;chd=t:0.649,2.6&amp;chds=0,2.6&amp;chs=100x125&amp;chco=E09FA0|E05F49&amp;chf=bg,s,fcfcfa&amp;chtt=Commit A" alt="init benchmarks">
           </td>
           <td>
-            <img src="http://chart.apis.google.com/chart?chxt=x&amp;cht=bvs&amp;chl=git|svn&amp;chd=t:1.53,24.7&amp;chds=0,24.7&amp;chs=100x125&amp;chco=E09FA0|E05F49&amp;chf=bg,s,fcfcfa&amp;chtt=Commit B" alt="init benchmarks">
+            <img src="https://chart.googleapis.com/chart?chxt=x&amp;cht=bvs&amp;chl=git|svn&amp;chd=t:1.53,24.7&amp;chds=0,24.7&amp;chs=100x125&amp;chco=E09FA0|E05F49&amp;chf=bg,s,fcfcfa&amp;chtt=Commit B" alt="init benchmarks">
           </td>
           <td>
-            <img src="http://chart.apis.google.com/chart?chxt=x&amp;cht=bvs&amp;chl=git|svn&amp;chd=t:0.257,1.09&amp;chds=0,1.09&amp;chs=100x125&amp;chco=E09FA0|E05F49&amp;chf=bg,s,fcfcfa&amp;chtt=Diff Curr" alt="init benchmarks">
+            <img src="https://chart.googleapis.com/chart?chxt=x&amp;cht=bvs&amp;chl=git|svn&amp;chd=t:0.257,1.09&amp;chds=0,1.09&amp;chs=100x125&amp;chco=E09FA0|E05F49&amp;chf=bg,s,fcfcfa&amp;chtt=Diff Curr" alt="init benchmarks">
           </td>
           <td>
-            <img src="http://chart.apis.google.com/chart?chxt=x&amp;cht=bvs&amp;chl=git|svn&amp;chd=t:0.248,3.99&amp;chds=0,3.99&amp;chs=100x125&amp;chco=E09FA0|E05F49&amp;chf=bg,s,fcfcfa&amp;chtt=Diff Rec" alt="init benchmarks">
+            <img src="https://chart.googleapis.com/chart?chxt=x&amp;cht=bvs&amp;chl=git|svn&amp;chd=t:0.248,3.99&amp;chds=0,3.99&amp;chs=100x125&amp;chco=E09FA0|E05F49&amp;chf=bg,s,fcfcfa&amp;chtt=Diff Rec" alt="init benchmarks">
           </td>
           <td>
-            <img src="http://chart.apis.google.com/chart?chxt=x&amp;cht=bvs&amp;chl=git|svn&amp;chd=t:1.17,83.57&amp;chds=0,83.57&amp;chs=100x125&amp;chco=E09FA0|E05F49&amp;chf=bg,s,fcfcfa&amp;chtt=Diff Tags" alt="init benchmarks">
+            <img src="https://chart.googleapis.com/chart?chxt=x&amp;cht=bvs&amp;chl=git|svn&amp;chd=t:1.17,83.57&amp;chds=0,83.57&amp;chs=100x125&amp;chco=E09FA0|E05F49&amp;chf=bg,s,fcfcfa&amp;chtt=Diff Tags" alt="init benchmarks">
           </td>
           <td>
-            <img src="http://chart.apis.google.com/chart?chxt=x&amp;cht=bvs&amp;chl=git*|git|svn&amp;chd=t:21.0,107.5,14.0&amp;chds=0,107.5&amp;chs=100x125&amp;chco=E09FA0|E09FA0|E05F49&amp;chf=bg,s,fcfcfa&amp;chtt=Clone" alt="init benchmarks">
+            <img src="https://chart.googleapis.com/chart?chxt=x&amp;cht=bvs&amp;chl=git*|git|svn&amp;chd=t:21.0,107.5,14.0&amp;chds=0,107.5&amp;chs=100x125&amp;chco=E09FA0|E09FA0|E05F49&amp;chf=bg,s,fcfcfa&amp;chtt=Clone" alt="init benchmarks">
           </td>
         </tr>
         <tr>
           <td>
-            <img src="http://chart.apis.google.com/chart?chxt=x&amp;cht=bvs&amp;chl=git|svn&amp;chd=t:0.012,0.381&amp;chds=0,0.381&amp;chs=100x125&amp;chco=E09FA0|E05F49&amp;chf=bg,s,fcfcfa&amp;chtt=Log (50)" alt="init benchmarks">
+            <img src="https://chart.googleapis.com/chart?chxt=x&amp;cht=bvs&amp;chl=git|svn&amp;chd=t:0.012,0.381&amp;chds=0,0.381&amp;chs=100x125&amp;chco=E09FA0|E05F49&amp;chf=bg,s,fcfcfa&amp;chtt=Log (50)" alt="init benchmarks">
           </td>
           <td>
-            <img src="http://chart.apis.google.com/chart?chxt=x&amp;cht=bvs&amp;chl=git|svn&amp;chd=t:0.519,169.197&amp;chds=0,169.197&amp;chs=100x125&amp;chco=E09FA0|E05F49&amp;chf=bg,s,fcfcfa&amp;chtt=Log (All)" alt="init benchmarks">
+            <img src="https://chart.googleapis.com/chart?chxt=x&amp;cht=bvs&amp;chl=git|svn&amp;chd=t:0.519,169.197&amp;chds=0,169.197&amp;chs=100x125&amp;chco=E09FA0|E05F49&amp;chf=bg,s,fcfcfa&amp;chtt=Log (All)" alt="init benchmarks">
           </td>
           <td>
-            <img src="http://chart.apis.google.com/chart?chxt=x&amp;cht=bvs&amp;chl=git|svn&amp;chd=t:0.601,82.843&amp;chds=0,82.843&amp;chs=100x125&amp;chco=E09FA0|E05F49&amp;chf=bg,s,fcfcfa&amp;chtt=Log (File)" alt="init benchmarks">
+            <img src="https://chart.googleapis.com/chart?chxt=x&amp;cht=bvs&amp;chl=git|svn&amp;chd=t:0.601,82.843&amp;chds=0,82.843&amp;chs=100x125&amp;chco=E09FA0|E05F49&amp;chf=bg,s,fcfcfa&amp;chtt=Log (File)" alt="init benchmarks">
           </td>
           <td>
-            <img src="http://chart.apis.google.com/chart?chxt=x&amp;cht=bvs&amp;chl=git|svn&amp;chd=t:0.896,2.816&amp;chds=0,2.816&amp;chs=100x125&amp;chco=E09FA0|E05F49&amp;chf=bg,s,fcfcfa&amp;chtt=Update" alt="init benchmarks">
+            <img src="https://chart.googleapis.com/chart?chxt=x&amp;cht=bvs&amp;chl=git|svn&amp;chd=t:0.896,2.816&amp;chds=0,2.816&amp;chs=100x125&amp;chco=E09FA0|E05F49&amp;chf=bg,s,fcfcfa&amp;chtt=Update" alt="init benchmarks">
           </td>
           <td>
-            <img src="http://chart.apis.google.com/chart?chxt=x&amp;cht=bvs&amp;chl=git|svn&amp;chd=t:1.91,3.04&amp;chds=0,3.04&amp;chs=100x125&amp;chco=E09FA0|E05F49&amp;chf=bg,s,fcfcfa&amp;chtt=Blame" alt="init benchmarks">
+            <img src="https://chart.googleapis.com/chart?chxt=x&amp;cht=bvs&amp;chl=git|svn&amp;chd=t:1.91,3.04&amp;chds=0,3.04&amp;chs=100x125&amp;chco=E09FA0|E05F49&amp;chf=bg,s,fcfcfa&amp;chtt=Blame" alt="init benchmarks">
           </td>
           <td>
-            <img src="http://chart.apis.google.com/chart?chxt=x&amp;cht=bvs&amp;chl=git|svn&amp;chd=t:181,132&amp;chds=0,181&amp;chs=100x125&amp;chco=E09FA0|E05F49&amp;chf=bg,s,fcfcfa&amp;chtt=Size" alt="init benchmarks">
+            <img src="https://chart.googleapis.com/chart?chxt=x&amp;cht=bvs&amp;chl=git|svn&amp;chd=t:181,132&amp;chds=0,181&amp;chs=100x125&amp;chco=E09FA0|E05F49&amp;chf=bg,s,fcfcfa&amp;chtt=Size" alt="init benchmarks">
           </td>
         </tr>
       </tbody>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,7 +17,7 @@
   <%= javascript_include_tag "/javascripts/selectivizr-min.js" %>
   <![endif]-->
 
-  <script src="http://use.typekit.com/jsq2fql.js" type="text/javascript"></script>
+  <script src="https://use.typekit.com/jsq2fql.js" type="text/javascript"></script>
   <script>
     //<![CDATA[
       try{Typekit.load();}catch(e){}

--- a/public/404.html
+++ b/public/404.html
@@ -8,7 +8,7 @@
     <!--[if (gte IE 6)&(lte IE 8)]>
       <script src="/assets/selectivizr-min.js?body=1" type="text/javascript"></script>
     <![endif]-->
-    <script src="http://use.typekit.com/jsq2fql.js" type="text/javascript"></script>
+    <script src="https://use.typekit.com/jsq2fql.js" type="text/javascript"></script>
     <script>
       //<![CDATA[
         try{Typekit.load();}catch(e){}

--- a/public/500.html
+++ b/public/500.html
@@ -8,7 +8,7 @@
     <!--[if (gte IE 6)&(lte IE 8)]>
       <script src="/assets/selectivizr-min.js?body=1" type="text/javascript"></script>
     <![endif]-->
-    <script src="http://use.typekit.com/jsq2fql.js" type="text/javascript"></script>
+    <script src="https://use.typekit.com/jsq2fql.js" type="text/javascript"></script>
     <script>
       //<![CDATA[
         try{Typekit.load();}catch(e){}

--- a/test/unit/helpers/site_helper_test.rb
+++ b/test/unit/helpers/site_helper_test.rb
@@ -20,7 +20,7 @@ class SiteHelperTest < ActionView::TestCase
 
   test "should create gchart" do
     src = gchart("git", [[0,1],[0,1]])
-    assert_equal "<img src=\"http://chart.apis.google.com/chart?chxt=x&amp;cht=bvs&amp;chl=0|0&amp;chd=t:1,1&amp;chds=0,1&amp;chs=100x125&amp;chco=E09FA0|E05F49&amp;chf=bg,s,fcfcfa&chtt=git\" alt=\"init benchmarks\" />", src
+    assert_equal "<img src=\"https://chart.googleapis.com/chart?chxt=x&amp;cht=bvs&amp;chl=0|0&amp;chd=t:1,1&amp;chds=0,1&amp;chs=100x125&amp;chco=E09FA0|E05F49&amp;chf=bg,s,fcfcfa&chtt=git\" alt=\"init benchmarks\" />", src
   end
   
 end


### PR DESCRIPTION
Using the SSL/TLS secured site https://git-scm.herokuapp.com/ browsers like firefox complains about unsecure http content.  This can be fixed by changing
http://use.typekit.com/ to
https://use.typekit.com/ and
http://chart.apis.google.com/ to
https://chart.googleapis.com/