### PR TITLE
index.rake: order the build of manpages in ascending versions

### DIFF
--- a/lib/tasks/index.rake
+++ b/lib/tasks/index.rake
@@ -8,7 +8,7 @@ def index_doc(filter_tags, doc_list, get_content)
   rebuild = ENV['REBUILD_DOC']
   rerun = ENV['RERUN'] || false
   
-  filter_tags.call(rebuild).sort_by { |tag| tag.first}.each do |tag|
+  filter_tags.call(rebuild).sort_by { |tag| Version.version_to_num(tag.first[1..-1])}.each do |tag|
     name, commit_sha, tree_sha, ts = tag
     puts "#{name}: #{ts}, #{commit_sha[0, 8]}, #{tree_sha[0, 8]}"
     


### PR DESCRIPTION
Using a simple alphabetical sort did not lead to correctly ordering
the versions to build. It is not known if it has some effects on the
issue of presenting the versions out of order on the website, but it
is safer anyway to stick to correct ordering for insertions into the
database.