### PR TITLE
remove references to book edition 1

### DIFF
--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -12,7 +12,6 @@
     <div style="float:right;margin: -20px 40px 0 40px;">
       <img  src="/images/progit2.png" width="118" height="157"/>
       <div style="light">2nd Edition (2014)</div>
-      <div class="switch"><a href="/book/<%= @book.code %>/v1">Switch to 1st Edition</a></div>
       <% if (@book.ebook_pdf || @book.ebook_epub || @book.ebook_mobi) %>
       <div class="ebook-download">
         <h2>Download Ebook</h2>
@@ -32,14 +31,6 @@
       </div>
       <% end %>
      </div>
-  <% else %>
-    <div style="float:right;margin: -20px 40px 0 40px;">
-      <img  src="/images/books/pro-git@2x.jpg" width="118" height="157"/>
-      <div>1st Edition (2009)</div>
-      <% if @book.has_edition(2) %>
-        <div class="switch"><a href="/book/<%= @book.code %>/v2">Switch to 2nd Edition</a></div>
-      <% end %>
-    </div>
   <% end %>
   <p>
   The entire Pro Git book, written by Scott Chacon and Ben Straub and published by Apress, is available here. All content is licensed under the <a href="https://creativecommons.org/licenses/by-nc-sa/3.0/">Creative Commons Attribution Non Commercial Share Alike 3.0 license</a>. Print versions of the book are available on <a href="http://www.amazon.com/Pro-Git-Scott-Chacon/dp/1484200772?ie=UTF8&camp=1789&creative=9325&creativeASIN=1430218339&linkCode=as2&tag=git-sfconservancy-20">Amazon.com</a>.</>


### PR DESCRIPTION
starts solving #1149 

We'll also need to:

* delete from the storage: `delete from books where edition == 2;`
* make sure the `lib/tasks/book.rake`, `lib/tasks/book2.rake`, and possible others, don't re-import the book