### PR TITLE
Revert "Update Ungit license"

### DIFF
--- a/resources/guis.yml
+++ b/resources/guis.yml
@@ -100,8 +100,8 @@ guis:
   - Windows
   - Mac
   - Linux
-  price: Free for individuals, subscription based for businesses
-  license: Ungit license (LYC)
+  price: Free
+  license: MIT
   order: 11
 - name: git-cola
   url: https://git-cola.github.io/


### PR DESCRIPTION
This reverts commit 3b6ac86f0e376988bfb3973b000e0d0e027aaddf.

Well, it's the equivalent, since between then and now all of the gui dated moved into a yaml file.

The reason is that the project moved back to MIT as mentioned in

  https://github.com/git/git-scm.com/pull/1057#issuecomment-356083297

/cc @FredrikNoren