### PR TITLE
Add git-bundle to the docs/ page

### DIFF
--- a/app/views/doc/rebase.html.haml
+++ b/app/views/doc/rebase.html.haml
@@ -93,6 +93,7 @@
           %li= link_to "filter-branch"
           %li= link_to "instaweb"
           %li= link_to "archive"
+          %li= link_to "bundle"
 
         %h3 Server Admin
         %ul.unstyled

--- a/app/views/shared/ref/_admin.html.erb
+++ b/app/views/shared/ref/_admin.html.erb
@@ -7,4 +7,5 @@
   <li><%= man('git-filter-branch') %></li>
   <li><%= man('git-instaweb') %></li>
   <li><%= man('git-archive') %></li>
+  <li><%= man('git-bundle') %></li>
 </ul>


### PR DESCRIPTION
Although I submitted a patch in commit a5f5ab6,
I realised git-bundle would still not appear at the docs/ page.

Some investigation taught me that I would have had to add it
in other files, too. (Fixed this)