### PR TITLE
Fix old URLs to the book

### DIFF
--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -60,11 +60,11 @@ class BooksController < ApplicationController
   def chapter
     chapter = params[:chapter].to_i
     section = params[:section].to_i
+    lang = params[:lang] || "en"
     chapter = @book.chapters.where(:number => chapter).first
     @content = chapter.sections.where(:number => section).first
     raise PageNotFound unless @content
-    @page_title = "Git - #{@content.title}"
-    render 'section'
+    return redirect_to "/book/#{lang}/v2/#{@content.slug}"
   end
 
   def update


### PR DESCRIPTION
A number of URLs are accepted and rendered directly, but doing so the
relative links are broken. This affects urls such as:

 * https://git-scm.com/book/ch4-1.html
 * https://git-scm.com/book/en/ch4-1.html

This change implements the redirect and fixes #967.