### PR TITLE
Fix downloads view template

### DIFF
--- a/app/views/downloads/download_windows.html.erb
+++ b/app/views/downloads/download_windows.html.erb
@@ -52,7 +52,7 @@
       <a href="/downloads/guis">
       <img src="/images/icons/nav-download-gui.png" />
       <h3>Download a GUI</h3>
-      <p>Several free and commercial GUI tools are available for the #{@platform.capitalize} platform.</p>
+      <p><%= raw "Several free and commercial GUI tools are available for the #{@platform.capitalize} platform." %></p>
       </a>
     </li>
     <li>

--- a/app/views/downloads/downloading.html.erb
+++ b/app/views/downloads/downloading.html.erb
@@ -37,7 +37,7 @@
       <a href="/downloads/guis">
       <img src="/images/icons/nav-download-gui.png" />
       <h3>Download a GUI</h3>
-      <p>Several free and commercial GUI tools are available for the #{@platform.capitalize} platform.</p>
+      <p><%= raw "Several free and commercial GUI tools are available for the #{@platform.capitalize} platform." %></p>
       </a>
     </li>
     <li>


### PR DESCRIPTION
Currently, the description under "Download a GUI" on the downloads page isn't parsing the template tag for the specific platform.

![git-scm com_download_win](https://user-images.githubusercontent.com/5957867/35124768-460307f4-fc75-11e7-845e-1f16d63efd42.png)

Based on the rest of the file, I believe these changes will fix that issue.