### PR TITLE
doc_file: remove limit on version_changes

### DIFF
--- a/app/models/doc_file.rb
+++ b/app/models/doc_file.rb
@@ -6,10 +6,10 @@ class DocFile < ActiveRecord::Base
 
   scope :with_includes, ->{ includes(:doc_versions => [:doc, :version]) }
 
-  def version_changes(limit_size = 100)
+  def version_changes()
     unchanged_versions = []
     changes = []
-    doc_versions = self.doc_versions.includes(:version).version_changes.limit(limit_size).to_a
+    doc_versions = self.doc_versions.includes(:version).version_changes.to_a
     doc_versions.each_with_index do |doc_version, i|
       next unless previous_doc_version = doc_versions[i+1]
       sha2 = doc_version.doc.blob_sha


### PR DESCRIPTION
This method is called to fill in the "which versions of Git touched this manpage" dropdown on all of the manual pages. It's reasonably expensive to compute, since it has to get a complete list of all of the versions that contain the file and then walk over them in order to see which ones have changed (and compute their diffs!).

For this reason the function by default limits us to looking at 100 tags. But this limit is done at the database level, meaning these aren't necessarily 100 _interesting_ tags that actually touch the file. In fact, some infrequently-touched files (like `git cherry`) don't have any modifications in the past 100 tags (which only goes back to around the 2.0.x era).

One can argue that tags older than that aren't really interesting, but the list looks odd when there are no changes at all. Let's remove the limit. These pages _are_ expensive to generate, but given the aggressive caching we've put in front of the site these days, it's probably OK.
