### PR TITLE
community: mention the Windows-specific resources

### DIFF
--- a/app/views/community/index.html.erb
+++ b/app/views/community/index.html.erb
@@ -24,6 +24,10 @@
   </p>
 
   <p>
+    Windows-specific questions can also be sent to the <a href="https://groups.google.com/forum/?fromgroups#!forum/git-for-windows">Git for Windows mailing list</a> (if in doubt whether your question is Windows-specific, just use the general Git mailing list). Please submit Windows-specific bugs to <a href="https://github.com/git-for-windows/git/issues">Git for Windows' bug tracker</a>.
+  </p>
+
+  <p>
     There is also <a href="https://groups.google.com/forum/?fromgroups#!forum/git-users">Git user mailing list</a> on Google Groups which is a nice place for beginners to ask about anything.
   </p>
 


### PR DESCRIPTION
Git for Windows has its own mailing list, and prefers bugs to be submitted
via the bug tracker.

Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>