### PR TITLE
fix script error when importing man pages of version 1.5.4 of git

### DIFF
--- a/lib/tasks/index.rake
+++ b/lib/tasks/index.rake
@@ -62,7 +62,7 @@ task :preindex => :environment do
     # generate command-list content
     categories = {}
     if cmd_list_file = tag_files.detect { |ent| ent.path == "command-list.txt" }
-      cmd_list = blob_content[cmd_list_file.sha].match(/(### command list.*)/m)[0].split("\n").reject{|l| l =~ /^#/}.inject({}) do |list, cmd|
+      cmd_list = blob_content[cmd_list_file.sha].match(/(### command list.*|# command name.*)/m)[0].split("\n").reject{|l| l =~ /^#/}.inject({}) do |list, cmd|
         name, kind, attr = cmd.split(/\s+/)
         list[kind] ||= []
         list[kind] << [name, attr]

--- a/lib/tasks/local_index.rake
+++ b/lib/tasks/local_index.rake
@@ -55,7 +55,7 @@ task :local_index => :environment do
       # generate command-list content
       categories = {}
       if system("git cat-file -e #{tag}:command-list.txt > /dev/null 2>&1")
-        cmd_list = `git cat-file blob #{tag}:command-list.txt`.match(/(### command list.*)/m)[0].split("\n").reject{|l| l =~ /^#/}.inject({}) do |list, cmd|
+        cmd_list = `git cat-file blob #{tag}:command-list.txt`.match(/(### command list.*|# command name.*)/m)[0].split("\n").reject{|l| l =~ /^#/}.inject({}) do |list, cmd|
           name, kind, attr = cmd.split(/\s+/)
           list[kind] ||= []
           list[kind] << [name, attr]


### PR DESCRIPTION
58f4e68 introduced a regression where the file `command-list.txt`
started to exist but did not yet contain the header `### command
list`, resulting in a void match.

This references #639