### PR TITLE
community: switch #gitorious to #gitlab

### DIFF
--- a/app/views/community/index.html.erb
+++ b/app/views/community/index.html.erb
@@ -48,7 +48,7 @@
   </p>
 
   <p>
-    If you need specific help about one of the for-profit Git hosting sites, you might try their own IRC channels (such as <span class="highlight fixed">#github</span> or <span class="highlight fixed">#gitorious</span>) on the same IRC server.
+    If you need specific help about one of the for-profit Git hosting sites, you might try their own IRC channels (such as <span class="highlight fixed">#github</span> or <span class="highlight fixed">#gitlab</span>) on the same IRC server.
   </p>
 
   <h2> Contributing to Git </h2>


### PR DESCRIPTION
As GitLab has acquired Gitorious [1], the former's IRC channel will probably be more popular.

[1] https://about.gitlab.com/2015/03/03/gitlab-acquires-gitorious/