### PR TITLE
Create a GitHub Issue Template.

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,4 @@
+ - [ ] This issue is about **specifically** the [git-scm.com](https://git-scm.com) website and is **not** an issue about
+     - [ ] Git (or its man pages), which should be raised with the [community](https://git-scm.com/community),
+     - [ ] Git for Windows, which should be raised at [git-for-windows/git](https://git-scm.com/community), or
+     - [ ] the contents of the Pro Git book, which should be raised at [progit/progit2](https://github.com/progit/progit2/issues).


### PR DESCRIPTION
People *constantly* open issues on the git/git-scm.com repository that
aren't actually relevant to the git-scm.com website. This introduces an
issue template which explicitly points people to the appropriate issue
tracker for the Git, Git for Windows, and Pro Git projects, so that anyone
who goes to open an issue on the git/git-scm.com issue tracker that
isn't about the website gets told where to go.