### PR TITLE
drop "ebooks" template from all book sidebars

### DIFF
--- a/app/views/books/_ebooks.html.erb
+++ b/app/views/books/_ebooks.html.erb
@@ -1,5 +1,0 @@
-<% if @book.ebook_pdf %>
-<p>Download this book in <a href="<%= @book.ebook_pdf %>">PDF</a>,
-   <a href="<%= @book.ebook_mobi %>" type="application/x-mobipocket-ebook">mobi</a>,
-or <a href="<%= @book.ebook_epub %>" type="application/epub+zip">ePub</a> form for free.</p>
-<% end %>

--- a/app/views/books/section.html.erb
+++ b/app/views/books/section.html.erb
@@ -2,7 +2,6 @@
 <% @subsection = 'book' %>
 
 <% content_for :sidebar do %>
-  <%= render 'ebooks' %>
   <%= render 'translations' %>
   <%= render 'shared/related' %>
 <% end %>

--- a/app/views/doc/_ebooks.html.erb
+++ b/app/views/doc/_ebooks.html.erb
@@ -1,5 +1,0 @@
-<% if @book.ebook_pdf %>
-<p>Download this book in <a href="<%= @book.ebook_pdf %>">PDF</a>,
-   <a href="<%= @book.ebook_mobi %>" type="application/x-mobipocket-ebook">mobi</a>,
-or <a href="<%= @book.ebook_epub %>" type="application/epub+zip">ePub</a> form for free.</p>
-<% end %>

--- a/app/views/doc/book.html.erb
+++ b/app/views/doc/book.html.erb
@@ -3,7 +3,6 @@
 <%- @page_title = "Git - Book" %>
 
 <% content_for :sidebar do %>
-  <%= render 'ebooks' %>
   <%= render 'translations' %>
 <% end %>
 

--- a/app/views/doc/book_section.html.erb
+++ b/app/views/doc/book_section.html.erb
@@ -2,7 +2,6 @@
 <% @subsection = 'book' %>
 
 <% content_for :sidebar do %>
-  <%= render 'ebooks' %>
   <%= render 'translations' %>
   <%= render 'shared/related' %>
 <% end %>


### PR DESCRIPTION
We dropped this from the main book page in #983, but the template still appears in the individual section pages. The same rationale applies, and we should drop it everywhere.

We can also drop the templates entirely (we may bring back the links later, but we can resurrect them at that time).
