### PR TITLE
Add latest version available information on download 'monitor'

### DIFF
--- a/app/assets/javascripts/site.js
+++ b/app/assets/javascripts/site.js
@@ -45,14 +45,14 @@ var DownloadBox = {
     var os = window.session.browser.os; // Mac, Win, Linux
     if(os == "Mac") {
       $(".monitor").addClass("mac");
-      $("#download-link").text("Downloads for Mac").attr("href", "/download/mac");
+      $("#download-link").text("Download " + $("#installer-version").attr('data-mac') + " for Mac").attr("href", "/download/mac");
       $("#gui-link").removeClass('mac').addClass('gui');
       $("#gui-link").text("Mac GUIs").attr("href", "/download/gui/mac");
       $("#gui-os-filter").attr('data-os', 'mac');
       $("#gui-os-filter").text("Only show GUIs for my OS (Mac)")
     } else if (os == "Windows") {
       $(".monitor").addClass("windows");
-      $("#download-link").text("Downloads for Windows").attr("href", "/download/win");
+      $("#download-link").text("Download " + $("#installer-version").attr('data-win') + " for Windows").attr("href", "/download/win");
       $("#gui-link").removeClass('mac').addClass('gui');
       $("#gui-link").text("Windows GUIs").attr("href", "/download/gui/win");
       $("#alt-link").removeClass("windows").addClass("mac");
@@ -334,5 +334,3 @@ var AboutContent = {
     });
   }
 }
-
-

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -29,6 +29,16 @@ module ApplicationHelper
     end
   end
 
+  def latest_mac_installer
+    @mac_installer ||= Download.latest_for 'mac'
+    @mac_installer ? @mac_installer.version.name : ''
+  end
+
+  def latest_win_installer
+    @win_installer ||= Download.latest_for 'windows32'
+    @win_installer ? @win_installer.version.name : ''
+  end
+
   def latest_release_date
     begin
     @version ||= Version.latest_version

--- a/app/views/shared/_monitor.html.erb
+++ b/app/views/shared/_monitor.html.erb
@@ -10,6 +10,7 @@
   <span class="release-date">
     <%= latest_release_date %>
   </span>
+  <span data-mac="<%= latest_mac_installer %>" data-win="<%= latest_win_installer %>" id="installer-version"></span>
 
   <%= link_to "Download Source Code", "https://www.kernel.org/pub/software/scm/git/", {:class => 'button', :id => 'download-link'} %>
 </div>


### PR DESCRIPTION
The information depends on the platform the user is using to access the site.
For windows, since on the DB there are several windows versions
(windows32, windows64, windows32Portable, windows64Portable)
I decided to go with windows32. Portable versions are almost never the
ones we want. windows32 can always be installed, even on windows64, so
decided to go for a conservative approach.

patched from #186 

closes #268 