### PR TITLE
Update "Git Beginner's Guide for Dummies" link URL in external-links …

### DIFF
--- a/app/views/doc/ext.html.erb
+++ b/app/views/doc/ext.html.erb
@@ -34,9 +34,10 @@
           </p>
         </li>
         <li>
-          <h4><a href="https://backlogtool.com/git-guide/en/">Git Beginner's Guide for Dummies</a></h4>
+          <h4><a href="https://backlog.com/git-tutorial/en/">Git Beginner's Guide for Dummies</a></h4>
           <p class='description'>
             This guide includes an introduction for complete beginners as well as hands-on tutorials for intermediate learners.
+            ( <a href="https://backlog.com/git-tutorial/kr/">Korean</a> / <a href="https://backlog.com/git-tutorial/cn/">Simplified Chinese</a> / <a href="https://backlog.com/git-tutorial/tw/">Traditional Chinese</a> / <a href="https://backlog.com/git-tutorial/vn/">Vietnamese</a> )
           </p>
         </li>
       </ul>


### PR DESCRIPTION
We changed the domain and URL of the Git tutorial added in external-links page in #434 pull request.
Also as we said in the pull request , we now have other languages version of the tutorial. ( Korean / Simplified Chinese / Traditional Chinese / Vietnamese )

This pull request changes the URL of English version and also add 4 language versions' links.

Thanks!