### PR TITLE
book2: Try to fix the book xref generation error

### DIFF
--- a/lib/tasks/book2.rake
+++ b/lib/tasks/book2.rake
@@ -395,9 +395,11 @@ task :genbook2 => :environment do
           (sec.search("section[@id]")+sec.search("figure[@id]")+sec.search("table[@id]")).each do |id|
             id_xref = id.attribute('id').to_s
             if id_xref[0,3] != 'idp'
-              xref = Xref.where(:book_id => book.id, :name => id_xref).first_or_create
-              xref.section = csection
-              xref.save
+              Xref.Transaction do
+                xref = Xref.where(:book_id => book.id, :name => id_xref).first_or_create
+                xref.section = csection
+                xref.save
+              end
             end
           end
 


### PR DESCRIPTION
This is a try-fix for the issued appeared while running book generation for  #1062 

Not being sure that the `#first_or_create` method tries to create the
record in db which would fail because the foreign relation fields is
missing at that time. A transaction protection is added to make sure
that all the fields are set up before saving.

If this fix turns out to be useful, then more sites are impacted.