### PR TITLE
Add git(1) to command reference

### DIFF
--- a/app/helpers/doc_helper.rb
+++ b/app/helpers/doc_helper.rb
@@ -1,7 +1,7 @@
 module DocHelper
 
-  def man(name)
-    link_to name.gsub(/^git-/, ''), doc_file_path(:file => name)
+  def man(name, text = nil)
+    link_to text || name.gsub(/^git-/, ''), doc_file_path(:file => name)
   end
 
   def linkify(content, section)

--- a/app/helpers/doc_helper.rb
+++ b/app/helpers/doc_helper.rb
@@ -1,7 +1,7 @@
 module DocHelper
 
   def man(name)
-    link_to name.gsub(/^git-?/, ''), doc_file_path(:file => name) 
+    link_to name.gsub(/^git-/, ''), doc_file_path(:file => name)
   end
 
   def linkify(content, section)

--- a/app/views/shared/ref/_guides.html.erb
+++ b/app/views/shared/ref/_guides.html.erb
@@ -1,11 +1,11 @@
 <h3 class='guides'>Guides</h3>
 <ul class='unstyled'>
   <li><%= man('gitattributes') %></li>
-  <li><%= man('giteveryday') %></li>
-  <li><%= man('gitglossary') %></li>
+  <li><%= man('giteveryday', 'Everyday Git') %></li>
+  <li><%= man('gitglossary', 'Glossary') %></li>
   <li><%= man('gitignore') %></li>
   <li><%= man('gitmodules') %></li>
-  <li><%= man('gitrevisions') %></li>
-  <li><%= man('gittutorial') %></li>
-  <li><%= man('gitworkflows') %></li>
+  <li><%= man('gitrevisions', 'Revisions') %></li>
+  <li><%= man('gittutorial', 'Tutorial') %></li>
+  <li><%= man('gitworkflows', 'Workflows') %></li>
 </ul>

--- a/app/views/shared/ref/_setup.html.erb
+++ b/app/views/shared/ref/_setup.html.erb
@@ -1,5 +1,6 @@
 <h3 class='setup'>Setup and Config</h3>
 <ul class='unstyled'>
+  <li><%= man('git') %></li>
   <li><%= man('git-config') %></li>
   <li><%= man('git-help') %></li>
 </ul>


### PR DESCRIPTION
Adds the [_git(1)_ man page](https://github.com/git/git/blob/e05806da9ec4aff8adfed142ab2a2b3b02e33c8c/Documentation/git.txt) to the main reference index at https://git-scm.com/docs.

_Setup and Config_ felt like the most appropriate subsection out of the existing ones, since that section already contains _git-help(1)_, but happy to shift this around if it's felt that there is a better fit elsewhere.

Related to #918, which fixes the command lists within this man page.