### PR TITLE
Include 'background-size' both outside and inside media query

### DIFF
--- a/app/assets/stylesheets/mixins.scss
+++ b/app/assets/stylesheets/mixins.scss
@@ -50,6 +50,7 @@
 
 @mixin background-image-2x($image_name, $w: auto, $h: auto, $pos: top right, $repeat: no-repeat, $ext: png) {
   background: transparent url($image_name + '.' + $ext) $pos $repeat;
+  background-size: $w $h;
   @media
     only screen and (-webkit-min-device-pixel-ratio: 2),
     only screen and (   min--moz-device-pixel-ratio: 2),


### PR DESCRIPTION
Fixes #1103.

Including the 'background-size' property twice is not exactly DRY but it
is required here as otherwise the 'background' shorthand property will
reset the 'background-size' to auto.