### PR TITLE
Update project & source URL from MSysGit to Git for Windows.

### DIFF
--- a/app/controllers/downloads_controller.rb
+++ b/app/controllers/downloads_controller.rb
@@ -27,8 +27,8 @@ class DownloadsController < ApplicationController
     @platform = 'windows' if @platform == 'win'
     if @platform == 'windows' || @platform == 'mac'
       if @platform == 'windows'
-        @project_url  = "https://msysgit.github.io/"
-        @source_url   = "https://github.com/msysgit/git/"
+        @project_url  = "https://git-for-windows.github.io/"
+        @source_url   = "https://github.com/git-for-windows/git"
       else
         @project_url = "http://sourceforge.net/projects/git-osx-installer/"
         @source_url   = "https://github.com/git/git/"


### PR DESCRIPTION
Since the upcoming Git for Windows versions will be maintained under the `git-for-windows` instead of the `msysgit` account, this commit updates the corresponding variables for the Git for Windows project site (`project_url`) as well as for the source link (`source_url`).