### PR TITLE
`yum` vs `dnf` for Fedora, Fixes #594.

### DIFF
--- a/app/views/downloads/download_linux.html.erb
+++ b/app/views/downloads/download_linux.html.erb
@@ -9,7 +9,8 @@
   <code>$ apt-get install git</code>
 
   <h3>Fedora</h3>
-  <code>$ yum install git</code>
+  <code>$ yum install git</code> (up to Fedora 21)<br>
+  <code>$ dnf install git</code> (Fedora 22 and later)
 
   <h3>Gentoo</h3>
   <code>$ emerge --ask --verbose dev-vcs/git</code>


### PR DESCRIPTION
Added `dnf` command for newer versions of Fedora.