### PR TITLE
Update broken GitHub cheat sheet link

### DIFF
--- a/app/views/doc/index.html.erb
+++ b/app/views/doc/index.html.erb
@@ -22,7 +22,7 @@
   <p class="quickref">
     Quick reference guides:
 
-    <%= link_to "GitHub Cheat Sheet", "https://training.github.com/kit/downloads/github-git-cheat-sheet.pdf" %>
+    <%= link_to "GitHub Cheat Sheet", "https://services.github.com/kit/downloads/github-git-cheat-sheet.pdf" %>
     <small class="light">(PDF) &nbsp;|&nbsp;</small>
     <%= link_to "Visual Git Cheat Sheet", "http://ndpsoftware.com/git-cheatsheet.html" %>
     <small class="light"> (SVG | PNG)


### PR DESCRIPTION
Looks like GitHub changed the subdomain for their training site, so the link to the cheat sheet was broken. This PR updates the url to point users to the right place. :pencil2: 