### PR TITLE
Fixes #1028: Adding a `banner` helper

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem 'rack-timeout'
 gem 'tilt'
 gem 'tire'
 gem 'unicorn'
+gem 'iso8601'
 
 gem 'json'
 gem 'yajl-ruby'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,6 +98,7 @@ GEM
     hashr (0.0.22)
     hike (1.2.3)
     i18n (0.8.1)
+    iso8601 (0.9.1)
     jquery-rails (4.3.1)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
@@ -274,6 +275,7 @@ DEPENDENCIES
   faraday_middleware
   foreman
   haml
+  iso8601
   jquery-rails
   json
   launchy

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -29,15 +29,28 @@ aside {
   margin-bottom: 35px;
 }
 
-#banner {
-    background-color: #fcbda5;
-    color: #855;
-    padding: 1.0em 100px;
-    margin-bottom: 30px;
-    font-size: 100%;
-}
-#banner a {
+.banner-message {
+  background-color: #fcbda5;
+  color: #855;
+  padding: 1.0em 100px;
+  margin-bottom: 30px;
+  font-size: 100%;
+  position: relative;
+
+  a {
     color: #C22;
+  }
+
+  .dismiss {
+    position: absolute;
+    top: 0;
+    right: 0;
+    border: none;
+    background: none;
+    width: 2em;
+    line-height: 2em;
+    padding: 0;
+  }
 }
 
 #content {


### PR DESCRIPTION
This allows for consistent banner messaging across the site, with the option to be dismissible, and reappear after a given duration. Closes #1028.

Probably worth noting that Ruby is not my strong point, but this seems to do the trick.

## Usage

```erb
<%= banner 'regular-campaign' do %>
  This is a regular banner, that behaves as banners always have.
<% end %>
```
![A regular banner](https://user-images.githubusercontent.com/159848/31311093-d9ed80ba-ab72-11e7-95bb-1f5713d53e12.png)

```erb
<%= banner 'dismissible-campaign', dismissible: true do %>
  This is a dismissible banner, that will stay hidden once the
  end user has closed it.
<% end %>
```
![A dismissible banner](https://user-images.githubusercontent.com/159848/31311102-0f0399b0-ab73-11e7-9a43-4f64d1caa246.png)

```erb
<%= banner 'reappearing-campaign', dismissible: true, duration: 'P7D' do %>
  This is a dismissible banner, that will reappear 7 days after
  the end user has closed it.
<% end %>
```

![A reappearing banner](https://user-images.githubusercontent.com/159848/31311105-329d6e3c-ab73-11e7-8f8f-43f0d02b5aa8.png)
