### PR TITLE
Update link to Qt's Git repos

### DIFF
--- a/app/views/site/index.html.erb
+++ b/app/views/site/index.html.erb
@@ -72,7 +72,7 @@
     <li><%= link_to "Android", "https://android-review.googlesource.com/#/q/status:open,n,z", class: 'android' %></li>
     <li><%= link_to "Linux", "http://git.kernel.org/?p=linux/kernel/git/torvalds/linux-2.6.git;a=summary", class: 'linux' %></li>
     <li><%= link_to "Ruby on Rails", "https://github.com/rails/rails", class: 'rails' %></li>
-    <li><%= link_to "Qt", "http://qt.gitorious.org/", class: 'qt' %></li>
+    <li><%= link_to "Qt", "http://code.qt.io/cgit/", class: 'qt' %></li>
     <li><%= link_to "Gnome", "http://git.gnome.org/browse/", class: 'gnome' %></li>
     <li><%= link_to "Eclipse", "http://git.eclipse.org/c/", class: 'eclipse' %></li>
     <li><%= link_to "KDE", "http://quickgit.kde.org/", class: 'kde' %></li>


### PR DESCRIPTION
Gitorious has been shut down, so this is the new canonical place to find their code:

http://code.qt.io/cgit/