### PR TITLE
docs: include SubmittingPatches

### DIFF
--- a/lib/tasks/index.rake
+++ b/lib/tasks/index.rake
@@ -26,6 +26,8 @@ def index_doc(filter_tags, doc_list, get_content)
     tag_files = doc_list.call(tree_sha)
     doc_files = tag_files.select { |ent| ent.first =~
         /^Documentation\/(
+          SubmittingPatches |
+          (
             git.* |
             everyday |
             howto-index |
@@ -37,7 +39,7 @@ def index_doc(filter_tags, doc_list, get_content)
             pretty.* |
             pull.* |
             technical\/.*
-        )\.txt/x }
+        )\.txt)/x }
  
     puts "Found #{doc_files.size} entries"
     doc_limit = ENV['ONLY_BUILD_DOC']


### PR DESCRIPTION
SubmittingPatches was recently changed upstream to be formatted in
AsciiDoc.  However, it isn't included in the built documentation because
it doesn't end in .txt.  Update the index tasks to be aware of its
special nature and include it when building the documentation.

No tests are included because the rake tasks are untested.