### PR TITLE
overview page: add link to git-worktree

### DIFF
--- a/app/views/shared/ref/_branching.html.erb
+++ b/app/views/shared/ref/_branching.html.erb
@@ -7,4 +7,5 @@
   <li><%= man('git-log') %></li>
   <li><%= man('git-stash') %></li>
   <li><%= man('git-tag') %></li>
+  <li><%= man('git-worktree') %></li>
 </ul>

--- a/config/initializers/categories.rb
+++ b/config/initializers/categories.rb
@@ -8,7 +8,7 @@ module Gitscm
       ['git-add', 'git-status', 'git-diff', 'git-commit', 'git-reset', 'git-rm', 'git-mv']
     ],['Branching and Merging',
       ['git-branch', 'git-checkout', 'git-merge',
-       'git-mergetool', 'git-log', 'git-stash', 'git-tag']
+       'git-mergetool', 'git-log', 'git-stash', 'git-tag', 'git-worktree']
     ],['Inspection and Comparison',
       ['git-show', 'git-log', 'git-diff', 'git-describe']
     ],['Patching',

--- a/lib/constants.rb
+++ b/lib/constants.rb
@@ -12,7 +12,7 @@ CMD_GROUPS = [
   ['Setup and Config', [ 'config', 'help' ]],
   ['Getting and Creating Projects', [ 'init', 'clone']],
   ['Basic Snapshotting', [ 'add', 'status', 'diff', 'commit', 'reset', 'rm', 'mv']],
-  ['Branching and Merging', [ 'branch', 'checkout', 'merge', 'mergetool', 'log', 'stash', 'tag' ]],
+  ['Branching and Merging', [ 'branch', 'checkout', 'merge', 'mergetool', 'log', 'stash', 'tag', 'worktree' ]],
   ['Sharing and Updating Projects', [ 'fetch', 'pull', 'push', 'remote', 'submodule' ]],
   ['Inspection and Comparison', [ 'show', 'log', 'diff', 'shortlog', 'describe' ]],
   ['Patching', ['am', 'apply', 'cherry-pick', 'rebase']],


### PR DESCRIPTION
It has been noted on
https://public-inbox.org/git/CACsJy8Dt_TjfRk05oNW8DXrdn6s_QV8NQZKnnrgGkj3WTN_=3A@mail.gmail.com/T/#t
that even though this is an official porcelain command there's no link
to it from /docs, fix that.

I have not run this version of the site (don't have the env to do
that), but replicated how we're listing mergetool, so this should
work.