### PR TITLE
crawl https://git-scm.com looking for broken links

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: ruby
 script: 'script/travis-ci'
 rvm:
@@ -5,4 +6,10 @@ rvm:
 notifications:
   email: false
 
-sudo: false
+matrix:
+  include:
+    - language: node_js
+      node_js: "6"
+      script: |
+        npm install broken-link-checker && \
+        $(npm bin)/blc https://git-scm.com -ro'


### PR DESCRIPTION
Adds a build matrix entry that uses the broken-link-checker node module to crawl
https://git-scm.com, searching through the site recursively, and attempting all
links, reporting if they succeed or fail. This should make it easier to identify
broken links on the site. (Closes #957.)

Also moves the sudo: line to the top of the file for style (it's a global build
matrix configuration, so it only seems right that it belongs with the other
global config settings up top).