### PR TITLE
Turn external link tutorials subsections 2 columns each

### DIFF
--- a/app/views/doc/_ext_tutorials.erb
+++ b/app/views/doc/_ext_tutorials.erb
@@ -1,7 +1,8 @@
 <h2>Tutorials</h2>
+
+<h3>Short &amp; Sweet</h3>
 <div class='two-column'>
   <div class='column-left'>
-    <h3>Short &amp; Sweet</h3>
     <ul class='content-list'>
       <li>
         <h4><a href="/docs/gittutorial">Official Git Tutorial</a></h4>
@@ -10,15 +11,19 @@
         </p>
       </li>
       <li>
-        <h4><a href="/docs/giteveryday">Everyday Git</a></h4>
-        <p class='description'>
-          Learn the basics with 20 of the most common commands.
-        </p>
-      </li>
-      <li>
         <h4><a href="http://gitimmersion.com/">Git Immersion</a></h4>
         <p class='description'>
           A guided tour that walks through the fundamentals of Git.
+        </p>
+      </li>
+    </ul>
+  </div>
+  <div class='column-right'>
+    <ul class='content-list'>
+      <li>
+        <h4><a href="/docs/giteveryday">Everyday Git</a></h4>
+        <p class='description'>
+          Learn the basics with 20 of the most common commands.
         </p>
       </li>
       <li>
@@ -30,8 +35,11 @@
       </li>
     </ul>
   </div>
-  <div class='column-right'>
-    <h3>Diving Deeper</h3>
+</div>
+
+<h3>Diving Deeper</h3>
+<div class='two-column'>
+  <div class='column-left'>
     <ul class='content-list'>
       <li>
         <h4><a
@@ -42,21 +50,9 @@
         </p>
       </li>
       <li>
-        <h4><a href="https://web.archive.org/web/20150301060509/http://hoth.entp.com/output/git_for_designers.html">Git for Designers</a></h4>
-        <p class='description'>
-          No knowledge of version control? No problem.
-        </p>
-      </li>
-      <li>
         <h4><a href="http://eagain.net/articles/git-for-computer-scientists/">Git for Computer Scientists</a></h4>
         <p class='description'>
           A quick introduction to Git internals for people who aren't scared by words like Directed Acyclic Graph.
-        </p>
-      </li>
-      <li>
-        <h4><a href="https://github.com/sensorflo/git-draw/wiki">git-draw</a></h4>
-        <p class='description'>
-          git-draw is a small tool that draws nearly the full content of a tiny git repository as a graph. It helps people with an engineering background learning Git's internals.
         </p>
       </li>
       <li>
@@ -66,21 +62,9 @@
         </p>
       </li>
       <li>
-        <h4><a href="https://help.github.com/">Help.GitHub</a></h4>
-        <p class='description'>
-          Guides on a variety of Git and GitHub related topics.
-        </p>
-      </li>
-      <li>
         <h4><a href="https://www.packtpub.com/application-development/git-version-control-made-easy">Git: Version Control Made Easy</a></h4>
         <p class='description'>
           Use the powerful features of Git in your projects.
-        </p>
-      </li>
-      <li>
-        <h4><a href="https://www.packtpub.com/web-development/version-control-git-video">Version Control with Git [Video]</a></h4>
-        <p class='description'>
-          Your Guide to deliver great code using TFS and Git.
         </p>
       </li>
       <li>
@@ -90,17 +74,45 @@
         </p>
       </li>
       <li>
+        <h4><a href="https://www.packtpub.com/application-development/hands-version-control-git-video">Hands-On Version Control with Git [Video]</a></h4>
+        <p class='description'>
+          Better project workflows with Distributed Version Control.
+        </p>
+      </li>
+    </ul>
+  </div>
+  <div class='column-right'>
+    <ul class='content-list'>
+      <li>
+        <h4><a href="https://web.archive.org/web/20150301060509/http://hoth.entp.com/output/git_for_designers.html">Git for Designers</a></h4>
+        <p class='description'>
+          No knowledge of version control? No problem.
+        </p>
+      </li>
+      <li>
+        <h4><a href="https://github.com/sensorflo/git-draw/wiki">git-draw</a></h4>
+        <p class='description'>
+          git-draw is a small tool that draws nearly the full content of a tiny git repository as a graph. It helps people with an engineering background learning Git's internals.
+        </p>
+      </li>
+      <li>
+        <h4><a href="https://help.github.com/">Help.GitHub</a></h4>
+        <p class='description'>
+          Guides on a variety of Git and GitHub related topics.
+        </p>
+      </li>
+      <li>
+        <h4><a href="https://www.packtpub.com/web-development/version-control-git-video">Version Control with Git [Video]</a></h4>
+        <p class='description'>
+          Your Guide to deliver great code using TFS and Git.
+        </p>
+      </li>
+      <li>
         <h4><a href="https://www.packtpub.com/application-development/conquering-git-advanced-training-guide-video">Conquering Git: Advanced Training Guide [Video]</a></h4>
         <p class='description'>
           Master versioning and manage your code with Git by controlling its workflow and using it for your projects.
         </p>
       </li>
-       <li>
-        <h4><a href="https://www.packtpub.com/application-development/hands-version-control-git-video">Hands-On Version Control with Git [Video]</a></h4>
-        <p class='description'>
-          Better project workflows with Distributed Version Control.
-        </p>
-      </li>     
     </ul>
   </div>
 </div>


### PR DESCRIPTION
Om external links, the Tutorials section has 2 subsections. One is using the left column,
while the other is using the right column. Since the number of items of each subsection
is now very different, the UI is not very simmetric and has a lot of white space.

This change makes each of the subsection to show it's elements on two columns, solving
these problems

Current UI:

![image](https://user-images.githubusercontent.com/1999050/41342184-8a731866-6ef3-11e8-875e-33206aa92ea5.png)

vs proposed solution:

![image](https://user-images.githubusercontent.com/1999050/41342198-92740e6c-6ef3-11e8-85f4-e349ef24f2bb.png)


