### PR TITLE
Add PPA instructions for Ubuntu

### DIFF
--- a/app/views/downloads/download_linux.html.erb
+++ b/app/views/downloads/download_linux.html.erb
@@ -6,8 +6,9 @@
   <p>It is easiest to install Git on Linux using the preferred package manager of your Linux distribution. If you prefer to build from source, you can find the tarballs <a href="https://www.kernel.org/pub/software/scm/git/">on kernel.org</a>.</p>
 
   <h3>Debian/Ubuntu</h3>
+  <p>For the latest stable version for your release of Debian/Ubuntu</p>
   <code># apt-get install git</code>
-  <p>For Ubuntu to get the latest git version with all fixes/features</p>
+  <p>For Ubuntu you can add this PPA to get the latest stable git version from the developers</p>
   <code># add-apt-repository ppa:git-core/ppa</code>
   <code># apt update; apt install git</code>
   

--- a/app/views/downloads/download_linux.html.erb
+++ b/app/views/downloads/download_linux.html.erb
@@ -8,7 +8,7 @@
   <h3>Debian/Ubuntu</h3>
   <p>For the latest stable version for your release of Debian/Ubuntu</p>
   <code># apt-get install git</code>
-  <p>For Ubuntu you can add this PPA to get the latest stable git version from the developers</p>
+  <p>For Ubuntu, this PPA provides the latest stable upstream Git version</p>
   <code># add-apt-repository ppa:git-core/ppa</code>
   <code># apt update; apt install git</code>
   

--- a/app/views/downloads/download_linux.html.erb
+++ b/app/views/downloads/download_linux.html.erb
@@ -7,7 +7,10 @@
 
   <h3>Debian/Ubuntu</h3>
   <code># apt-get install git</code>
-
+  <p>For Ubuntu to get the latest git version with all fixes/features</p>
+  <code># add-apt-repository ppa:git-core/ppa</code>
+  <code># apt update; apt install git</code>
+  
   <h3>Fedora</h3>
   <code># yum install git</code> (up to Fedora 21)<br>
   <code># dnf install git</code> (Fedora 22 and later)


### PR DESCRIPTION
Since Debian and Ubuntu "stable" or LTS releases are typically far behind the Git team supported releases.

Atlassian BitBucket Server (on-premise) for example requires Git 2.2.x or higher, but Ubuntu 14.04 LTS only goes up to 1.9.1 in their repositories.