### PR TITLE
drop sfc donation banner

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -28,13 +28,6 @@
 
 <body id="<%= @section %>">
 
-  <div id="banner">
-    Git is a member project of Software Freedom Conservancy, which
-    handles legal and financial needs for the project. Conservancy is
-    currently raising funds to continue their mission. Consider
-    <a href="https://sfconservancy.org/supporter/">becoming a supporter</a>!
-  </div>
-
   <div class="inner">
     <%= render partial: "shared/header" %>
   </div> <!-- .inner -->


### PR DESCRIPTION
Conservancy can still use money, of course, but we've been running this for 3 months, and they have hit their minimum funding goal. It's kind of annoying to have on every page, so let's drop it.

We could have a more tasteful donate button somewhere else on the site that we have up all the time, but I'll leave that for another PR.

I'm leaving the banner CSS in place, as it may be useful again (though I suppose if we want to save a few bytes, we should drop it, as it's currently unused).
