### PR TITLE
fix old book redirects

### DIFF
--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -89,6 +89,9 @@ class BooksController < ApplicationController
   def redirect_book
     uri_path = params[:lang]
     if slug = REDIRECT[uri_path]
+      /^(.*?)\/(.*)/.match(slug) do |m|
+        return redirect_to slug_book_path(lang: m[1], slug: m[2])
+      end
       return redirect_to lang_book_path(lang: slug)
     end
   end

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -10,6 +10,7 @@ class BooksController < ApplicationController
       @book = Book.where(:code => lang, :edition => edition).first
     else
       @book = Book.where(:code => lang).order("percent_complete DESC, edition DESC").first
+      raise PageNotFound unless @book
       redirect_to "/book/#{lang}/v#{@book.edition}"
     end
     raise PageNotFound unless @book

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,7 +42,7 @@ Gitscm::Application.routes.draw do
     get "/:lang/v:edition/:slug"          => "books#section"
     get "/:lang/v:edition/:chapter/:link" => "books#link", chapter: /(ch|app)\d+/
     get "/:lang"                          => "books#show", as: :lang
-    get "/:lang/:slug"                    => "books#section"
+    get "/:lang/:slug"                    => "books#section", as: :slug
   end
   post "/update"   => "books#update"
 


### PR DESCRIPTION
The historical book redirects (e.g., http://book.git-scm.com/4_git_treeishes.html) redirected to a bogus URL that ended in a 500. This fixes the redirects, and also converts the 500 into a 404 as appropriate.

Fixes #922.
