### PR TITLE
tasks/index: make REBUILD_DOC imply RERUN

### DIFF
--- a/lib/tasks/index.rake
+++ b/lib/tasks/index.rake
@@ -6,7 +6,7 @@ require 'digest/sha1'
 def index_doc(filter_tags, doc_list, get_content)
   ActiveRecord::Base.logger.level = Logger::WARN
   rebuild = ENV['REBUILD_DOC']
-  rerun = ENV['RERUN'] || false
+  rerun = ENV['RERUN'] || rebuild || false
   
   filter_tags.call(rebuild).sort_by { |tag| tag.first}.each do |tag|
     name, commit_sha, tree_sha, ts = tag


### PR DESCRIPTION
There's not much point in asking for REBUILD_DOC without RERUN. So let's make the former imply the latter, as it's one less thng to remember when rebuilding an old version. This was also how it worked prior to the rewrite in #1027.

/cc @jnavila
