### PR TITLE
drop conservancy donation banner

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -29,13 +29,6 @@
 
 <body id="<%= @section %>">
 
-  <%= render layout: "shared/banner", locals: { id: "conservancy2018", dismissable: true } do %>
-      Git is a member of Software Freedom Conservancy, which handles
-      legal and financial needs for the project.  Conservancy is
-      currently raising funds to continue their mission. Consider
-      <a href="https://sfconservancy.org/supporter/">becoming a supporter</a>!
-  <% end %>
-
   <div class="inner">
     <%= render partial: "shared/header" %>
   </div> <!-- .inner -->


### PR DESCRIPTION
We're in the new year, and the banner has been up for almost a month. It's presumably reached most of the audience by now, and we're out of the end-of-year tax season. So let's drop it for now.
