### PR TITLE
community: Replace gmane archive link with a mail-archive one.

### DIFF
--- a/app/views/community/index.html.erb
+++ b/app/views/community/index.html.erb
@@ -20,7 +20,7 @@
   </p>
 
   <p>
-    The <a href="http://dir.gmane.org/gmane.comp.version-control.git">archive</a> can be found on Gmane.  Click <a href="mailto:majordomo@vger.kernel.org?body=subscribe git">here</a> to subscribe. If you have trouble sending to the list with your regular mail reader, you may also <a href="http://post.gmane.org/post.php?group=gmane.comp.version-control.git">post via gmane</a>.
+    The <a href="https://public-inbox.org/git">archive</a> can be found on public-inbox. Click <a href="mailto:majordomo@vger.kernel.org?body=subscribe git">here</a> to subscribe.
   </p>
 
   <p>


### PR DESCRIPTION
The link to gname in the community page[1](https://git-scm.com/community) seems to be broken:
http://dir.gmane.org/gmane.comp.version-control.git

Gmane itself seems to be down, I don't know if temporarily or not, so after a
quick search I found another archive in mail-archive.com[2](https://www.mail-archive.com/git@vger.kernel.org/), and thought that I
could be worth to replace them.
