### PR TITLE
Filter out github draft and pre-releases

### DIFF
--- a/app/services/download_service.rb
+++ b/app/services/download_service.rb
@@ -79,15 +79,17 @@ class DownloadService
       downloads = []
       releases  = @octokit.releases(repository)
 
-      releases.each do |release|
-        release.assets.each do |asset|
-          downloads << [
-            asset.name,
-            asset.updated_at,
-            asset.browser_download_url
-          ]
-        end
-      end
+      releases
+          .reject{ |release| release.prerelease || release.draft }
+          .each do |release|
+            release.assets.each do |asset|
+              downloads << [
+                asset.name,
+                asset.updated_at,
+                asset.browser_download_url
+              ]
+            end
+          end
 
       downloads
     end

--- a/app/services/download_service.rb
+++ b/app/services/download_service.rb
@@ -80,7 +80,7 @@ class DownloadService
       releases  = @octokit.releases(repository)
 
       releases
-          .reject{ |release| release.prerelease || release.draft }
+          .reject { |release| release.prerelease || release.draft }
           .each do |release|
             release.assets.each do |asset|
               downloads << [


### PR DESCRIPTION
This addresses #1278, by excluding pre-releases like the git-for-windows 2.19.2 which should not be downloaded due to some. But this only makes sense if we delete the current git-for-windows 2.19.2 from the DB, but I'm not sure how the access the prod DB to delete it(cc @peff or @jnavila )