### PR TITLE
add raygun to gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem 'rack-timeout'
 gem 'tilt'
 gem 'tire'
 gem 'unicorn'
+gem 'raygun4ruby'
 
 gem 'json'
 gem 'yajl-ruby'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,6 +68,7 @@ GEM
       sass (~> 3.2.19)
     compass-rails (2.0.0)
       compass (>= 0.12.2)
+    concurrent-ruby (1.0.5)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     database_cleaner (1.5.3)
@@ -97,6 +98,8 @@ GEM
     hashdiff (0.3.4)
     hashr (0.0.22)
     hike (1.2.3)
+    httparty (0.15.6)
+      multi_xml (>= 0.5.2)
     i18n (0.8.1)
     jquery-rails (4.3.1)
       rails-dom-testing (>= 1, < 3)
@@ -114,6 +117,7 @@ GEM
     mini_portile2 (2.1.0)
     minitest (5.10.1)
     multi_json (1.12.1)
+    multi_xml (0.6.0)
     multipart-post (2.0.0)
     netrc (0.11.0)
     nokogiri (1.7.1)
@@ -158,6 +162,11 @@ GEM
       thor (>= 0.18.1, < 2.0)
     raindrops (0.18.0)
     rake (12.0.0)
+    raygun4ruby (2.5.0)
+      concurrent-ruby
+      httparty (> 0.13.7)
+      json
+      rack
     redcarpet (3.4.0)
     redis (3.3.3)
     redis-actionpack (5.0.1)
@@ -285,6 +294,7 @@ DEPENDENCIES
   rails (= 4.2.6)
   rails-perftest
   rails_12factor
+  raygun4ruby
   redcarpet
   redis-rails
   rspec-rails

--- a/config/initializers/raygun.rb
+++ b/config/initializers/raygun.rb
@@ -1,0 +1,7 @@
+Raygun.setup do |config|
+  config.api_key = ENV['RAYGUN_APIKEY']
+  config.filter_parameters = Rails.application.config.filter_parameters
+
+  # The default is Rails.env.production?
+  # config.enable_reporting = !Rails.env.development? && !Rails.env.test?
+end


### PR DESCRIPTION
We don't currently have any kind of logging or alerting on unhandled exceptions. I'm experimenting with Raygun's free "intro" plan so that I can at least get basic data like "what exceptions did we see today?".

This helped a lot with understanding what was going on with the spike I mentioned in https://github.com/git/git-scm.com/pull/1045#issuecomment-335882563. 
