### PR TITLE
Add community links

### DIFF
--- a/app/views/community/index.html.erb
+++ b/app/views/community/index.html.erb
@@ -29,6 +29,7 @@
 
   <p>
     There is also <a href="https://groups.google.com/forum/?fromgroups#!forum/git-users">Git user mailing list</a> on Google Groups which is a nice place for beginners to ask about anything.
+    If you're a downstream packager of Git, consider joining the <a href="https://groups.google.com/forum/?fromgroups#!forum/git-packagers">Git packagers mailing list</a> for low-volume announcements from the developers, as well as other discussion related to packaging &amp; porting Git.
   </p>
 
   <h2> Bug Reporting </h2>

--- a/app/views/community/index.html.erb
+++ b/app/views/community/index.html.erb
@@ -60,6 +60,7 @@
 
   <p>
     If the manpages and this book aren’t enough and you need in-person help, you can try the <span class="highlight fixed">#git</span> channel on the Freenode IRC server (<strong>irc.freenode.net</strong>). These channels are regularly filled with hundreds of people who are all very knowledgeable about Git and are often willing to help.
+    The <span class="highlight fixed">#git-devel</span> channel welcomes Git development discussion, and might be able to help you contribute to Git.
   </p>
 
   <p>


### PR DESCRIPTION
Adds a note to the community page about the `#git-devel` IRC channel and the new git-packagers mailing list.