### PR TITLE
Gemfile: bump to latest asciidoctor

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ ruby "2.1.8"
 gem 'rails', '4.2.6'
 gem 'rails_12factor', group: :production
 
-gem 'asciidoctor', '>=1.5.0'
+gem 'asciidoctor', '>=1.5.4'
 gem 'dalli'
 gem 'exceptional'
 gem 'faraday'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,7 +39,7 @@ GEM
     addressable (2.3.6)
     ansi (1.4.3)
     arel (6.0.3)
-    asciidoctor (1.5.2)
+    asciidoctor (1.5.4)
     awesome_print (1.2.0)
     better_errors (1.1.0)
       coderay (>= 1.0.0)
@@ -241,7 +241,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  asciidoctor (>= 1.5.0)
+  asciidoctor (>= 1.5.4)
   awesome_print
   better_errors
   binding_of_caller


### PR DESCRIPTION
This has tabsize fixes from asciidoctor/asciidoctor@2893d1666060 that make some of the mixed tab/space diagrams line up properly (e.g., the first one in git-merge-base).

Actually, that commit is in 1.5.3, but it seems like it should not hurt to get the latest round of bugfixes, too.

Fixes #680 and #847.
