### PR TITLE
docs: update cheat sheet link

### DIFF
--- a/app/views/doc/ref.html.erb
+++ b/app/views/doc/ref.html.erb
@@ -7,7 +7,7 @@
   <div class='callout quickref'>
     <p>
       Quick reference guides:
-      <a href="https://training.github.com/kit/downloads/github-git-cheat-sheet.pdf">GitHub Cheat Sheet</a>
+      <a href="https://services.github.com/kit/downloads/github-git-cheat-sheet.pdf">GitHub Cheat Sheet</a>
       <small class='light'>(PDF) &nbsp;|&nbsp;</small>
       <a href="http://ndpsoftware.com/git-cheatsheet.html">Visual Git Cheat Sheet</a>
       <small class='light'>(SVG | PNG)</small>


### PR DESCRIPTION
Commit 91bdfb4 (Update broken GitHub cheat sheet link, 2016-05-27) updated the link on https://git-scm.com/doc, but not the identical one on `/docs`, with an `s`. The former is the main documentation landing page (which mentions the manpages along with the book, videos, etc), and the latter is just the manpages.
