### PR TITLE
Add Git User's Survey 2016 announcement banner

### DIFF
--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -45,6 +45,31 @@ aside {
   float: right;
 }
 
+#promo {
+  background-color: #433b34;
+  color: #f0f0e8;
+  padding: 8px 0 2px 0;
+  header {
+    color: #fff;
+    font-size: 16px;
+    font-weight: bold;
+    line-height: 1.3;
+    margin-bottom: 3px;
+    em {
+      color: #f0f0e8;
+      font-size: 12px;
+      font-weight: normal;
+      padding-left: 10px;
+    }
+  }
+  p {
+    line-height: 1.3;
+  }
+  a {
+    color: $orange;
+  }
+}
+
 #main {
   background-color: #fcfcfa;
   border: solid 1px #e2e0d8;

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -28,6 +28,15 @@
 
 <body id="<%= @section %>">
 
+  <div class="inner" id="#promo">
+    <header>
+      The Git User's Survey 2016 is now up! <em>12 September &mdash; 20 October 2016.</em>
+    </header>
+    <p>
+      Please devote a few moments of your time to <a href="https://survs.com/survey/0janvqmmyg">fill out the simple questionnaire</a>. It'll help the Git community understand your needs, what you like about Git (and what you don't), and help us improve it in general. The results will be published at <a href="http://git.wiki.kernel.org/index.php/GitSurvey2016">GitSurvey2016</a> page.
+    </p>
+  </div>
+
   <div class="inner">
     <%= render partial: "shared/header" %>
   </div> <!-- .inner -->


### PR DESCRIPTION
Could you add an announcement about [Git User's Survey 2016](https://survs.com/survey/ulcu05whhi)
somewhere visible on Git Homepage (http://git-scm.com)?  Perhaps
something like this pull request (this is only a proposal).

It's based on commit 4818b272b2 announcing Git Survey 2012,
the last one before this, modified a bit for the changes in the page,
like moving from Haml to ERB. **Not tested**!

Thanks in advance.

-- 
Jakub Narębski (@jnareb)
on behalf of
Git Development Community
