### PR TITLE
Add more info to location of external sources

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,4 +1,5 @@
 - [ ] This issue is about **specifically** the [git-scm.com](https://git-scm.com) website and is **not** an issue about
-     - [ ] Git (or its man pages), which are located under https://git-scm.com/docs, should be raised with the [community](https://git-scm.com/community),
-     - [ ] Git for Windows, which should be raised at [git-for-windows/git](https://github.com/git-for-windows/git), or
-     - [ ] the contents of the Pro Git book, which are located under https://git-scm.com/book, should be raised at [progit/progit2](https://github.com/progit/progit2/issues).
+     - [ ] the Git documentation (a.k.a. man/help pages, i.e. anything with a URL starting with `https://git-scm.com/docs`), which should be raised with the [community](https://git-scm.com/community),
+     - [ ] the contents of the Pro Git book (i.e. anything with a URL starting with `https://git-scm.com/book` or its PDF versions), which should be raised at [progit/progit2](https://github.com/progit/progit2/issues).
+     - [ ] Git itself, which should also be raised with the [community](https://git-scm.com/community), or
+     - [ ] Git for Windows, which should be raised at [git-for-windows/git](https://github.com/git-for-windows/git).

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,4 +1,4 @@
- - [ ] This issue is about **specifically** the [git-scm.com](https://git-scm.com) website and is **not** an issue about
-     - [ ] Git (or its man pages), which should be raised with the [community](https://git-scm.com/community),
+- [ ] This issue is about **specifically** the [git-scm.com](https://git-scm.com) website and is **not** an issue about
+     - [ ] Git (or its man pages), which are located under https://git-scm.com/docs, should be raised with the [community](https://git-scm.com/community),
      - [ ] Git for Windows, which should be raised at [git-for-windows/git](https://github.com/git-for-windows/git), or
-     - [ ] the contents of the Pro Git book, which should be raised at [progit/progit2](https://github.com/progit/progit2/issues).
+     - [ ] the contents of the Pro Git book, which are located under https://git-scm.com/book, should be raised at [progit/progit2](https://github.com/progit/progit2/issues).

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,5 +1,6 @@
-- [ ] This issue is about **specifically** the [git-scm.com](https://git-scm.com) website and is **not** an issue about
-     - [ ] the Git documentation (a.k.a. man/help pages, i.e. anything with a URL starting with `https://git-scm.com/docs`), which should be raised with the [community](https://git-scm.com/community),
-     - [ ] the contents of the Pro Git book (i.e. anything with a URL starting with `https://git-scm.com/book` or its PDF versions), which should be raised at [progit/progit2](https://github.com/progit/progit2/issues).
-     - [ ] Git itself, which should also be raised with the [community](https://git-scm.com/community), or
-     - [ ] Git for Windows, which should be raised at [git-for-windows/git](https://github.com/git-for-windows/git).
+- [ ] This is **not** an issue about 
+     - the Git documentation (a.k.a. man/help pages, i.e. anything with a URL starting with `https://git-scm.com/docs`), which should be raised with the [community](https://git-scm.com/community),
+     - the contents of the Pro Git book (i.e. anything with a URL starting with `https://git-scm.com/book` or its PDF versions), which should be raised at [progit/progit2](https://github.com/progit/progit2/issues).
+     - Git itself, which should also be raised with the [community](https://git-scm.com/community), or
+     - Git for Windows, which should be raised at [git-for-windows/git](https://github.com/git-for-windows/git).
+     - and is actually about the website itself (e.g. website-specific content, JS, or CSS that doesn't seem to be doing its job correctly).


### PR DESCRIPTION
Add more info to location of external sources on issue template

As mentioned in #962, it is not clear to new users that some website content is extracted from other sources like the progit book and git man pages. This tries to improve a little but I think it could still be improved, but I don't have any good idea for now