### PR TITLE
Fix auto-updating of the MacOSX downloadable versions

### DIFF
--- a/lib/tasks/downloads.rake
+++ b/lib/tasks/downloads.rake
@@ -5,7 +5,7 @@ require 'rss'
 # [OvD] note that Google uses Atom & Sourceforge uses RSS
 # however this isn't relevant when parsing the feeds for
 # name, version, url & date with Feedzirra
-SOURCEFORGE_URL = "http://sourceforge.net/api/file/index/project-id/2063428/mtime/desc/limit/20/rss"
+SOURCEFORGE_URL = "https://sourceforge.net/projects/git-osx-installer/rss?limit=20"
 
 def file_downloads(repository)
   downloads = []


### PR DESCRIPTION
Apparently SourceForge changed their RSS URLs at some stage in the past,
putting redirects into the old places. However, we cannot use those
redirects:

	** Execute mac_downloads
	rake aborted!
	redirection forbidden:
	http://sourceforge.net/api/file/index/project-id/2063428/mtime/desc/limit/20/rss -> https://sourceforge.net/api/file/index/project-id/2063428/mtime/desc/limit/20/rss
	lib/tasks/downloads.rake:12:in `file_downloads'
	lib/tasks/downloads.rake:81:in `block in <top (required)>'
	Tasks: TOP => mac_downloads

Let's just follow the redirection manually.

This should fix the issue where the MacOSX downloads are stuck at Git
v2.6.4, as reported by Michał Staruch in a top-posted mail to the Git
mailing list.

Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>