### PR TITLE
add "about this site" page

### DIFF
--- a/MIT-LICENSE.txt
+++ b/MIT-LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2012 Scott Chacon
+Copyright (c) 2012-2018 Scott Chacon and others
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,7 +1,7 @@
 <footer>
   <div class="site-source">
-    This <a href="https://github.com/git/git-scm.com/blob/master/README.md#license">open sourced</a> site is <a href="https://github.com/git/git-scm.com">hosted on GitHub.</a><br>
-    Patches, suggestions and comments are welcome.
+    <a href="/site">About this site</a><br>
+    Patches, suggestions, and comments are welcome.
   </div>
   <div class="sfc-member">
     Git is a member of <a href="/sfc">Software Freedom Conservancy</a>

--- a/app/views/site/about.html.erb
+++ b/app/views/site/about.html.erb
@@ -1,0 +1,70 @@
+<div id="main">
+  <h1>About git-scm.com</h1>
+
+  This site is open source and maintained by members of the Git
+  community.  We welcome patches, suggestions, and corrections.
+
+  <h2>Open Source</h2>
+
+  The content on this site is pulled from multiple sources. It is
+  available under various licenses, and bugs reports should be directed
+  to the appropriate repositories:
+
+  <ul>
+
+    <li>Most of the "base" site content is hosted in the
+    <a href="https://github.com/git/git-scm.com">git/git-scm.com</a>
+    repository at GitHub. That includes all pages except the book and
+    manpages, along with the general design of the site. This content
+    is available under the
+    <a href="https://github.com/git/git-scm.com/blob/master/MIT-LICENSE.txt">MIT license</a>.
+    Bug reports and suggestions may be made in that repository.
+
+    <li>Content from the ProGit book is imported from the
+    <a href="https://github.com/progit/progit2">progit/progit2</a>
+    repository, which is available under a Creative Commons
+    <a href="https://creativecommons.org/licenses/by-nc-sa/3.0/">CC-BY-NC-SA</a>
+    license, <a href="https://github.com/progit/progit2/blob/master/LICENSE.asc">
+    as specified in the progit2 repository</a>.
+    Bug reports and suggestions may be made in the progit2 repository.
+
+    <li>The reference manual is imported from the Git project, and is
+    available under the <a href="https://github.com/git/git/blob/master/COPYING">GPL</a>.
+    Bug reports and suggestions should be made to the upstream
+    <a href="/community">Git community</a>.
+
+    <li>Bugs in the Git software itself should similarly go to the
+    <a href="/community">Git community</a>.
+
+  </ul>
+
+  <h2>Authors</h2>
+
+  <p>This site was originally conceived and written by
+  <a href="https://github.com/schacon">Scott Chacon</a>.
+  Much of the current visual design is the work of
+  <a href="https://github.com/jasonlong">Jason Long</a>.
+  The site is currently collaboratively maintained in the
+  <a href="https://github.com/git/git-scm.com">git-scm.com</a>
+  repository at GitHub.
+
+  <p>Credit also goes to the many contributors, bug reporters, and
+  maintainers over the years, both in this repository and in others from
+  which we pull content. See the individual repository histories for a
+  complete list.
+
+  <h2>Sponsors</h2>
+
+  We are grateful to the companies which have donated resources and
+  services to keep the site running, including:
+
+  <ul>
+    <li><a href="https://heroku.com">Heroku</a>
+    <li><a href="https://cloudflare.com">Cloudflare</a>
+    <li><a href="https://bonsai.io/">Bonsai</a>
+  </ul>
+
+  For a detailed view of the site's network layout, see our
+  <a href="https://github.com/git/git-scm.com/blob/master/ARCHITECTURE.md">architecture document</a>.
+
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -83,6 +83,7 @@ Gitscm::Application.routes.draw do
 
   get "/course/svn" => "site#svn"
   get "/sfc" => "site#sfc"
+  get "/site" => "site#about"
   get "/trademark" => redirect("/about/trademark")
 
   get "/contributors" => redirect("https://github.com/git/git/graphs/contributors")


### PR DESCRIPTION
I've long wanted a place to give more discussion on how to report site bugs (and hopefully direct reports to the proper repos), as well as to credit the fiscal sponsors of the site. This adds such a page, and links it from the footer (instead of linking straight to the github repository).

I think the page could probably use a little visual sprucing-up, but I'd just as soon wait for @jasonlong's redesign work.