### PR TITLE
Fix typos

### DIFF
--- a/app/views/blog/posts/2010-03-17-replace.markdown
+++ b/app/views/blog/posts/2010-03-17-replace.markdown
@@ -180,7 +180,7 @@ The other cool thing is that this is kept in our references:
 This means that it's easy to share our replacement with others, because we can
 push this to our server and other people can easily download it.  This is not that
 helpful in the history grafting scenario we've gone over here (since everyone
-would be downloading both histories anyhow, so why seperate them?) but it can
+would be downloading both histories anyhow, so why separate them?) but it can
 be useful in other circumstances.  I'll cover some other interesting scenarios
 in another post - I think this is probably enough to process for now.
 

--- a/app/views/blog/posts/2011-07-11-reset.html
+++ b/app/views/blog/posts/2011-07-11-reset.html
@@ -376,7 +376,7 @@ branch back to an older commit (the first commit you want to keep):</p>
 <p>
 Now you can see that your reachable history, the history you would push,
 now looks like you had one commit with the one file, then a second that both
-added the new file and modified the first to it's final state.
+added the new file and modified the first to its final state.
 </p>
 
 <h2>Check it out</h2>

--- a/lib/elasticsearch.rb
+++ b/lib/elasticsearch.rb
@@ -133,7 +133,7 @@ module ElasticSearch
 
     # Search this index using a post body
     #
-    #   types   - the type or types (comma seperated) to search
+    #   types   - the type or types (comma-separated) to search
     #   options - options hash for this search request
     #
     # Returns a hash, the parsed response body from elasticsearch
@@ -146,7 +146,7 @@ module ElasticSearch
 
     # Search this index using a query string
     #
-    #   types   - the type or types (comma seperated) to search
+    #   types   - the type or types (comma-separated) to search
     #   query   - the search query string
     #   options - options hash for this search request (optional)
     #
@@ -162,7 +162,7 @@ module ElasticSearch
 
     # Count results using a query string
     #
-    #   types   - the type or types (comma seperated) to search
+    #   types   - the type or types (comma-separated) to search
     #   query   - the search query string
     #   options - options hash for this search request (optional)
     #

--- a/lib/elasticsearch.rb
+++ b/lib/elasticsearch.rb
@@ -91,7 +91,7 @@ module ElasticSearch
 
     # Force a refresh of this index
     #
-    # This basically tells elasticsearch to flush it's buffers
+    # This basically tells elasticsearch to flush its buffers
     # but not clear caches (unlike a commit in Solr)
     # "Commits" happen automatically and are managed by elasticsearch
     #


### PR DESCRIPTION
Dear Upstream,

please pull these to get rid of some typos.

Regards, bedhanger

The following changes since commit 0ea6582dad294829651b23ab280c2917f7568e6b:

- Merge pull request #1025 from jnavila/add_git_technical_doc (2017-09-30 18:34:58 +0200)

are available in the Git repository at:

- https://github.com/bedhanger/git-scm.com.git, on branch `fix-typos`

for you to fetch changes up to f63005e56acf5fc1d1aeee78b8555acdb6c0aa62:

- Correct spelling: use 'its' when expressing ownership (2017-10-01 20:18:51 +0200)
----------------------------------------------------------------
bedhanger (3):

- elasticsearch.rb: correct spelling: 'comma seperated' -> 'comma-separated'
- 2010-03-17-replace.markdown: correct spelling: 'seperate' -> 'separate'
- Correct spelling: use 'its' when expressing ownership