### PR TITLE
Change pricing for GitKraken to reflect new pricing model

### DIFF
--- a/resources/guis.yml
+++ b/resources/guis.yml
@@ -43,7 +43,7 @@ guis:
   - Windows
   - Mac
   - Linux
-  price: $49/user / Free for non-commercial use
+  price: Free / $29 / $49
   license: Proprietary
   order: 5
 - name: SmartGit


### PR DESCRIPTION
GitKraken introduced an Individual license at $29 / year.  This is in addition to the free (non-commercial) tier and the Pro tier for $49 / year that it previously had.
