### PR TITLE
fix some n+1 ActiveRecord queries

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,6 +47,7 @@ group :development, :test do
   gem "sqlite3"
   gem 'byebug'
   gem 'ruby-prof'
+  gem 'bullet'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,6 +47,9 @@ GEM
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
     builder (3.2.2)
+    bullet (5.5.1)
+      activesupport (>= 3.0.0)
+      uniform_notifier (~> 1.10.0)
     byebug (3.1.2)
       columnize (~> 0.8)
       debugger-linecache (~> 1.2)
@@ -231,6 +234,7 @@ GEM
       kgio (~> 2.6)
       rack
       raindrops (~> 0.7)
+    uniform_notifier (1.10.0)
     webmock (1.18.0)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -244,6 +248,7 @@ DEPENDENCIES
   awesome_print
   better_errors
   binding_of_caller
+  bullet
   byebug
   coffee-rails
   compass-rails
@@ -284,5 +289,8 @@ DEPENDENCIES
   webmock
   yajl-ruby
 
+RUBY VERSION
+   ruby 2.1.8p440
+
 BUNDLED WITH
-   1.11.2
+   1.13.6

--- a/app/views/books/_chapter_listings.html.erb
+++ b/app/views/books/_chapter_listings.html.erb
@@ -2,7 +2,7 @@
   <% per_column = (@book.chapters.count / 3.0).ceil -%>
   <% start      = per_column * (column - 1)       -%>
   <% stop       = start + (per_column - 1)        -%>
-  <% @book.chapters[start..stop].each do |chapter| %>
+  <% @book.chapters.includes(:sections)[start..stop].each do |chapter| %>
   <% if chapter %>
   <% if chapter.sections.size > 0 %>
   <li class='chapter'>

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -47,7 +47,7 @@
   The entire Pro Git book, written by Scott Chacon and Ben Straub and published by Apress, is available here. All content is licensed under the <a href="https://creativecommons.org/licenses/by-nc-sa/3.0/">Creative Commons Attribution Non Commercial Share Alike 3.0 license</a>. Print versions of the book are available on <a href="http://www.amazon.com/Pro-Git-Scott-Chacon/dp/1484200772?ie=UTF8&camp=1789&creative=9325&creativeASIN=1430218339&linkCode=as2&tag=git-sfconservancy-20">Amazon.com</a>.</>
   </p>
   <ol class='book-toc'>
-    <% @book.chapters.each do |chapter| %>
+    <% @book.chapters.includes(:sections).each do |chapter| %>
     <% next if chapter.sections.size == 0 %>
     <li class='chapter'>
     <h2><%= chapter.cs_number %>. <a href="/book/<%= @book.code %>/v<%= @book.edition %>/<%=u chapter.sections.first.slug %>"><%= chapter.title %></a></h2>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -35,4 +35,10 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  config.after_initialize do
+    Bullet.enable = true
+    Bullet.alert = true
+    Bullet.bullet_logger = true
+  end
 end


### PR DESCRIPTION
Generating the book table-of-contents made a separate sql query for each chapter to get the section slugs. Doing it all in a single query reduces the page-load latency.