### PR TITLE
Add links to tarballs on Linux download page

### DIFF
--- a/app/views/downloads/download_linux.html.erb
+++ b/app/views/downloads/download_linux.html.erb
@@ -3,7 +3,7 @@
 
 <div id="main">
   <h1>Download for Linux and Unix</h1>
-  <p>It is easiest to install Git on Linux using the preferred package manager of your Linux distribution.</p>
+  <p>It is easiest to install Git on Linux using the preferred package manager of your Linux distribution. If you prefer to build from source, you can find the tarballs <a href="https://www.kernel.org/pub/software/scm/git/">on kernel.org</a>.</p>
 
   <h3>Debian/Ubuntu</h3>
   <code>$ apt-get install git</code>
@@ -37,6 +37,6 @@
   <code>$ apk add git</code>
   
   <h3>Red Hat Enterprise Linux, Oracle Linux, CentOS, Scientific Linux, et al.</h3>
-  <p>RHEL and derivatives typically ship older versions of git.  If you cannot (or don't want to) compile git from source, you may need to use a 3rd-party repository such as <a href="https://ius.io/">the IUS Community Project</a> to obtain a more recent version of git.</p>
+  <p>RHEL and derivatives typically ship older versions of git. You can <a href="https://www.kernel.org/pub/software/scm/git/">download a tarball</a> and build from source, or use a 3rd-party repository such as <a href="https://ius.io/">the IUS Community Project</a> to obtain a more recent version of git.</p>
 
 </div>


### PR DESCRIPTION
Related to https://github.com/git/git-scm.com/issues/416

I added an obvious link at the top as well as another in the RHEL-and-friends section, as it explicitly mentioned building from source as an option but didn't provide a link.