### PR TITLE
add 2016 survey banner

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -28,6 +28,20 @@
 
 <body id="<%= @section %>">
 
+  <div id="banner">
+    <div class="inner">
+      <h3>The 2016 Git User's Survey is now up! <em>12 September &mdash; 20 October 2016.</em></h3>
+
+      <p>Please devote a few moments of your time to
+      <a href="https://survs.com/survey/0janvqmmyg">fill out the simple questionnaire</a>.
+      It will help the Git community understand your needs, what you like
+      about Git (and what you don't), and help us improve it in general.
+      The results will be published at the
+      <a href="http://git.wiki.kernel.org/index.php/GitSurvey2016">GitSurvey2016</a>
+      wiki page.
+    </div>
+  </div>
+
   <div class="inner">
     <%= render partial: "shared/header" %>
   </div> <!-- .inner -->


### PR DESCRIPTION
This adds a banner to most pages advertising the 2016 Git User's Survey. The content is mostly stolen from @jnareb's 678f4a14bcee915611c0453d61368c4781dd165e, with a few minor English fixups.

However, I think the banner CSS added by fc7ab3bfc4c784daa in late 2015 looks nicer than the old "promo" styles from 4818b272b25bfb3eabb55bcb449d0ad92c8eccc1, so I've gone with that.

/cc @jnareb; please remind me to take this down after the survey ends
