### PR TITLE
Add log if ES is unreachable

### DIFF
--- a/lib/searchable.rb
+++ b/lib/searchable.rb
@@ -38,8 +38,13 @@ module Searchable
         query_options["query"]["bool"]["should"] << { "term" => { format => keyword } }
       end
 
-      client = ElasticClient.instance
-      search = client.search index: ELASTIC_SEARCH_INDEX, body: query_options rescue nil
+      begin
+        client = ElasticClient.instance
+        search = client.search index: ELASTIC_SEARCH_INDEX, body: query_options
+      rescue StandardError => ex
+        Rails.logger.error("Could not connect to ElasticSearch: " + ex.message)
+        nil
+      end
 
       if search
         ref_hits = []

--- a/lib/searchable.rb
+++ b/lib/searchable.rb
@@ -38,13 +38,8 @@ module Searchable
         query_options["query"]["bool"]["should"] << { "term" => { format => keyword } }
       end
 
-      begin
-        client = ElasticClient.instance
-        search = client.search index: ELASTIC_SEARCH_INDEX, body: query_options
-      rescue StandardError => ex
-        Rails.logger.error("Could not connect to ElasticSearch: " + ex.message)
-        nil
-      end
+      client = ElasticClient.instance
+      search = client.search index: ELASTIC_SEARCH_INDEX, body: query_options
 
       if search
         ref_hits = []


### PR DESCRIPTION
If ES is down, we were swallowing the exception. Now we at least log it as an error. Not sure if we have warnings at heroku level (@peff ), but if we don't, it won't hurt

closes #1001 