### PR TITLE
generate books from scratch

### DIFF
--- a/lib/tasks/book2.rake
+++ b/lib/tasks/book2.rake
@@ -79,7 +79,12 @@ def genbook (code, &get_content)
   alldoc = Nokogiri::HTML(html)
   number = 1
 
-  book = Book.where(:edition => 2, :code => code).first_or_create
+  book = Book.where(:edition => 2, :code => code).first
+  if book
+      book.destroy
+  end
+
+  book = Book.where(:edition => 2, :code => code).create
 
   alldoc.xpath("//div[@class='sect1']").each_with_index do |entry, index |
     chapter_title = entry.at("h2").content

--- a/lib/tasks/book2.rake
+++ b/lib/tasks/book2.rake
@@ -79,12 +79,8 @@ def genbook (code, &get_content)
   alldoc = Nokogiri::HTML(html)
   number = 1
 
-  book = Book.where(:edition => 2, :code => code).first
-  if book
-      book.destroy
-  end
-
-  book = Book.where(:edition => 2, :code => code).create
+  book = Book.where(:edition => 2, :code => code).destroy_all
+  book = Book.create(:edition => 2, :code => code)
 
   alldoc.xpath("//div[@class='sect1']").each_with_index do |entry, index |
     chapter_title = entry.at("h2").content


### PR DESCRIPTION
This should clean up the crufty chapter 10.10 we have in our database by running `heroku rake remote_genbook2 GENLANG=en` (and ditto, will prevent such reoccurences in automatic runs in the future).

It works by just blowing away the old book content before reimporting the new (and doing it in an atomic transaction, so we never make anything worse).

/cc @jnavila