### PR TITLE
Minor improvements to rake tasks

### DIFF
--- a/app/services/download_service.rb
+++ b/app/services/download_service.rb
@@ -73,8 +73,9 @@ class DownloadService
     private
 
     def files_from_github(repository)
+      @octokit = Octokit::Client.new(:login => ENV['API_USER'], :password => ENV['API_PASS'])
       downloads = []
-      releases  = Octokit.client.releases(repository)
+      releases  = @octokit.releases(repository)
 
       releases.each do |release|
         release.assets.each do |asset|

--- a/lib/tasks/index.rake
+++ b/lib/tasks/index.rake
@@ -8,7 +8,7 @@ def index_doc(filter_tags, doc_list, get_content)
   rebuild = ENV['REBUILD_DOC']
   rerun = ENV['RERUN'] || rebuild || false
   
-  filter_tags.call(rebuild).sort_by { |tag| Version.version_to_num(tag.first[1..-1])}.reverse.each do |tag|
+  filter_tags.call(rebuild).sort_by { |tag| Version.version_to_num(tag.first[1..-1])}.each do |tag|
     name, commit_sha, tree_sha, ts = tag
     puts "#{name}: #{ts}, #{commit_sha[0, 8]}, #{tree_sha[0, 8]}"
     

--- a/lib/tasks/index.rake
+++ b/lib/tasks/index.rake
@@ -8,7 +8,7 @@ def index_doc(filter_tags, doc_list, get_content)
   rebuild = ENV['REBUILD_DOC']
   rerun = ENV['RERUN'] || rebuild || false
   
-  filter_tags.call(rebuild).sort_by { |tag| Version.version_to_num(tag.first[1..-1])}.each do |tag|
+  filter_tags.call(rebuild).sort_by { |tag| Version.version_to_num(tag.first[1..-1])}.reverse.each do |tag|
     name, commit_sha, tree_sha, ts = tag
     puts "#{name}: #{ts}, #{commit_sha[0, 8]}, #{tree_sha[0, 8]}"
     


### PR DESCRIPTION
While testing some stuff yesterday I noticed 2 possible improvements:

- The 'downloads' rake task doesn't use authenticated requests to github: this makes the rate limit much lower and I was facing a 'too many requests' response when running the task.

- The 'preindex' task starts populating by the lowest/oldest version. But most of the times we are interested in making the most recent providers available first (specially for local development). Not sure if there's any consequence, but from reading the code couldn't see anything obvious