### PR TITLE
Add information for security relevant issues

### DIFF
--- a/app/views/community/index.html.erb
+++ b/app/views/community/index.html.erb
@@ -57,6 +57,13 @@
       guide</a> helpful for producing useful bug reports.
   </p>
 
+  <h2> Reporting Security Issues </h2>
+
+  <p>
+    Issues which are security relevant should be disclosed privately to
+    the <a href="mailto:git-security@googlegroups.com">Git Security</a> mailing list.
+  </p>
+
   <h2> IRC Channel </h2>
 
   <p>


### PR DESCRIPTION
It's not obvious from the git-scm.com website where to report security vulnerabilities in git.

This PR adds the missing information.