### PR TITLE
Fix links to the wrong Git web interface

### DIFF
--- a/app/views/community/index.html.erb
+++ b/app/views/community/index.html.erb
@@ -39,7 +39,7 @@
     details). Note that you do not need to subscribe to the list to send
     to it. You can help us out by attempting to reproduce the bug in the latest
     released version of git, or if you're willing to build git from source, the
-    <a href="https://github.com/git/git/tree/next"><code>next</code> branch</a>.
+    <a href="https://git.kernel.org/pub/scm/git/git.git/?h=next"><code>next</code> branch</a>.
     Sometimes an attempted fix may be pending in this branch, in which case
     your feedback as to whether the fix worked for you will be appreciated.
   </p>
@@ -78,5 +78,5 @@
   <h2> Contributing to Git </h2>
 
   <p>
-    The <a href="https://github.com/git/git/tree/master/Documentation">Documentation directory</a> in the Git source code has several files of interest to developers who are looking to help contribute. After reading the <a href="https://github.com/git/git/blob/master/Documentation/CodingGuidelines">coding guidelines</a>, you can learn <a href="https://github.com/git/git/blob/master/Documentation/SubmittingPatches">how to submit patches</a>. For those looking to get more deeply involved, there is a <a href="https://github.com/git/git/blob/master/Documentation/howto/maintain-git.txt">howto for Git maintainers</a>.
+    The <a href="https://git.kernel.org/pub/scm/git/git.git/tree/Documentation">Documentation directory</a> in the Git source code has several files of interest to developers who are looking to help contribute. After reading the <a href="https://git.kernel.org/pub/scm/git/git.git/tree/Documentation/CodingGuidelines">coding guidelines</a>, you can learn <a href="https://git.kernel.org/pub/scm/git/git.git/tree/Documentation/SubmittingPatches">how to submit patches</a>. For those looking to get more deeply involved, there is a <a href="https://git.kernel.org/pub/scm/git/git.git/tree/Documentation/howto/maintain-git.txt">howto for Git maintainers</a>.
   </p>

--- a/app/views/downloads/index.html.erb
+++ b/app/views/downloads/index.html.erb
@@ -28,7 +28,7 @@
         </table>
       </div>
       <p>
-        <a href="https://www.kernel.org/pub/software/scm/git/">Older releases</a> are available and the <a href="https://github.com/git/git">Git source repository</a> is on GitHub.
+        <a href="https://www.kernel.org/pub/software/scm/git/">Older releases</a> are available and the <a href="https://git.kernel.org/pub/scm/git/git.git/">Git source repository</a> is available on kernel.org.
       </p>
     </div>
     <div class="column-right">
@@ -64,9 +64,9 @@
     If you already have Git installed, you can get the latest development version via Git itself:
   </p>
   <code>
-    git clone https://github.com/git/git
+    git clone https://git.kernel.org/pub/scm/git/git.git
   </code>
   <p>
-    You can also always browse the current contents of the git repository using the <a href="https://github.com/git/git">web interface</a>.
+    You can also always browse the current contents of the git repository using the <a href="https://git.kernel.org/pub/scm/git/git.git/">web interface</a>.
   </p>
 </div>

--- a/app/views/site/about.html.erb
+++ b/app/views/site/about.html.erb
@@ -29,7 +29,7 @@
     Bug reports and suggestions may be made in the progit2 repository.
 
     <li>The reference manual is imported from the Git project, and is
-    available under the <a href="https://github.com/git/git/blob/master/COPYING">GPL</a>.
+    available under the <a href="https://git.kernel.org/pub/scm/git/git.git/tree/COPYING">GPL</a>.
     Bug reports and suggestions should be made to the upstream
     <a href="/community">Git community</a>.
 

--- a/app/views/site/index.html.erb
+++ b/app/views/site/index.html.erb
@@ -51,7 +51,7 @@
       </tr>
       <tr>
         <td nowrap="true"><%= link_to "Windows Build", "/download/win", class: 'icon windows', id: 'alt-link' %></td>
-        <td nowrap="true"><%= link_to "Source Code", "https://github.com/git/git", class: 'icon source' %></td>
+        <td nowrap="true"><%= link_to "Source Code", "https://git.kernel.org/pub/scm/git/git.git/", class: 'icon source' %></td>
       </tr>
     </table>
 </section>


### PR DESCRIPTION
I have corrected links to the GitHub mirror of the official Git repository.