### PR TITLE
index.rake: uncomment loop-next for found tags

### DIFF
--- a/lib/tasks/index.rake
+++ b/lib/tasks/index.rake
@@ -13,7 +13,7 @@ def index_doc(filter_tags, doc_list, get_content)
     puts "#{name}: #{ts}, #{commit_sha[0, 8]}, #{tree_sha[0, 8]}"
     
     stag = Version.where(:name => name.gsub('v','')).first
-    #next if stag && !rerun
+    next if stag && !rerun
 
     stag = Version.where(:name => name.gsub('v','')).first_or_create
     


### PR DESCRIPTION
If we've already got a version for a particular tag, we don't need to reimport it. However, in the transition to the shared local/preindex code, this line got commented out (probably because it was useful for debugging and got left in).

You can always override it setting the RERUN environment variable.
