### PR TITLE
Fix GUI links and add HTTPS when possible

### DIFF
--- a/app/views/downloads/guis/index.html.haml
+++ b/app/views/downloads/guis/index.html.haml
@@ -28,19 +28,19 @@
             <strong>Platforms:</strong> Windows, Mac</br>
             <strong>Price:</strong> Free
         %li.mac
-          =link_to(image_tag('guis/gitx@2x.png', {:width => '294', :height => '166'}), "http://rowanj.github.io/gitx/")
+          =link_to(image_tag('guis/gitx@2x.png', {:width => '294', :height => '166'}), "https://rowanj.github.io/gitx/")
           %h4= link_to "GitX-dev ", "https://rowanj.github.io/gitx/"
           %p.description
             <strong>Platforms:</strong> Mac</br>
             <strong>Price:</strong> Free
         %li.mac.windows
-          =link_to(image_tag('guis/sourcetree@2x.png', {:width => '294', :height => '166'}), "http://www.sourcetreeapp.com/")
+          =link_to(image_tag('guis/sourcetree@2x.png', {:width => '294', :height => '166'}), "https://www.sourcetreeapp.com/")
           %h4= link_to "SourceTree", "https://www.sourcetreeapp.com/"
           %p.description
             <strong>Platforms:</strong> Mac, Windows</br>
             <strong>Price:</strong> Free
         %li.mac.windows.linux
-          =link_to(image_tag('guis/smartgit@2x.png', {:width => '294', :height => '166'}), "http://www.syntevo.com/smartgit/index.html")
+          =link_to(image_tag('guis/smartgit@2x.png', {:width => '294', :height => '166'}), "https://www.syntevo.com/smartgit/")
           %h4= link_to "SmartGit", "https://www.syntevo.com/smartgit/"
           %p.description
             <strong>Platforms:</strong> Windows, Mac, Linux</br>
@@ -58,33 +58,33 @@
             <strong>Platforms:</strong> Linux</br>
             <strong>Price:</strong> Free
         %li.mac.windows.linux
-          =link_to(image_tag('guis/git-kraken@2x.png', {:width => '294', :height => '166'}), "http://www.gitkraken.com/")
-          %h4= link_to "GitKraken", "http://www.gitkraken.com/"
+          =link_to(image_tag('guis/git-kraken@2x.png', {:width => '294', :height => '166'}), "https://www.gitkraken.com/")
+          %h4= link_to "GitKraken", "https://www.gitkraken.com/"
           %p.description
             <strong>Platforms:</strong> Windows, Mac, Linux</br>
             <strong>Price:</strong> Free
     %div.column-right
       %ul.gui-thumbnails
         %li.mac
-          =link_to(image_tag('guis/tower@2x.png', {:width => '294', :height => '166'}), "http://git-tower.com/")
+          =link_to(image_tag('guis/tower@2x.png', {:width => '294', :height => '166'}), "https://www.git-tower.com/")
           %h4= link_to "Tower", "https://www.git-tower.com/"
           %p.description
             <strong>Platforms:</strong> Mac</br>
             <strong>Price:</strong> $69/user (Free 30 day trial)
         %li.mac
-          =link_to(image_tag('guis/gitbox@2x.png', {:width => '294', :height => '166'}), "http://gitboxapp.com/")
+          =link_to(image_tag('guis/gitbox@2x.png', {:width => '294', :height => '166'}), "http://www.gitboxapp.com/")
           %h4= link_to "Gitbox", "http://www.gitboxapp.com/"
           %p.description
             <strong>Platforms:</strong> Mac</br>
             <strong>Price:</strong> $14.99
         %li.windows
-          =link_to(image_tag('guis/git-extensions@2x.png', {:width => '294', :height => '166'}), "http://code.google.com/p/gitextensions/")
+          =link_to(image_tag('guis/git-extensions@2x.png', {:width => '294', :height => '166'}), "https://gitextensions.github.io/")
           %h4= link_to "Git Extensions", "https://gitextensions.github.io/"
           %p.description
             <strong>Platforms:</strong> Windows</br>
             <strong>Price:</strong> Free
         %li.mac.windows.linux
-          =link_to(image_tag('guis/git-cola@2x.png', {:width => '294', :height => '166'}), "http://git-cola.github.io/")
+          =link_to(image_tag('guis/git-cola@2x.png', {:width => '294', :height => '166'}), "https://git-cola.github.io/")
           %h4= link_to "git-cola", "https://git-cola.github.io/"
           %p.description
             <strong>Platforms:</strong> Windows, Mac, Linux</br>


### PR DESCRIPTION
This commit fixes links on the https://git-scm.com/downloads/guis page.
Some were plainly wrong while some others were inconsistent (text link vs image link); this commit aims to improve this.

* GitX: make image link match text link (https)
* Sourcetree: make image link match text link (https)
* SmartGit: make image link match text link (https)
* GitKraken: add https to both links
* GitTower: make image link match text link (https and www)
* GitBoxApp: make image link match text link (www)
* GitExtensions: fix wrong image link, still leading to googlecode dead project
* GitCola: make image link match text link (https)