### PR TITLE
Fix typos in 2011-07-11-reset.html

### DIFF
--- a/app/views/blog/posts/2011-07-11-reset.html
+++ b/app/views/blog/posts/2011-07-11-reset.html
@@ -335,7 +335,7 @@ Index by running something like <code>git reset eb43bf file.txt</code>.
 
 <p>So what does that mean?  That functionally does the same thing as if we had
 reverted the content of the file to <b>v1</b>, ran <code>git add</code> on it,
-then reverted it back to to <b>v3</b> again.  If we run <code>git commit</code>,
+then reverted it back to <b>v3</b> again.  If we run <code>git commit</code>,
 it will record a change that reverts that file back to <b>v1</b>, even though
 we never actually had it in our Working Directory again.</p>
 
@@ -383,7 +383,7 @@ added the new file and modified the first to it's final state.
 <p>Finally, some of you may wonder what the difference between <code>checkout</code>
 and <code>reset</code> is. Well, like <code>reset</code>, <code>checkout</code>
 manipulates the three trees and it is a bit different depending on whether you
-give the command a file path or not.  So, let's look at both examples seperately.
+give the command a file path or not.  So, let's look at both examples separately.
 </p>
 
 <h3>git checkout [branch]</h3>


### PR DESCRIPTION
Remove extra to
Found a spelling mistake while reading -
`seperately` > `separately`