### PR TITLE
manpages: Add the technical pages to generation

### DIFF
--- a/lib/tasks/index.rake
+++ b/lib/tasks/index.rake
@@ -53,7 +53,7 @@ task :preindex => :environment do
     # find all the doc entries
     tree_info = @octokit.tree( repo, tree_sha, :recursive => true )
     tag_files = tree_info.tree
-    doc_files = tag_files.select { |ent| ent.path =~ /^Documentation\/(git.*|everyday|howto-index|user-manual|diff.*|fetch.*|merge.*|rev.*|pretty.*|pull.*)\.txt/ }
+    doc_files = tag_files.select { |ent| ent.path =~ /^Documentation\/(git.*|everyday|howto-index|user-manual|diff.*|fetch.*|merge.*|rev.*|pretty.*|pull.*|technical\/.*)\.txt/ }
 
     puts "Found #{doc_files.size} entries"
 
@@ -109,7 +109,8 @@ task :preindex => :environment do
 
       content = blob_content[entry.sha]
       expand!(content, tag_files, blob_content, categories)
-      asciidoc = Asciidoctor::Document.new(content, attributes: {'sectanchors' => ''})
+      content.gsub!(/link:technical\/(.*?)\.html\[(.*?)\]/, "link:\1\[\2\]")
+      asciidoc = Asciidoctor::Document.new(content, attributes: {'sectanchors' => ''}, doctype: 'book')
       asciidoc_sha = Digest::SHA1.hexdigest( asciidoc.source )
       doc = Doc.where( :blob_sha => asciidoc_sha ).first_or_create
       if rerun || !doc.plain || !doc.html

--- a/lib/tasks/index.rake
+++ b/lib/tasks/index.rake
@@ -53,7 +53,21 @@ task :preindex => :environment do
     # find all the doc entries
     tree_info = @octokit.tree( repo, tree_sha, :recursive => true )
     tag_files = tree_info.tree
-    doc_files = tag_files.select { |ent| ent.path =~ /^Documentation\/(git.*|everyday|howto-index|user-manual|diff.*|fetch.*|merge.*|rev.*|pretty.*|pull.*|technical\/.*)\.txt/ }
+    doc_files = tag_files.select { |ent| ent.path =~
+        /^Documentation\/(
+            git.* |
+            everyday |
+            howto-index |
+            user-manual |
+            diff.* |
+            fetch.* |
+            merge.* |
+            rev.* |
+            pretty.* |
+            pull.* |
+            technical\/.*
+        )\.txt/x
+    }
 
     puts "Found #{doc_files.size} entries"
 

--- a/lib/tasks/index.rake
+++ b/lib/tasks/index.rake
@@ -123,7 +123,7 @@ task :preindex => :environment do
 
       content = blob_content[entry.sha]
       expand!(content, tag_files, blob_content, categories)
-      content.gsub!(/link:technical\/(.*?)\.html\[(.*?)\]/, "link:\1\[\2\]")
+      content.gsub!(/link:technical\/(.*?)\.html\[(.*?)\]/, 'link:\1[\2]')
       asciidoc = Asciidoctor::Document.new(content, attributes: {'sectanchors' => ''}, doctype: 'book')
       asciidoc_sha = Digest::SHA1.hexdigest( asciidoc.source )
       doc = Doc.where( :blob_sha => asciidoc_sha ).first_or_create

--- a/lib/tasks/local_index.rake
+++ b/lib/tasks/local_index.rake
@@ -105,7 +105,7 @@ task :local_index => :environment do
 
         content = `git cat-file blob #{sha}`.chomp
         expand!(content, tag, categories)
-        content.gsub!(/link:technical\/(.*?)\.html\[(.*?)\]/, "link:\1\[\2\]")
+        content.gsub!(/link:technical\/(.*?)\.html\[(.*?)\]/, 'link:\1[\2]')
 
         asciidoc = Asciidoctor::Document.new(content, attributes: {'sectanchors' => ''})
         asciidoc_sha = Digest::SHA1.hexdigest( asciidoc.source )

--- a/lib/tasks/local_index.rake
+++ b/lib/tasks/local_index.rake
@@ -91,6 +91,7 @@ task :local_index => :environment do
 
         content = `git cat-file blob #{sha}`.chomp
         expand!(content, tag, categories)
+        content.gsub!(/link:technical\/(.*?)\.html\[(.*?)\]/, "link:\1\[\2\]")
 
         asciidoc = Asciidoctor::Document.new(content, attributes: {'sectanchors' => ''})
         asciidoc_sha = Digest::SHA1.hexdigest( asciidoc.source )

--- a/lib/tasks/local_index.rake
+++ b/lib/tasks/local_index.rake
@@ -107,7 +107,7 @@ task :local_index => :environment do
         expand!(content, tag, categories)
         content.gsub!(/link:technical\/(.*?)\.html\[(.*?)\]/, 'link:\1[\2]')
 
-        asciidoc = Asciidoctor::Document.new(content, attributes: {'sectanchors' => ''})
+        asciidoc = Asciidoctor::Document.new(content, attributes: {'sectanchors' => ''}, doctype: 'book')
         asciidoc_sha = Digest::SHA1.hexdigest( asciidoc.source )
 
         doc = Doc.where(:blob_sha => asciidoc_sha).first_or_create

--- a/lib/tasks/local_index.rake
+++ b/lib/tasks/local_index.rake
@@ -42,7 +42,7 @@ task :local_index => :environment do
       stag.save
 
       # find all the doc entries
-      entries = `git ls-tree #{tag}:Documentation`.strip.split("\n")
+      entries = `git ls-tree -r #{tag}:Documentation`.strip.split("\n")
       tree = entries.map do |e|
         mode, type, sha, path = e.split(' ')
         [path, sha, type]
@@ -58,7 +58,8 @@ task :local_index => :environment do
               merge.* |
               rev.* |
               pretty.* |
-              pull.*
+              pull.* |
+              technical\/.*
           )\.txt/x
       }
 
@@ -96,7 +97,7 @@ task :local_index => :environment do
 
       tree.each do |entry|
         path, sha, type = entry
-        path = path.gsub('.txt', '')
+        path = File.basename(path, '.txt' )
         next if doc_limit && path !~ /#{doc_limit}/
         file = DocFile.where(:name => path).first_or_create
 

--- a/lib/tasks/local_index.rake
+++ b/lib/tasks/local_index.rake
@@ -47,7 +47,20 @@ task :local_index => :environment do
         mode, type, sha, path = e.split(' ')
         [path, sha, type]
       end
-      tree = tree.select { |t| t.first =~ /^(git.*|everyday|howto-index|user-manual|diff.*|fetch.*|merge.*|rev.*|pretty.*|pull.*)\.txt/ }
+      tree = tree.select { |t| t.first =~
+          /^(
+              git.* |
+              everyday  |
+              howto-index |
+              user-manual |
+              diff.* |
+              fetch.* |
+              merge.* |
+              rev.* |
+              pretty.* |
+              pull.*
+          )\.txt/x
+      }
 
       puts "Found #{tree.size} entries"
       doc_limit = ENV['ONLY_BUILD_DOC']


### PR DESCRIPTION
The technical subdirectory is added to the list of processed
files. But the relative paths can not be processed correctly because
the route matching in the webserver doesn't expect subdirectories. So
we set everything at the same level.

This fixes #994 