### PR TITLE
Fix git-for-windows repo url

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,4 +1,4 @@
  - [ ] This issue is about **specifically** the [git-scm.com](https://git-scm.com) website and is **not** an issue about
      - [ ] Git (or its man pages), which should be raised with the [community](https://git-scm.com/community),
-     - [ ] Git for Windows, which should be raised at [git-for-windows/git](https://git-scm.com/community), or
+     - [ ] Git for Windows, which should be raised at [git-for-windows/git](https://github.com/git-for-windows/git), or
      - [ ] the contents of the Pro Git book, which should be raised at [progit/progit2](https://github.com/progit/progit2/issues).


### PR DESCRIPTION
Probably a copy paste error from https://github.com/git/git-scm.com/pull/944