### PR TITLE
community: clarify where website/pro-git bug reports go

### DIFF
--- a/app/views/community/index.html.erb
+++ b/app/views/community/index.html.erb
@@ -12,7 +12,7 @@
   <h2> Mailing List</h2>
 
   <p>
-    Questions or comments for the Git community can be sent to the mailing list by using the email address <a href="mailto:git@vger.kernel.org">git@vger.kernel.org</a>. <strong>Bug reports should be sent to this mailing list.</strong>
+    Questions or comments for the Git community can be sent to the mailing list by using the email address <a href="mailto:git@vger.kernel.org">git@vger.kernel.org</a>. <strong>Bug reports for git should be sent to this mailing list.</strong>
   </p>
 
   <p>
@@ -30,9 +30,16 @@
   <h2> Bug Reporting </h2>
 
   <p>
-    Bugs can be reported directly to the mailing list (see above for
+    Bugs in git can be reported directly to the mailing list (see above for
     details). Note that you do not need to subscribe to the list to send
     to it.
+  </p>
+
+  <p>
+    Bugs related to this website can be reported at its
+    <a href="https://github.com/git/git-scm.com/issues">issue tracker</a>.
+    Bugs related to the content of the "Pro Git" book can be reported at its
+    <a href="https://github.com/progit/progit2">issue tracker</a>.
   </p>
 
   <p>


### PR DESCRIPTION
We do link to the git-scm.com repo in the footer, and to the Pro Git repo from "book" pages. But somebody searching for "how to report bugs" may come across the community advice instead, which is not at all clear that those projects are maintained separately.
