### PR TITLE
Fixed text flash on os detection

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -74,6 +74,7 @@ var DownloadBox = {
       $("#gui-os-filter").attr('data-os', 'linux');
       $("#gui-os-filter").text("Only show GUIs for my OS (Linux)")
     } else {
+      $("#download-link").text("Download Source Code").attr("href", "https://www.kernel.org/pub/software/scm/git/");
     }
   }
 }

--- a/app/assets/stylesheets/front-page.scss
+++ b/app/assets/stylesheets/front-page.scss
@@ -113,6 +113,7 @@ $monitor-height: 271px;
     left: 24px;
 
     td {
+      min-width: 122px;
       padding: 8px 20px 6px 0;
     }
 

--- a/app/views/shared/_monitor.html.erb
+++ b/app/views/shared/_monitor.html.erb
@@ -12,5 +12,9 @@
   </span>
   <span data-mac="<%= latest_mac_installer %>" data-win="<%= latest_win_installer %>" id="installer-version"></span>
 
-  <%= link_to "Download Source Code", "https://www.kernel.org/pub/software/scm/git/", {:class => 'button', :id => 'download-link'} %>
+  <a class="button" id="download-link" href="https://www.kernel.org/pub/software/scm/git/">
+    <noscript>
+      Download Source Code
+    </noscript>
+  </a>
 </div>


### PR DESCRIPTION
- Updated `#download-link` to only display text before os detection if JS is disabled
  - This prevents a flash when the text changes
- Added a `min-width` to `#front-downloads table td`
  - This prevents an ugly resizing after os detection

---

I'm not sure if this is necessary with a rewrite going on (#1179), but this would be nice to have if the refresh isn't coming immediately. It's definitely a nit and not a priority fix.