### PR TITLE
add Alpine install command to download page

### DIFF
--- a/app/views/downloads/download_linux.html.erb
+++ b/app/views/downloads/download_linux.html.erb
@@ -32,6 +32,9 @@
   
   <h3>OpenBSD</h3>
   <code>$ pkg_add git</code>
+
+  <h3>Alpine</h3>
+  <code>$ apk add git</code>
   
   <h3>Red Hat Enterprise Linux, Oracle Linux, CentOS, Scientific Linux, et al.</h3>
   <p>RHEL and derivatives typically ship older versions of git.  If you cannot (or don't want to) compile git from source, you may need to use a 3rd-party repository such as <a href="https://ius.io/">the IUS Community Project</a> to obtain a more recent version of git.</p>


### PR DESCRIPTION
Just added install command for Alpine (see https://alpinelinux.org), a well used lite distro.