### PR TITLE
app/views/community: clarify subscription and archive are two separate things

### DIFF
--- a/app/views/community/index.html.erb
+++ b/app/views/community/index.html.erb
@@ -20,7 +20,7 @@
   </p>
 
   <p>
-    The <a href="https://public-inbox.org/git">archive</a> can be found on public-inbox. Click <a href="mailto:majordomo@vger.kernel.org?body=subscribe git">here</a> to subscribe.
+    By subscribing (click <a href="mailto:majordomo@vger.kernel.org?body=subscribe git">here</a>), you can make sure you're not missing follow-up discussions and you can also learn about other development in the community.  The list <a href="https://public-inbox.org/git">archive</a> can be found on public-inbox.
   </p>
 
   <p>


### PR DESCRIPTION
The original seounded as if it wanted to teach how to subscribe to
the public-inbox archive, which does not make much sense.  Separate
the two and then explain the benefit of subscribing a bit better by
taking suggestion made by Ævar on the mailing list (<878tkjk7m7.fsf@gmail.com>).

Signed-off-by: Junio C Hamano <gitster@pobox.com>