### PR TITLE
fix asciidoc compatibility mode for manpages

### DIFF
--- a/lib/tasks/index.rake
+++ b/lib/tasks/index.rake
@@ -108,7 +108,7 @@ task :preindex => :environment do
 
       content = blob_content[entry.sha]
       expand!(content, tag_files, blob_content, categories)
-      asciidoc = Asciidoctor::Document.new(content, attributes: {'sectanchors' => ''})
+      asciidoc = Asciidoctor::Document.new(content, attributes: {'sectanchors' => '', 'compat-mode' => true})
       asciidoc_sha = Digest::SHA1.hexdigest( asciidoc.source )
       doc = Doc.where( :blob_sha => asciidoc_sha ).first_or_create
       if rerun || !doc.plain || !doc.html


### PR DESCRIPTION
asciidoctor must be run with option "compat-mode" to mimic the
rendering of asciidoc.

Not sure whether this is needed.