### PR TITLE
Add new category "Guides" to reference topics

### DIFF
--- a/app/helpers/doc_helper.rb
+++ b/app/helpers/doc_helper.rb
@@ -1,7 +1,7 @@
 module DocHelper
 
   def man(name)
-    link_to name.gsub('git-', ''), doc_file_path(:file => name) 
+    link_to name.gsub(/^git-?/, ''), doc_file_path(:file => name) 
   end
 
   def linkify(content, section)

--- a/app/views/doc/_topics.html.erb
+++ b/app/views/doc/_topics.html.erb
@@ -14,12 +14,12 @@
       <%= render 'shared/ref/debugging' %>
       <%= render 'shared/ref/email' %>
       <%= render 'shared/ref/external' %>
+      <%= render 'shared/ref/server' %>
     </div>
     <div class='column-right'>
-      <%= render 'shared/ref/admin' %>
-      <%= render 'shared/ref/server' %>
-      <%= render 'shared/ref/plumbing' %>
       <%= render 'shared/ref/guides' %>
+      <%= render 'shared/ref/admin' %>
+      <%= render 'shared/ref/plumbing' %>
     </div>
   </div>
 </div>

--- a/app/views/doc/_topics.html.erb
+++ b/app/views/doc/_topics.html.erb
@@ -19,6 +19,7 @@
       <%= render 'shared/ref/admin' %>
       <%= render 'shared/ref/server' %>
       <%= render 'shared/ref/plumbing' %>
+      <%= render 'shared/ref/guides' %>
     </div>
   </div>
 </div>

--- a/app/views/doc/ref.html.erb
+++ b/app/views/doc/ref.html.erb
@@ -26,12 +26,12 @@
         <%= render 'shared/ref/debugging' %>
       </div>
       <div class='column-right'>
+        <%= render 'shared/ref/guides' %>
         <%= render 'shared/ref/email' %>
         <%= render 'shared/ref/external' %>
         <%= render 'shared/ref/admin' %>
         <%= render 'shared/ref/server' %>
         <%= render 'shared/ref/plumbing' %>
-        <%= render 'shared/ref/guides' %>
       </div>
     </div>
   </div>

--- a/app/views/doc/ref.html.erb
+++ b/app/views/doc/ref.html.erb
@@ -23,14 +23,15 @@
         <%= render 'shared/ref/sharing' %>
         <%= render 'shared/ref/inspection' %>
         <%= render 'shared/ref/patching' %>
+        <%= render 'shared/ref/debugging' %>
       </div>
       <div class='column-right'>
-        <%= render 'shared/ref/debugging' %>
         <%= render 'shared/ref/email' %>
         <%= render 'shared/ref/external' %>
         <%= render 'shared/ref/admin' %>
         <%= render 'shared/ref/server' %>
         <%= render 'shared/ref/plumbing' %>
+        <%= render 'shared/ref/guides' %>
       </div>
     </div>
   </div>

--- a/app/views/shared/ref/_guides.html.erb
+++ b/app/views/shared/ref/_guides.html.erb
@@ -1,0 +1,11 @@
+<h3 class='guides'>Guides</h3>
+<ul class='unstyled'>
+  <li><%= man('git-attributes') %></li>
+  <li><%= man('git-everyday') %></li>
+  <li><%= man('git-glossary') %></li>
+  <li><%= man('git-ignore') %></li>
+  <li><%= man('git-modules') %></li>
+  <li><%= man('git-revisions') %></li>
+  <li><%= man('git-tutorial') %></li>
+  <li><%= man('git-workflows') %></li>
+</ul>

--- a/app/views/shared/ref/_guides.html.erb
+++ b/app/views/shared/ref/_guides.html.erb
@@ -1,11 +1,11 @@
 <h3 class='guides'>Guides</h3>
 <ul class='unstyled'>
-  <li><%= man('git-attributes') %></li>
-  <li><%= man('git-everyday') %></li>
-  <li><%= man('git-glossary') %></li>
-  <li><%= man('git-ignore') %></li>
-  <li><%= man('git-modules') %></li>
-  <li><%= man('git-revisions') %></li>
-  <li><%= man('git-tutorial') %></li>
-  <li><%= man('git-workflows') %></li>
+  <li><%= man('gitattributes') %></li>
+  <li><%= man('giteveryday') %></li>
+  <li><%= man('gitglossary') %></li>
+  <li><%= man('gitignore') %></li>
+  <li><%= man('gitmodules') %></li>
+  <li><%= man('gitrevisions') %></li>
+  <li><%= man('gittutorial') %></li>
+  <li><%= man('gitworkflows') %></li>
 </ul>

--- a/config/initializers/categories.rb
+++ b/config/initializers/categories.rb
@@ -27,6 +27,9 @@ module Gitscm
       ['git-cat-file', 'git-commit-tree', 'git-count-objects', 'git-diff-index',
        'git-diff-tree', 'git-hash-object', 'git-merge-base', 'git-read-tree',
        'git-rev-list', '']
+    ],['Guides',
+      ['git-attributes', 'git-everyday', 'git-glossary', 'git-ignore',
+       'git-modules', 'git-revisions', 'git-tutorial', 'git-workflows']
     ]
   ]
 end


### PR DESCRIPTION
I've never worked with Ruby and I'm not very sure about the changes, however, it seems to work (see screenshots below). I've just grepped the codebase for occurrences of topic names ("Patching", "Debugging") and added "Guides" were it seemed reasonable. I've skipped `lib/constants.rb` because it is about the actual commands. Also, I didn't add new css rules, because there is no icon for the new category.

This PR is for issue #675.

I'm not sure in which column to put "Guides"

Topic dropdown:
![image](https://cloud.githubusercontent.com/assets/624072/18418516/b36023ae-7850-11e6-856a-2061a5a75124.png)

Reference landing page (with "Debugging" moved to the end of the first column):
![image](https://cloud.githubusercontent.com/assets/624072/18418517/c545b994-7850-11e6-8a05-0daf3e2b4823.png)