### PR TITLE
Update platforms and pricing for Tower Git client

### DIFF
--- a/app/views/downloads/guis/index.html.haml
+++ b/app/views/downloads/guis/index.html.haml
@@ -63,8 +63,8 @@
           =link_to(image_tag('guis/tower@2x.png', {:width => '294', :height => '166'}), "http://git-tower.com/")
           %h4= link_to "Tower", "http://www.git-tower.com/"
           %p.description
-            <strong>Platforms:</strong> Mac</br>
-            <strong>Price:</strong> $69/user (Free 30 day trial)
+            <strong>Platforms:</strong> Windows, Mac</br>
+            <strong>Price:</strong> $79/user (Free 30 day trial)
         %li.mac
           =link_to(image_tag('guis/gitbox@2x.png', {:width => '294', :height => '166'}), "http://gitboxapp.com/")
           %h4= link_to "Gitbox", "http://www.gitboxapp.com/"


### PR DESCRIPTION
The "downloads/guis" page was outdated. The Tower Git desktop client is now available for Windows, too.