### PR TITLE
re-add conservancy donation banner

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -21,6 +21,13 @@
 
 <body id="<%= @section %>">
 
+  <%= banner 'sfc-support-2017', dismissible: true do %>
+    Git is a member project of Software Freedom Conservancy, which
+    handles legal and financial needs for the project. Conservancy is
+    currently raising funds to continue their mission. Consider
+    <a href="https://sfconservancy.org/supporter/">becoming a supporter</a>!
+  <% end %>
+
   <div class="inner">
     <%= render partial: "shared/header" %>
   </div> <!-- .inner -->


### PR DESCRIPTION
It's the end of the tax year (when many people think about donations), and Conservancy has a matching donor set up. Let's run the donation banner for a few weeks, and take it down in January.

This uses the swank dismissible banner code added by @andrewhayward in #1034 (thanks!).