### PR TITLE
Add Google Analytics

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,6 +2,15 @@
 <html lang="en">
 
 <head>
+  <!-- Global site tag (gtag.js) - Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=UA-49925874-3"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', 'UA-49925874-3');
+  </script>
 
   <meta charset='utf-8'>
   <meta content='IE=edge,chrome=1' http-equiv='X-UA-Compatible'>

--- a/app/views/layouts/errors.html.erb
+++ b/app/views/layouts/errors.html.erb
@@ -1,5 +1,15 @@
 <html lang="en">
   <head>
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-49925874-3"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'UA-49925874-3');
+    </script>
+
     <meta charset="utf-8" />
     <meta content="IE=edge,chrome=1" http-equiv="X-UA-Compatible" />
     <link href="errors.css"


### PR DESCRIPTION
Once upon a time the site had GA hooked up, but it was taken out at some point. I'm currently working on a proposal to refresh of the site design a bit and I'd like to have better insight into which sections get the most traffic. My assumption is the docs and the Pro Git book are the bulk of the page views. Testing these assumptions will help inform how we can improve the global and secondary navigation of the site.

I have added the Git site as a property under my Google account, but I'm able to add others with various permissions. I just need an email address to invite folks.

FWIW, the docs say to add the GA snippet as the first thing in the `<head>` tag. This is different than their instructions from yesteryear.

/cc @peff 