### PR TITLE
List windows as an available platform for the gitg GUI client.

### DIFF
--- a/app/views/downloads/guis/index.html.haml
+++ b/app/views/downloads/guis/index.html.haml
@@ -101,11 +101,11 @@
           %p.description
             <strong>Platforms:</strong> Windows, Mac, Linux</br>
             <strong>Price:</strong> Free
-        %li.linux
+        %li.windows.linux
           =link_to(image_tag('guis/gitg@2x.png', {:width => '294', :height => '166'}), "https://wiki.gnome.org/Apps/Gitg/")
           %h4= link_to "gitg", "https://wiki.gnome.org/Apps/Gitg/"
           %p.description
-            <strong>Platforms:</strong> Linux</br>
+            <strong>Platforms:</strong> Windows, Linux</br>
             <strong>Price:</strong> Free
         %li.windows
           =link_to(image_tag('guis/aurees@2x.png', {:width => '294', :height => '166'}), "https://aurees.com/")


### PR DESCRIPTION
The Gitg page offers Windows 64 bit binaries for download, so presumably Windows should be listed as an available platform for it.