### PR TITLE
Remove the ebooks download sections

### DIFF
--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -14,25 +14,6 @@
       <img  src="/images/progit2.png" width="118" height="157"/>
       <div style="light">2nd Edition (2014)</div>
       <div class="switch"><a href="/book/<%= @book.code %>/v1">Switch to 1st Edition</a></div>
-      <div class="ebook-download">
-        <h2>Download Ebook</h2>
-        <div class="ebooks">
-          <% if @book.ebook_pdf %>
-            <a href="<%= @book.ebook_pdf %>"><img width="50px" src="/images/pdf.png"/></a>
-          <% end %>
-          <% if @book.ebook_epub %>
-            <a href="<%= @book.ebook_epub %>"><img width="50px" src="/images/epub.png"/></a>
-          <% end %>
-        </div>
-        <div class="ebooks">
-          <% if @book.ebook_mobi %>
-            <a href="<%= @book.ebook_mobi %>"><img width="50px" src="/images/mobi.png"/></a>
-          <% end %>
-          <% if @book.ebook_html %>
-            <a href="<%= @book.ebook_html %>"><img width="50px" src="/images/html.png"/></a>
-          <% end %>
-        </div>
-      </div>
     </div>
   <% else %>
     <div style="float:right;margin: -20px 40px 0 40px;">

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -3,7 +3,6 @@
 <%- @page_title = "Git - Book" %>
 
 <% content_for :sidebar do %>
-  <%= render 'ebooks' %>
   <%= render 'translations' %>
 <% end %>
 


### PR DESCRIPTION
The books are no longer update for download in ebook formats (pdf,
epub, kindle) since Atlas was down. Let's be bold and just remove
downloads for now.

A direct solution to #929 