### PR TITLE
require a recent version of asciidoctor

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source 'https://rubygems.org'
 gem 'rails', '4.2'
 gem 'rails_12factor', group: :production
 
-gem 'asciidoctor'
+gem 'asciidoctor', '>=1.5.0'
 gem 'dalli'
 gem 'exceptional'
 gem 'faraday'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,7 +39,7 @@ GEM
     addressable (2.3.6)
     ansi (1.4.3)
     arel (6.0.0)
-    asciidoctor (0.1.4)
+    asciidoctor (1.5.2)
     awesome_print (1.2.0)
     better_errors (1.1.0)
       coderay (>= 1.0.0)
@@ -254,7 +254,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  asciidoctor
+  asciidoctor (>= 1.5.0)
   awesome_print
   better_errors
   binding_of_caller


### PR DESCRIPTION
Version 0.1.4 of AsciiDoctor is quite old, and has some errors rendering git's manpages. One of the most noticeable is that `[verse]` sections are treated as literals in the older version, leading every manpage to start off with the misleading `'git add'` (in single quotes, rather than rendered in italics).

I think we would also need to re-index the manpages once this version-bump is merged (at least I needed to do so locally).

/cc @bk2204