### PR TITLE
Fix asciidoc compatibility issues

### DIFF
--- a/lib/tasks/book2.rake
+++ b/lib/tasks/book2.rake
@@ -84,7 +84,7 @@ task :remote_genbook2 => :environment do
       end
     end
 
-    asciidoc = Asciidoctor::Document.new(content,template_dir: template_dir)
+    asciidoc = Asciidoctor::Document.new(content,template_dir: template_dir, attributes: { 'compat-mode' => true})
     html = asciidoc.render
     alldoc = Nokogiri::HTML(html)
     number = 1


### PR DESCRIPTION
Some parts of asciidoc are not rendered correctly by asciidoctor
unless a `compat-mode` option is enabled.

This fixes #925 