### PR TITLE
prune sections passed the last of each chapter

### DIFF
--- a/lib/tasks/book2.rake
+++ b/lib/tasks/book2.rake
@@ -173,6 +173,10 @@ def genbook (code, &get_content)
       section += 1
       pretext = ""
     end
+    while (schapter.sections.where(:number => section).any?)
+      schapter.sections.where(:number => section).destroy_all
+      section += 1
+    end
   end
   book.sections.each do |section|
     section.set_slug


### PR DESCRIPTION
For some reason, there might remain dangling sections that were left
from previous processing passed the last one of the current
processing. In this case, we need to tidy them up.

This is presently the case for the english version in chapter 10.