### PR TITLE
Update GitAhead license

### DIFF
--- a/resources/guis.yml
+++ b/resources/guis.yml
@@ -199,8 +199,8 @@ guis:
   - Windows
   - Mac
   - Linux
-  price: Free for non-commercial use
-  license: Proprietary
+  price: Free
+  license: MIT
   order: 22
 - name: Pocket Git
   url: http://pocketgit.com/


### PR DESCRIPTION
The GitAhead GUI is now open source and free for everybody.