### PR TITLE
Do not enforce the family for monospace fonts

### DIFF
--- a/app/assets/stylesheets/git-scm.scss
+++ b/app/assets/stylesheets/git-scm.scss
@@ -30,7 +30,7 @@ pre {
   background-color: #fff;
   border: solid 1px #efeee6;
   color: #f14e32;
-  font-family: Courier, monospace !important;
+  font-family: Courier, monospace;
   line-height: 18px;
   overflow: auto
 }

--- a/app/assets/stylesheets/typography.scss
+++ b/app/assets/stylesheets/typography.scss
@@ -220,7 +220,7 @@ code {
   background-color: #fff;
   border: solid 1px #efeee6;
   color: $orange;
-  font-family: $fixed-width-font-family !important;
+  font-family: $fixed-width-font-family;
   line-height: $fixed-width-line-height;
   overflow: auto;
 }
@@ -325,5 +325,5 @@ div.more {
 }
 
 .fixed {
-  font-family: $fixed-width-font-family !important;
+  font-family: $fixed-width-font-family;
 }


### PR DESCRIPTION
Why is this rule here?

- Ugly defaults (another question is: do `<pre>` and `<code>` even need a default? isn't the browser going to take care of them?)
- It completely goes over what I have set up as my browser fonts (which I did specifically in order to avoid ugly defaults everywhere, or improve readability)

I have to use Stylish to get enforce my own fonts, and for what?