### PR TITLE
Remove unused metadata property of elastic documents

### DIFF
--- a/app/assets/stylesheets/search.scss
+++ b/app/assets/stylesheets/search.scss
@@ -55,16 +55,6 @@
         color: $font-color;
         transition-duration: 0s;
 
-        span.metadata {
-          display: block;
-          margin-top: -3px;
-          margin-bottom: 3px;
-          font-size: 11px;
-          font-weight: normal;
-          line-height: 1;
-          color: $light-font-color;
-        }
-
         &:hover,
         &.highlight {
           color: #fff;

--- a/app/views/shared/_search.html.erb
+++ b/app/views/shared/_search.html.erb
@@ -20,9 +20,6 @@
             <li>
               <%= link_to match[:url] do %>
                 <%= match[:name] %>
-                <% if match[:meta] %>
-                  <span class="metadata"> <%= match[:meta] %> </span>
-                <% end %>
               <% end %>
             </li>
           <% end %>

--- a/lib/searchable.rb
+++ b/lib/searchable.rb
@@ -59,8 +59,6 @@ module Searchable
             highlight: highlight,
             url: (search_type == "book" ? "/book/#{slug}" : "/docs/#{name}")
           }
-          # TODO is meta populated?
-          hit[:meta] = result["meta"] if search_type == "book"
           ref_hits << hit
         end
         if ref_hits.size > 0


### PR DESCRIPTION
As pointed on https://github.com/git/git-scm.com/pull/1282/files#r239242893, the 'meta' property does not seem being used currently.

On the commit https://github.com/git/git-scm.com/commit/a5ced93d42157f25f603b16a661640009822d57b#diff-080d7e25e5d0472dd9a470de6e3f1d11 it seems we removed the logic for `meta`, which included adding chapter info, and started relying the information would come from elastic itself, which is not true, because we never specify that custom data when storing the documents.

I suspect that since that commit (2012?) the metadata is not being used, hence it can be removed