### PR TITLE
Revert "Merge pull request #1047 from git/raygun"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,6 @@ gem 'rack-timeout'
 gem 'tilt'
 gem 'tire'
 gem 'unicorn'
-gem 'raygun4ruby'
 
 gem 'json'
 gem 'yajl-ruby'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,7 +68,6 @@ GEM
       sass (~> 3.2.19)
     compass-rails (2.0.0)
       compass (>= 0.12.2)
-    concurrent-ruby (1.0.5)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     database_cleaner (1.5.3)
@@ -98,8 +97,6 @@ GEM
     hashdiff (0.3.4)
     hashr (0.0.22)
     hike (1.2.3)
-    httparty (0.15.6)
-      multi_xml (>= 0.5.2)
     i18n (0.8.1)
     jquery-rails (4.3.1)
       rails-dom-testing (>= 1, < 3)
@@ -117,7 +114,6 @@ GEM
     mini_portile2 (2.1.0)
     minitest (5.10.1)
     multi_json (1.12.1)
-    multi_xml (0.6.0)
     multipart-post (2.0.0)
     netrc (0.11.0)
     nokogiri (1.7.1)
@@ -162,11 +158,6 @@ GEM
       thor (>= 0.18.1, < 2.0)
     raindrops (0.18.0)
     rake (12.0.0)
-    raygun4ruby (2.5.0)
-      concurrent-ruby
-      httparty (> 0.13.7)
-      json
-      rack
     redcarpet (3.4.0)
     redis (3.3.3)
     redis-actionpack (5.0.1)
@@ -294,7 +285,6 @@ DEPENDENCIES
   rails (= 4.2.6)
   rails-perftest
   rails_12factor
-  raygun4ruby
   redcarpet
   redis-rails
   rspec-rails

--- a/config/initializers/raygun.rb
+++ b/config/initializers/raygun.rb
@@ -1,7 +1,0 @@
-Raygun.setup do |config|
-  config.api_key = ENV['RAYGUN_APIKEY']
-  config.filter_parameters = Rails.application.config.filter_parameters
-
-  # The default is Rails.env.production?
-  # config.enable_reporting = !Rails.env.development? && !Rails.env.test?
-end


### PR DESCRIPTION
I added Raygun support to get a handle on the exceptions we were seeing due to timeouts in #1045. That's now reverted, so the primary reason is gone.

Furthermore, the Intro plan only allows 500 exceptions per month, and we exceeded that pretty quickly. Most of these are just noise, so we may want to consider a service like this after cleaning them up. But in the meantime, it's not accomplishing anything.

The noisy exceptions seem to mostly be related to book languages with broken links or incomplete translations. They fall mainly into two buckets:

  - dereferencing nil for various items. E.g., hitting https://git-scm.com/book/sr/v1/%D0%9F%D0%BE%D1%87%D0%B5%D1%82%D0%B0%D0%BA-Getting-Help returns the 500 error page.

  - ActionController::BadRequest. E.g., hitting https://git-scm.com/book/ko/Git-%EC%EF%BF%BD%EF%BF%BD%EB%B2%EF%BF%BD-GitWeb returns no output
