### PR TITLE
Fix search bar lag

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -176,7 +176,7 @@ var Search = {
   selectResultOption: function() {
     var link = $('#search-results a')[Search.selectedIndex];
     var url = $(link).attr('href');
-    if(!link) {
+    if(!url) {
       var term = $('#search-text').val();
       url = "/search/results?search=" + term;
     }

--- a/app/views/shared/_search.html.erb
+++ b/app/views/shared/_search.html.erb
@@ -6,7 +6,7 @@
     <td class="matches">
       <ul>
         <li>
-          <%= link_to "Show all results...", "/search/results?search=#{@term}" %>
+          <a>Show all results...</a>
         </li>
       </ul>
     </td>


### PR DESCRIPTION
If someone wrote some search term fast enough and submitedthe query, it was possible to end in a search result without the full term. For instance: typing 'quick' very fast plus submitting (enter key), would often end in the url: https://git-scm.com/search/results?search=qui

This is due to the way that we present search result recommendations. The current strategy implies changing the DOM, which maynot be the most efficient thing (using jquery).

So what would happen before the proposed fix:

- A user enters term very fast (for instance 'quick')
- Halfway the typing (let's say at 'qui' point), the site would present search result recommendations
- The first recommendation is "Show all results", which links to  https://git-scm.com/search/results?search=qui
- The user then submits the search (pressing enter key)
- At this moment the search box has content = 'quick'
- By pressing enter, our current javascript logic kicks in
- It fetches the url of the selected option (by default the first one - "Show all results"
- If it doesn't have a valid url, it defaults to /search/results?search=<search box input>
- But it has a valid (but outdated) url, so it uses it
- The user is now redirected into https://git-scm.com/search/results?search=qui instead of https://git-scm.com/search/results?search=quick

The proposed solution is to remove the url from the "Show all results", hence falling into the "not valid url" logic, that will compute the search url with the current/updated search box input

closes #1279 