### PR TITLE
update progit image in book list

### DIFF
--- a/app/views/doc/ext.html.erb
+++ b/app/views/doc/ext.html.erb
@@ -96,10 +96,10 @@
     <div class='column-left'>
       <ul class='books-list'>
         <li>
-          <a href="/book"><img src="/images/books/pro-git@2x.jpg" width="107" height="141" /></a>
+          <a href="/book"><img src="/images/progit2.png" width="107" height="141" /></a>
           <h4><a href="/book">Pro Git</a></h4>
           <p class='description'>
-            By Scott Chacon
+            By Scott Chacon and Ben Straub
             <img class="creative-commons" src="/images/creative-commons@2x.png" width="115" height="28" />
           </p>
         </li>


### PR DESCRIPTION
The book list had the cover and single author for the original edition of Pro Git. Let's use the updated materials (we already have the picture elsewhere in the repo).