### PR TITLE
Fix git for windows version parsing

### DIFF
--- a/app/services/download_service.rb
+++ b/app/services/download_service.rb
@@ -23,9 +23,10 @@ class DownloadService
         next unless match
 
         portable = match[1]
+        version_name = match [2]
         bitness  = match[3]
 
-        version = find_or_create_version_by_name(name)
+        version = find_or_create_version_by_name(version_name)
 
         find_or_create_download(
           filename:     name,

--- a/app/services/download_service.rb
+++ b/app/services/download_service.rb
@@ -30,13 +30,17 @@ class DownloadService
         version_name = match[2].slice(/^\d+\.\d+\.\d+/)
         version = find_version_by_name(version_name)
 
-        find_or_create_download(
-          filename:     name,
-          platform:     "windows#{bitness}#{portable}",
-          release_date: date,
-          version:      version,
-          url:          url
-        )
+        if version
+          find_or_create_download(
+              filename: name,
+              platform: "windows#{bitness}#{portable}",
+              release_date: date,
+              version: version,
+              url: url
+          )
+        else
+          Rails.logger.info("Could not find version #{version_name}")
+        end
       end
     end
 
@@ -52,13 +56,17 @@ class DownloadService
 
         version = find_version_by_name(name)
 
-        find_or_create_download(
-          filename:     name,
-          platform:     'mac',
-          release_date: date,
-          version:      version,
-          url:          url
-        )
+        if version
+          find_or_create_download(
+              filename: name,
+              platform: 'mac',
+              release_date: date,
+              version: version,
+              url: url
+          )
+        else
+          Rails.logger.info("Could not find version #{name}")
+        end
       end
     end
 

--- a/app/services/download_service.rb
+++ b/app/services/download_service.rb
@@ -23,9 +23,11 @@ class DownloadService
         next unless match
 
         portable = match[1]
-        version_name = match [2]
         bitness  = match[3]
 
+        # Git for windows sometimes creates extra releases all based off of the same upstream Git version
+        # so we want to crop versions like 2.16.1.4 to just 2.16.1
+        version_name = match[2].slice(/^\d+\.\d+\.\d+/)
         version = find_or_create_version_by_name(version_name)
 
         find_or_create_download(

--- a/app/services/download_service.rb
+++ b/app/services/download_service.rb
@@ -28,7 +28,7 @@ class DownloadService
         # Git for windows sometimes creates extra releases all based off of the same upstream Git version
         # so we want to crop versions like 2.16.1.4 to just 2.16.1
         version_name = match[2].slice(/^\d+\.\d+\.\d+/)
-        version = find_or_create_version_by_name(version_name)
+        version = find_version_by_name(version_name)
 
         find_or_create_download(
           filename:     name,
@@ -50,7 +50,7 @@ class DownloadService
         url  = sourceforge_project_download_url('git-osx-installer', name)
         name = match[1]
 
-        version = find_or_create_version_by_name(name)
+        version = find_version_by_name(name)
 
         find_or_create_download(
           filename:     name,
@@ -114,10 +114,12 @@ class DownloadService
       end
     end
 
-    def find_or_create_version_by_name(name)
-      Version.find_by(name: name) || Version.create(name: name)
-    rescue ActiveRecord::RecordNotUnique
-      retry
+    def find_version_by_name(name)
+      # We assume the preindex rake task ran previously and saved possible new versions into the storage.
+      # Otherwise this code should also create the versions, while the preindex task needs to be updated to deal
+      # with versions imported by other tasks without importing the docs.
+      # More details at https://github.com/git/git-scm.com/pull/1207.
+      Version.find_by(name: name)
     end
   end
 end

--- a/spec/services/download_service_spec.rb
+++ b/spec/services/download_service_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe DownloadService do
       subject.download_mac_versions
     end
 
-    it 'reaches out to Sourceforge for relases' do
+    it 'reaches out to Sourceforge for releases' do
       expect(WebMock).to have_requested(:get, 'https://sourceforge.net/projects/git-osx-installer/rss?limit=20')
     end
 


### PR DESCRIPTION
close #1206 

ps: I would like to add/update some tests to avoid breaking this logic again, but I have to explore a bit how to work on vcr

Previous logic was changed during the refactor at
https://github.com/git/git-scm.com/commit/0f4974ec4cfbf3c5c897b2c7e2357d23f1002fa0#diff-2426dabc6613c25dd009ffe7b4a91788

The 'versions' table should contain a single entry for each git released version (only 1 entry for git 2.17.0 for instance),
but currently we have a version named 2.17.0 (found during the parsing of the mac downloads) and another named
Git-2.17.0 found during the parsing of the windows downloads.

The 'downloads' table can/should have more than 1 entry for each version. It should contain an entry for each OS/bitness/portability combination.