### PR TITLE
Improve caching for pages and assets

### DIFF
--- a/app/controllers/doc_controller.rb
+++ b/app/controllers/doc_controller.rb
@@ -1,5 +1,6 @@
 class DocController < ApplicationController
 
+  before_filter :set_caching
   before_filter :set_doc_file, only: [:man]
   before_filter :set_doc_version, only: [:man]
   before_filter :set_book, only: [:index]
@@ -87,6 +88,10 @@ class DocController < ApplicationController
   end
 
   private
+
+  def set_caching
+    expires_in 10.minutes, :public => true
+  end
 
   def set_book
     @book ||= Book.where(:code => (params[:lang] || "en")).order("percent_complete, edition DESC").first

--- a/app/controllers/site_controller.rb
+++ b/app/controllers/site_controller.rb
@@ -1,6 +1,8 @@
 class SiteController < ApplicationController
 
   def index
+    expires_in 10.minutes, :public => true
+
     @section    = "home"
     @subsection = ""
   end

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,10 +1,12 @@
 <header>
 
   <a href="/"><img src="/images/logo@2x.png" width="110" height="46" alt="Git" /></a>
-  <span id="tagline">
-    <%= raw random_tagline %>
-  </span>
-
+  <span id="tagline"></span>
+  <script type="text/javascript">
+    var taglines = <%= raw JSON.generate(TAGLINES) %>;
+    var tagline = taglines[Math.floor(Math.random() * taglines.length)];
+    document.getElementById('tagline').innerHTML = '--' + tagline;
+  </script>
   <form id="search" action="/search/results">
     <input id="search-text" name="search" placeholder="Search entire site..." autocomplete="off" type="text" />
   </form>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -21,6 +21,7 @@ Rails.application.configure do
 
   # Disable Rails's static asset server (Apache or nginx will already do this).
   config.serve_static_assets = true
+  config.static_cache_control = "public, max-age=31536000"
 
   # Compress JavaScripts and CSS.
   config.assets.js_compressor = :uglifier


### PR DESCRIPTION
This change improves caching of all pages by inlining all taglines and injecting one at random at client side. This makes eTag of each page the same upon refresh, reducing load from browsers, and allowing to use CDNs like CloudFlare to improve performance.

Before:

```
diff <(curl http://localhost:3000) <(curl http://localhost:3000)
<     <em>--</em>distributed-even-if-your-workflow-isnt
---
>     <em>--</em>fast-version-control
curl -s http://localhost:3000 --head | grep Etag
Etag: W/"7dc67aac3f485b108b0fc933d0701986"
curl -s http://localhost:3000 --head | grep Etag
Etag: W/"710e3e8a2c0619ca705ba9a522400222"
```

After:

```
diff <(curl http://localhost:3000) <(curl http://localhost:3000)
curl -s http://localhost:3000 --head | grep Etag
Etag: W/"eb613a79d536ecaf9817aabbd531a56c"
curl -s http://localhost:3000 --head | grep Etag
Etag: W/"eb613a79d536ecaf9817aabbd531a56c"
```

I highly recommend putting CloudFlare in front of https://git-scm.com to fully experience what this PR enables. But it improves performance even without it.