### PR TITLE
downloads: support 32bit/64bit windows links

### DIFF
--- a/app/controllers/downloads_controller.rb
+++ b/app/controllers/downloads_controller.rb
@@ -25,19 +25,33 @@ class DownloadsController < ApplicationController
   def download
     @platform = params[:platform]
     @platform = 'windows' if @platform == 'win'
-    if @platform == 'windows' || @platform == 'mac'
-      if @platform == 'windows'
-        @project_url  = "https://msysgit.github.io/"
-        @source_url   = "https://github.com/msysgit/git/"
-      else
-        @project_url = "http://sourceforge.net/projects/git-osx-installer/"
-        @source_url   = "https://github.com/git/git/"
-      end
+    if @platform == 'mac'
+      @project_url = "http://sourceforge.net/projects/git-osx-installer/"
+      @source_url   = "https://github.com/git/git/"
 
       @download = Download.latest_for(@platform)
       @latest = Version.latest_version
 
       render "downloads/downloading"
+    elsif @platform == 'windows'
+      @project_url = "https://git-for-windows.github.io/"
+      @source_url = "https://github.com/git-for-windows/git"
+
+      @download32 = Download.latest_for(@platform + "32")
+      @download64 = Download.latest_for(@platform + "64")
+      @download32portable = Download.latest_for(@platform + "32Portable")
+      @download64portable = Download.latest_for(@platform + "64Portable")
+      @latest = Version.latest_version
+
+      if request.env["HTTP_USER_AGENT"] =~ /WOW64|Win64/
+        @download = @download64
+        @bitness = "64-bit"
+      else
+        @download = @download32
+        @bitness = "32-bit"
+      end
+
+      render "downloads/download_windows"
     elsif @platform == 'linux'
       render "downloads/download_linux"
     else

--- a/app/views/downloads/download_windows.html.haml
+++ b/app/views/downloads/download_windows.html.haml
@@ -1,0 +1,60 @@
+- @section = "downloads"
+- @subsection = ""
+- @page_title = "Git - Downloading Package"
+
+- content_for :sidebar do
+  = render 'shared/book'
+
+%div#main
+  %h1 Downloading Git
+
+  %div.callout.downloading
+    %h3 Your download is starting...
+
+    %p=raw "You are downloading the latest (<strong>#{@download.version.name}</strong>) <strong>#{@bitness}</strong> version of <strong>Git for Windows</strong>. This is the most recent <a href='#{@project_url}'>maintained build</a>. It was released <strong>#{time_ago_in_words @download.release_date} ago</strong>, on #{@download.release_date.strftime("%Y-%m-%d")}."
+
+    %p=raw "<strong>If your download hasn't started, <a href=\"#{@download.url}\">click here to download manually</a>.</strong>"
+
+    %h3 Other Git for Windows downloads
+
+    %h4 Git for Windows Setup
+
+    %p=raw "<strong><a href=\"#{@download32.url}\">32-bit Git for Windows Setup</a>.</strong>"
+
+    %p=raw "<strong><a href=\"#{@download64.url}\">64-bit Git for Windows Setup</a>.</strong>"
+
+    %h4 Git for Windows Portable ("thumbdrive edition")
+
+    %p=raw "<strong><a href=\"#{@download32portable.url}\">32-bit Git for Windows Portable</a>.</strong>"
+
+    %p=raw "<strong><a href=\"#{@download64portable.url}\">64-bit Git for Windows Portable</a>.</strong>"
+
+    %p.small=raw "The current source code release is version <strong>#{@latest.name}</strong>. If you want the newer version, you can build it from <a href=\"#{@source_url}\">the source code</a>."
+
+    %iframe{:width => 1, :height => 1, :frameborder => 0, :src => @download.url}
+
+  %h2 Now What?
+
+  %p
+    Now that you have downloaded Git, it's time to start using it.
+
+  %ul#download-next-steps
+    %li
+      <a href="/book">
+      <img src="/images/icons/nav-read-book.png" />
+      <h3>Read the Book</h3>
+      <p>Dive into the Pro Git book and learn at your own pace.</p>
+      </a>
+    %li
+      <a href="/downloads/guis">
+      <img src="/images/icons/nav-download-gui.png" />
+      <h3>Download a GUI</h3>
+      <p>Several free and commercial GUI tools are available for the #{@platform.capitalize} platform.</p>
+      </a>
+    %li
+      <a href="/community">
+      <img src="/images/icons/nav-get-involved.png" />
+      <h3>Get Involved</h3>
+      <p>A knowledgeable Git community is available to answer your questions.</p>
+      </a>
+

--- a/lib/tasks/downloads.rake
+++ b/lib/tasks/downloads.rake
@@ -41,19 +41,25 @@ task :downloads => [:environment, :windows_downloads, :mac_downloads]
 
 task :windows_downloads => :environment do
   # find latest windows version
-  project = "msysgit"
-  win_downloads = file_downloads_from_github("msysgit/msysgit")
+  project = "git-for-windows"
+  win_downloads = file_downloads_from_github("git-for-windows/git")
   win_downloads.each do |url, date|
     name = url.split('/').last
-    if m = /^Git-(.*?)-(.*?)(\d{4})(\d{2})(\d{2})\.exe/.match(name)
-      version = m[1]
+    # Git for Windows uses the following naming system
+    # [Portable]Git-#.#.#.#[-dev-preview]-32/64-bit[.7z].exe
+    if m = /^(Portable|)Git-(\d+\.\d+\.\d+\.\d+)-(?:.+-)*(32|64)-bit(?:\..*)?\.exe/.match(name)
+      portable = m[1]
+      version = m[2]
+      bitness = m[3]
+      puts portable
       puts version
+      puts bitness
       puts name
       puts url
       puts date
       puts
-      if v = Version.where(name: version).first
-        options = {version: v, url: url, filename: name, platform: 'windows', release_date: date}
+      if v = Version.where(name: version.slice(/^\d+\.\d+\.\d+/)).first
+        options = {version: v, url: url, filename: name, platform: 'windows' + bitness + portable, release_date: date}
         unless Download.exists?(options)
           d = Download.new(options)
           begin


### PR DESCRIPTION
With the switch to the *MSYS2* backend for the *Git for Windows* project
the opportunity arose to support both `32bit` and `64bit` builds. In
additon to those `32bit` and `64bit` builds *Git for Windows* now ships
with portable releases as well. So it makes sense to display all those
links on the download page. Since this behavior differs from the `mac`
platform would be best to introduce a new download page for the `windows`
platform.

The naming convention for *Git for Windows* builds changed too, so the
`rake downloads` task had to be adapted. It now parses the *Git for
Windows* release file properly and also extracts the `bitness` and the
portable information of the release file. That `bitness` and the portable
information is then appended to the platform when storing the release
information in the database.

To provide an automatic download for the latest *Git for Windows* release
in the correct `bitness` parsing of the user agent in the download
controller was added. The view was updated to show the current download
and then list the other options as well.