### PR TITLE
Updated github cheat-sheet link

### DIFF
--- a/app/views/doc/index.html.erb
+++ b/app/views/doc/index.html.erb
@@ -22,7 +22,7 @@
   <p class="quickref">
     Quick reference guides:
 
-    <%= link_to "GitHub Cheat Sheet", "https://services.github.com/kit/downloads/github-git-cheat-sheet.pdf" %>
+    <%= link_to "GitHub Cheat Sheet", "https://services.github.com/on-demand/downloads/github-git-cheat-sheet.pdf" %>
     <small class="light">(PDF) &nbsp;|&nbsp;</small>
     <%= link_to "Visual Git Cheat Sheet", "http://ndpsoftware.com/git-cheatsheet.html" %>
     <small class="light"> (SVG | PNG)

--- a/app/views/doc/ref.html.erb
+++ b/app/views/doc/ref.html.erb
@@ -7,7 +7,7 @@
   <div class='callout quickref'>
     <p>
       Quick reference guides:
-      <a href="https://services.github.com/kit/downloads/github-git-cheat-sheet.pdf">GitHub Cheat Sheet</a>
+      <a href="https://services.github.com/on-demand/downloads/github-git-cheat-sheet.pdf">GitHub Cheat Sheet</a>
       <small class='light'>(PDF) &nbsp;|&nbsp;</small>
       <a href="http://ndpsoftware.com/git-cheatsheet.html">Visual Git Cheat Sheet</a>
       <small class='light'>(SVG | PNG)</small>


### PR DESCRIPTION
Looks like the Github git cheat sheet link moved from `services.github.com/kit/...` to `services.github.com/on-demand/...`. I updated the link in the docs.