### PR TITLE
Update GitKraken price

### DIFF
--- a/resources/guis.yml
+++ b/resources/guis.yml
@@ -43,7 +43,7 @@ guis:
   - Windows
   - Mac
   - Linux
-  price: Free for non-commercial use
+  price: $49 / user / Free for non-commercial use and commercial startups less than a year old
   license: Proprietary
   order: 5
 - name: SmartGit

--- a/resources/guis.yml
+++ b/resources/guis.yml
@@ -43,7 +43,7 @@ guis:
   - Windows
   - Mac
   - Linux
-  price: $49 / user / Free for non-commercial use and commercial startups less than a year old
+  price: $49/user / Free for non-commercial use
   license: Proprietary
   order: 5
 - name: SmartGit


### PR DESCRIPTION
https://www.gitkraken.com/pricing indicates $49 / year. Hovering over the question mark under the 'free' description says commercial work is anything you get paid for, but there's an exception for 'startups in their first year of existence'

This line is a little long? Not sure if you want to drop the note about startups and just keep '$49 / user / Free for non-commercial use'

Also not sure if you want to specify $49 / user or $49 / user / year. I tried to keep the same standard as other ones, but I didn't check if other paid GUIs were subscription or flat fee.