### PR TITLE
remote_genbook2: handle repos with no releases

### DIFF
--- a/lib/tasks/book2.rake
+++ b/lib/tasks/book2.rake
@@ -234,8 +234,8 @@ task :remote_genbook2 => :environment do
       book = Book.where(:edition => 2, :code => code).first_or_create
       book.ebook_html = repo_head
 
-      rel = @octokit.latest_release(repo)
-      if rel
+      begin
+        rel = @octokit.latest_release(repo)
         get_url =   -> content_type do
           asset = rel.assets.select { |asset| asset.content_type==content_type}.first
           if asset
@@ -247,7 +247,7 @@ task :remote_genbook2 => :environment do
         book.ebook_pdf  = get_url.call("application/pdf")
         book.ebook_epub = get_url.call("application/epub+zip")
         book.ebook_mobi  = get_url.call("application/x-mobipocket-ebook")
-      else
+      rescue Octokit::NotFound
         book.ebook_pdf  = nil
         book.ebook_epub = nil
         book.ebook_mobi  = nil


### PR DESCRIPTION
If there are no releases for a translation, then we get an Octokit::NotFound exception when asking for the release
page. That causes us to skip our "book.save" call, meaning we never actually update the database with the newly
imported translation (and we just try it fruitlessly in every run).

We can fix that by rescuing the exception (the code was already designed to handle this case by looking for a nil
release list).

/cc @jnavila I think that most translations haven't been building updates since #1062 was merged.