### PR TITLE
link to SFC "supporter" page in header

### DIFF
--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -30,6 +30,12 @@ aside {
 }
 
 
+#banner {
+  background-color: #f0ffb8;
+  padding: 0.5em;
+  font-size: 120%;
+}
+
 #content {
   width: 702px;
   float: right;

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -8,4 +8,11 @@
     <input id="search-text" name="search" placeholder="Search entire site..." autocomplete="off" type="text" />
   </form>
   <div id="search-results"></div>
+
+  <div id="banner">
+    Git is a member project of Software Freedom Conservancy, which
+    handles legal and financial needs for the project. Conservancy is
+    currently raising funds to continue their mission. Consider
+    <a href="https://sfconservancy.org/supporter/">becoming a supporter</a>!
+  </div>
 </header>


### PR DESCRIPTION
SFC is running a fund-drive, and it would be nice for us to get the word out. This PR sticks a banner at the top of each page. That's a bit invasive for all the time, but we could probably run this for a few weeks.

Style improvements very welcome.

I know this is fairly last-minute, but it would be nice to get it up for the final week of 2015, as many people choose to make donations before the tax year ends.