### PR TITLE
books_controller: convert bogus xrefs to PageNotFound

### DIFF
--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -33,7 +33,9 @@ class BooksController < ApplicationController
   def link
     link = params[:link]
     @book = Book.where(:code => params[:lang], :edition => params[:edition]).first
+    raise PageNotFound unless @book
     xref = @book.xrefs.where(:name => link).first
+    raise PageNotFound unless xref
     return redirect_to "/book/#{@book.code}/v#{@book.edition}/#{ERB::Util.url_encode(xref.section.slug)}##{xref.name}" unless @content
   end
 


### PR DESCRIPTION
This started as an attempt to plug some 500's that the app generates. I specifically wanted to know if any of the config tweaks I've been making might be causing problems, so I started collecting the logs and looking for 500's. But there are many uninteresting ones.

I ended up giving up after fixing one class, because the majority seem to be malicious attack nonsense like:

```
/docs/git-show/index2.php?_SERVER[]=&_SERVER[REMOTE_ADDR]=%27.system(%27id%27).exit().%27&option=wrapper&module[module]=1
```

That obviously isn't a valid URL for the site, but the query-string causes some of the middleware to barf before it even gets to us (loading it locally, it dies with a Rack ParameterTypeError, `expected Hash (got Array) for param _SERVER`).

So anyway, here's the one fix, which is bogus xrefs for the book. You can trigger this easily with nonsense like:

If you give a bogus book link like:

```
/book/en/v2/ch00/foo
```

or even:

```
/book/en/v5/ch00/_getting_started
```

which returns a 500 instead of a 404.

It's not clear to me if some of these _should_ work, but I'll leave that to users to report the 404's. Here are a few examples:

```
/book/zh-tw/v2/ch00/callout_embedding_git_in_your_applications_CO1-3
```

```
/book/ru/v2/ch00/co_____________git__8217_____________________CO1-3
```

I don't know if those are made-up, or if we're generating them somewhere in our book text. And if we are, whether there's some bug or if those translations are simply missing those xrefs. At any rate, I think a 404 is more appropriate than a 500, so this is the obvious first step.

/cc @jnavila in case you have thoughts on the xrefs