### PR TITLE
Add recommended trademark notice

### DIFF
--- a/app/views/site/trademark.html.erb
+++ b/app/views/site/trademark.html.erb
@@ -50,6 +50,12 @@ We encourage the use of the applicable symbols whenever possible, but
 recognize that many users will omit them in non-commercial and informal
 contexts.</p>
 
+<p>You can use "Git and the Git logo are either registered trademarks
+or trademarks of Software Freedom Conservancy, Inc., corporate home of
+the Git Project, in the United States and/or other countries." when
+you need to mention "Git" in e.g. list of trademarks held by other
+people.</p>
+
 <h3>2.2 Use of the Marks without written permission</h3>
 
 <p>You may use the Marks without prior written permission (subject


### PR DESCRIPTION
SAP wanted to have an officially sanctioned way to give trademark notice in their marketting literature, and Tony (the Conservancy lawyer) gave what is in the "double quotes" in this change as a generic statement we can recommend people to use.