### PR TITLE
Added new slogan: import from another VCS

### DIFF
--- a/lib/constants.rb
+++ b/lib/constants.rb
@@ -5,6 +5,7 @@ TAGLINES = %w{
     distributed-even-if-your-workflow-isnt
     local-branching-on-the-cheap
     distributed-is-the-new-centralized
+    import-from-other-vcs
 }
 
 # DocsController#commands


### PR DESCRIPTION
This headline text may seem insane, but... with git-svn, git-cvs and git-remote-hg interfaces, other VCSes are almostly convertible to Git. I think this is important to be seen to show that git is **universal** - can be converted to/from another VCS, so may serve as replacement/back end/front end to another VCS, making people more accustomed to Git and finally converting them to it. Also, I suggesting adding more slogans.
