### PR TITLE
Added fix to replace escaped html entities in <pre> elements with literal character.

### DIFF
--- a/app/assets/javascripts/site.js
+++ b/app/assets/javascripts/site.js
@@ -12,6 +12,10 @@ $(document).ready(function() {
   DownloadBox.init();
   AboutContent.init();
   FlippyBook.init();
+  
+  $('pre').each(function(i, e) { 
+    e.innerText = e.innerText.replace(/&lt;/g,'<');
+  });
 
   var _gauges = _gauges || [];
   (function() {


### PR DESCRIPTION
Fix from issue #645 (@Peter-Liang). The code runs on document ready to replace the wrongly escaped entities within `<pre>` elements.

Example affected page: https://git-scm.com/book/en/v2/Git-Basics-Undoing-Things#Unmodifying-a-Modified-File
