### PR TITLE
Revert "Merge pull request #1045 from git/raise-version-limit"

### DIFF
--- a/app/models/doc_file.rb
+++ b/app/models/doc_file.rb
@@ -6,10 +6,10 @@ class DocFile < ActiveRecord::Base
 
   scope :with_includes, ->{ includes(:doc_versions => [:doc, :version]) }
 
-  def version_changes()
+  def version_changes(limit_size = 100)
     unchanged_versions = []
     changes = []
-    doc_versions = self.doc_versions.includes(:version).version_changes.to_a
+    doc_versions = self.doc_versions.includes(:version).version_changes.limit(limit_size).to_a
     doc_versions.each_with_index do |doc_version, i|
       next unless previous_doc_version = doc_versions[i+1]
       sha2 = doc_version.doc.blob_sha


### PR DESCRIPTION
That PR causes us to correctly generate the complete list of changed versions for each manpage. But as discussed in #1045, this is causing non-trivial numbers of timeouts on Heroku. I don't _think_ they're affecting a lot of users, but I'm not happy to see them at all.

So let's pull that back. The existing limits are actually pretty reasonable for what people might care about. The main reason I noticed at all is that there are some funny corner cases like `git cherry`, which hasn't been touched in the last 100 tags. But I'd rather consistently generate an answer that helps most people than sometimes timing out. Plus it's hard to distinguish these from real, serious errors on the site.

We may want to revisit this (perhaps by caching more aggressively, or even pre-computing the version history during the `preindex` import task). But that's no harder or easier to do atop a stable base with the limit.