### PR TITLE
Manpages with lang

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,16 @@ Or you can do it from GitHub (much slower) like this:
     $ export API_PASS=github_password
     $ rake preindex
 
+Similarly, you can also populate the localized man pages. From a local clone of https://github.com/jnavila/git-html-l10n :
+
+    $ GIT_REPO=../git-html-l10n/.git rake local_index_l10n
+
+Or you can do it from GitHub (much slower) like this:
+
+    $ export API_USER=github_username
+    $ export API_PASS=github_password
+    $ rake preindex_l10n
+
 Now you need to get the latest downloads for the downloads pages:
 
     $ rake downloads

--- a/app/assets/stylesheets/reference.scss
+++ b/app/assets/stylesheets/reference.scss
@@ -157,6 +157,17 @@ h3.plumbing {
     font-size: 12px;
     font-weight: normal;
   }
+  footer {
+    padding: 4px 12px;
+    margin-top: 0;
+    font-size: 11px;
+    font-weight: normal;
+    a {
+        padding: 4px;
+        margin-top: 0;
+        color: blue;
+    }
+  }
 }
 
 #topics-dropdown {

--- a/app/assets/stylesheets/reference.scss
+++ b/app/assets/stylesheets/reference.scss
@@ -100,6 +100,10 @@ h3.plumbing {
     &#reference-topics-trigger {
       float: right;
     }
+
+    &#reference-languages-trigger {
+      float: right;
+    }
   }
 }
 
@@ -139,6 +143,20 @@ h3.plumbing {
 .windows.chrome #previous-versions-dropdown,
 .windows.ie8 #previous-versions-dropdown {
   width: 370px;
+}
+
+#l10n-versions-dropdown {
+  width: 250px;
+  right: 12px;
+  padding: 12px;
+  font-weight: normal;
+  line-height: 1;
+  header {
+    padding: 0 12px;
+    margin: 0;
+    font-size: 12px;
+    font-weight: normal;
+  }
 }
 
 #topics-dropdown {

--- a/app/controllers/doc_controller.rb
+++ b/app/controllers/doc_controller.rb
@@ -20,6 +20,7 @@ class DocController < ApplicationController
       return redirect_to doc_file_path(file: @doc_file.name)
     end
     @version  = @doc_version.version
+    @language = @doc_version.language
     @doc      = @doc_version.doc
     @page_title = "Git - #{@doc_file.name} Documentation"
     return redirect_to docs_path unless @doc_version
@@ -64,11 +65,10 @@ class DocController < ApplicationController
   def set_doc_version
     return unless @doc_file
     version = params[:version]
-    if version
+    if version && /\d+\.\d+\.\d+/ =~ version
       @doc_version = @doc_file.doc_versions.for_version(version)
     else
-      @doc_version = @doc_file.doc_versions.latest_version
+      @doc_version = @doc_file.doc_versions.latest_version(version || "en")
     end
   end
-
 end

--- a/app/models/doc_file.rb
+++ b/app/models/doc_file.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 # frozen_string_literal: true
 
 # t.string :name
@@ -7,6 +8,18 @@ class DocFile < ApplicationRecord
   has_many :versions, through: :doc_versions
 
   scope :with_includes, -> { includes(doc_versions: [:doc, :version]) }
+
+  def languages
+    true_lang={
+      "de"=>"Deutsch",
+      "en"=>"English",
+      "fr"=>"Français",
+      "pt_BR"=>"Português (Brasil)"
+    }
+    self.doc_versions.select(:language).distinct.collect do |v|
+      [v[:language], true_lang[v[:language]] || v[:language]]
+    end
+  end
 
   def version_changes(limit_size = 100)
     unchanged_versions = []

--- a/app/models/doc_file.rb
+++ b/app/models/doc_file.rb
@@ -9,15 +9,20 @@ class DocFile < ApplicationRecord
 
   scope :with_includes, -> { includes(doc_versions: [:doc, :version]) }
 
-  def languages
-    true_lang={
+  @@true_lang={
       "de"=>"Deutsch",
       "en"=>"English",
       "fr"=>"Français",
       "pt_BR"=>"Português (Brasil)"
     }
+
+  def true_lang
+    @@true_lang
+  end
+
+  def languages
     self.doc_versions.select(:language).distinct.collect do |v|
-      [v[:language], true_lang[v[:language]] || v[:language]]
+      [v[:language], @@true_lang[v[:language]] || v[:language]]
     end
   end
 

--- a/app/models/doc_version.rb
+++ b/app/models/doc_version.rb
@@ -11,9 +11,9 @@ class DocVersion < ApplicationRecord
   belongs_to :doc_file
 
   scope :with_includes, -> { includes(:doc) }
-  scope :for_version, ->(version) { where(:language => 'en').joins(:version).where(versions: {name: version}).limit(1).first }
-  scope :latest_version, -> {  where(:language => 'en').joins(:version).order("versions.vorder DESC").limit(1).first }
-  scope :version_changes, -> {  where(:language => 'en').with_includes.joins(:version).order("versions.vorder DESC") }
+  scope :for_version, ->(version) { where(language: "en").joins(:version).where(versions: {name: version}).limit(1).first }
+  scope :latest_version, ->(lang = "en") {  where(language: lang).joins(:version).order("versions.vorder DESC").limit(1).first }
+  scope :version_changes, -> {  where(language: "en").with_includes.joins(:version).order("versions.vorder DESC") }
 
   delegate :name, to: :version
   delegate :committed, to: :version

--- a/app/models/doc_version.rb
+++ b/app/models/doc_version.rb
@@ -4,15 +4,16 @@
 # t.belongs_to :doc
 # t.belongs_to :doc_file
 # t.timestamps
+# t.language
 class DocVersion < ApplicationRecord
   belongs_to :doc
   belongs_to :version
   belongs_to :doc_file
 
   scope :with_includes, -> { includes(:doc) }
-  scope :for_version, ->(version) { joins(:version).where(versions: {name: version}).limit(1).first }
-  scope :latest_version, -> { joins(:version).order("versions.vorder DESC").limit(1).first }
-  scope :version_changes, -> { with_includes.joins(:version).order("versions.vorder DESC") }
+  scope :for_version, ->(version) { where(:language => 'en').joins(:version).where(versions: {name: version}).limit(1).first }
+  scope :latest_version, -> {  where(:language => 'en').joins(:version).order("versions.vorder DESC").limit(1).first }
+  scope :version_changes, -> {  where(:language => 'en').with_includes.joins(:version).order("versions.vorder DESC") }
 
   delegate :name, to: :version
   delegate :committed, to: :version

--- a/app/views/doc/_languages.html.erb
+++ b/app/views/doc/_languages.html.erb
@@ -1,0 +1,13 @@
+<a class="dropdown-trigger" id="reference-languages-trigger" data-panel-id="l10n-versions-dropdown" href="#">Language <%= @language %> ▾</a>
+<div class='dropdown-panel right' id='l10n-versions-dropdown'>
+  <header>Localized versions of <strong><%= @doc_file.name %></strong> manual</header>
+  <ol class='reference-previous-versions'>
+    <% @doc_file.languages.each do |code, language| %>
+      <li>
+        <a href="/docs/<%= @doc_file.name %>/<%= code %>"><span class="version"><%= language %></span>
+        </a>
+        </li>
+    <% end %>
+    <li>&nbsp;</li>
+  </ol>
+</div>

--- a/app/views/doc/_languages.html.erb
+++ b/app/views/doc/_languages.html.erb
@@ -1,4 +1,5 @@
-<a class="dropdown-trigger" id="reference-languages-trigger" data-panel-id="l10n-versions-dropdown" href="#">Language <%= @language %> ▾</a>
+<a class="dropdown-trigger" id="reference-languages-trigger" data-panel-id="l10n-versions-dropdown" href="#"><%if @language%>
+  <%= @doc_file.true_lang[@language]||@language %> <% else %> Language <% end %>▾</a>
 <div class='dropdown-panel right' id='l10n-versions-dropdown'>
   <header>Localized versions of <strong><%= @doc_file.name %></strong> manual</header>
   <ol class='reference-previous-versions'>

--- a/app/views/doc/_languages.html.erb
+++ b/app/views/doc/_languages.html.erb
@@ -8,6 +8,8 @@
         </a>
         </li>
     <% end %>
-    <li>&nbsp;</li>
   </ol>
+  <footer>
+    Want to read in your language or fix typos?<br/> <a href="https://github.com/jnavila/git-manpages-l10n">You can help translate this page</a>.
+  </footer>
 </div>

--- a/app/views/doc/_versions.html.erb
+++ b/app/views/doc/_versions.html.erb
@@ -1,4 +1,9 @@
-<a class="dropdown-trigger" id="reference-versions-trigger" data-panel-id="previous-versions-dropdown" href="#">Version <%= @version.name %> ▾</a>
+<a class="dropdown-trigger" id="reference-versions-trigger" data-panel-id="previous-versions-dropdown" href="#">Version
+  <%= if  /\d+\.\d+\.\d+/ =~ @version.name
+        @version.name
+      else
+      @language
+      end %> ▾ </a>
 <span class="light"><%= @doc_file.name %> last updated in <%= @last.version.name %></span>
 <div class='dropdown-panel left' id='previous-versions-dropdown'>
   <header>Changes in the <strong><%= @doc_file.name %></strong> manual</header>

--- a/app/views/doc/_versions.html.erb
+++ b/app/views/doc/_versions.html.erb
@@ -1,9 +1,9 @@
-<a class="dropdown-trigger" id="reference-versions-trigger" data-panel-id="previous-versions-dropdown" href="#">Version
-  <%= if  /\d+\.\d+\.\d+/ =~ @version.name
-        @version.name
-      else
-      @language
-      end %> ▾ </a>
+<a class="dropdown-trigger" id="reference-versions-trigger" data-panel-id="previous-versions-dropdown" href="#">
+  <% if  (/\d+\.\d+\.\d+/ =~ @version.name )%>
+    Version <%=  @version.name %>
+     <% else %>
+      Latest version
+      <% end %> ▾ </a>
 <span class="light"><%= @doc_file.name %> last updated in <%= @last.version.name %></span>
 <div class='dropdown-panel left' id='previous-versions-dropdown'>
   <header>Changes in the <strong><%= @doc_file.name %></strong> manual</header>

--- a/app/views/doc/man.html.erb
+++ b/app/views/doc/man.html.erb
@@ -3,6 +3,7 @@
 
 <% cache @doc do %>
   <div id='reference-version'>
+    <%= render 'doc/languages' %>
     <%= render 'doc/topics' %>
     <%= render 'doc/versions' %>
   </div>

--- a/db/migrate/20190131210305_add_language_to_doc_version.rb
+++ b/db/migrate/20190131210305_add_language_to_doc_version.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+class AddLanguageToDocVersion < ActiveRecord::Migration
+  def change
+    add_column :doc_versions, :language, :string, default: "en"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20141027114732) do
+ActiveRecord::Schema.define(version: 20190131210305) do
 
   create_table "books", force: :cascade do |t|
     t.string   "code"
@@ -56,6 +56,7 @@ ActiveRecord::Schema.define(version: 20141027114732) do
     t.integer  "doc_file_id"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.string   "language",    default: "en"
   end
 
   create_table "docs", force: :cascade do |t|
@@ -76,6 +77,17 @@ ActiveRecord::Schema.define(version: 20141027114732) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.datetime "release_date"
+  end
+
+  create_table "related_items", force: :cascade do |t|
+    t.string   "name"
+    t.string   "content_type"
+    t.string   "content_url"
+    t.string   "related_type"
+    t.string   "related_id"
+    t.integer  "score"
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
   create_table "sections", force: :cascade do |t|

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1,0 +1,4 @@
+CREATE TABLE IF NOT EXISTS "schema_migrations" ("version" varchar NOT NULL);
+CREATE UNIQUE INDEX "unique_schema_migrations" ON "schema_migrations" ("version");
+INSERT INTO schema_migrations (version) VALUES ('0');
+

--- a/lib/tasks/index.rake
+++ b/lib/tasks/index.rake
@@ -141,6 +141,7 @@ def index_doc(filter_tags, doc_list, get_content)
         end
         dv = DocVersion.where(version_id: stag.id, doc_file_id: file.id).first_or_create
         dv.doc_id = doc.id
+	dv.language = 'en'
         dv.save
       end
 

--- a/lib/tasks/index.rake
+++ b/lib/tasks/index.rake
@@ -42,7 +42,7 @@ def index_l10n_doc(filter_tags, doc_list, get_content)
         if content_file
           new_content = get_content.call (content_file.second)
         else
-          puts "can not resolve #{name}\n"
+          puts "Included file #{name} was not translated. Processing anyway\n"
         end
         [new_content, name]
     end

--- a/lib/tasks/index.rake
+++ b/lib/tasks/index.rake
@@ -57,6 +57,8 @@ def index_l10n_doc(filter_tags, doc_list, get_content)
         end
         if new_content
           expand!(path, new_content, get_f_content, categories)
+        else
+          "\n\n[WARNING]\n====\nMissing `#{path}`\n\nSee original version for this content.\n====\n\n"
         end
       end
       return content

--- a/lib/tasks/index.rake
+++ b/lib/tasks/index.rake
@@ -5,6 +5,104 @@ require "octokit"
 require "time"
 require "digest/sha1"
 
+
+def index_l10n_doc(filter_tags, doc_list, get_content)
+
+  ActiveRecord::Base.logger.level = Logger::WARN
+  rebuild = ENV["REBUILD_DOC"]
+  rerun = ENV["RERUN"] || rebuild || false
+
+  filter_tags.call(rebuild, false).sort_by { |tag| Version.version_to_num(tag.first[1..-1]) }.each do |tag|
+    name, commit_sha, tree_sha, ts = tag
+    puts "#{name}: #{ts}, #{commit_sha[0, 8]}, #{tree_sha[0, 8]}"
+
+    stag = Version.where(name: name.gsub("v", "l10n")).first_or_create
+
+    next if (stag.commit_sha == commit_sha) && !rerun
+
+    stag.commit_sha = commit_sha
+    stag.tree_sha = tree_sha
+    stag.committed = ts
+    stag.save
+
+    tag_files = doc_list.call(tree_sha)
+    doc_files = tag_files.select { |ent| ent.first =~
+        /^([_\w]+)\/(
+          (
+            git.*
+        )\.txt)/x
+    }
+
+    puts "Found #{doc_files.size} entries"
+    doc_limit = ENV["ONLY_BUILD_DOC"]
+
+    get_content_f = Proc.new do |source, target|
+      name = File.join(File.dirname(source), target)
+        content_file = tag_files.detect { |ent| ent.first == name }
+        if content_file
+          new_content = get_content.call (content_file.second)
+        else
+          puts "can not resolve #{name}\n"
+        end
+        [new_content, name]
+    end
+
+    def expand!(path, content, get_f_content , categories)
+      content.gsub!(/include::(\S+)\.txt/) do |line|
+        line.gsub!("include::", "")
+        if categories[line]
+          new_content = categories[line]
+        else
+          new_content, path = get_f_content.call(path, line)
+        end
+        if new_content
+          expand!(path, new_content, get_f_content, categories)
+        end
+      end
+      return content
+    end
+
+    doc_files.each do |entry|
+      full_path, sha = entry
+      lang = File.dirname(full_path)
+      path = File.basename(full_path, ".txt")
+      #next if doc_limit && path !~ /#{doc_limit}/
+
+      file = DocFile.where(name: path).first_or_create
+
+      puts "   build: #{path} for #{lang}"
+
+      content = get_content.call sha
+      categories = {}
+      expand!(full_path, content, get_content_f, categories)
+      content.gsub!(/link:technical\/(.*?)\.html\[(.*?)\]/, 'link:\1[\2]')
+      asciidoc = Asciidoctor::Document.new(content, attributes: {"sectanchors" => ""}, doctype: "book")
+      asciidoc_sha = Digest::SHA1.hexdigest(asciidoc.source)
+      doc = Doc.where(blob_sha: asciidoc_sha).first_or_create
+      if rerun || !doc.plain || !doc.html
+        html = asciidoc.render
+        html.gsub!(/linkgit:(\S+)\[(\d+)\]/) do |line|
+          x = /^linkgit:(\S+)\[(\d+)\]/.match(line)
+          line = "<a href='/docs/#{x[1]}/#{lang}'>#{x[1]}[#{x[2]}]</a>"
+        end
+        #HTML anchor on hdlist1 (i.e. command options)
+        html.gsub!(/<dt class="hdlist1">(.*?)<\/dt>/) do |m|
+          text = $1.tr("^A-Za-z0-9-", "")
+          anchor = "#{path}-#{text}"
+          "<dt class=\"hdlist1\" id=\"#{anchor}\"> <a class=\"anchor\" href=\"##{anchor}\"></a>#{$1} </dt>"
+        end
+        doc.plain = asciidoc.source
+        doc.html  = html
+        doc.save
+      end
+      dv = DocVersion.where(version_id: stag.id, doc_file_id: file.id, language: lang).first_or_create
+      dv.doc_id = doc.id
+      dv.language = lang
+      dv.save
+    end
+  end
+end
+
 def index_doc(filter_tags, doc_list, get_content)
   ActiveRecord::Base.logger.level = Logger::WARN
   rebuild = ENV["REBUILD_DOC"]
@@ -101,7 +199,7 @@ def index_doc(filter_tags, doc_list, get_content)
           else
             new_content = get_f_content.call(new_fname)
             if new_content
-              expand_content(new_content, new_fname, get_f_content, generated)
+              expand_content(new_content.force_encoding("UTF-8"), new_fname, get_f_content, generated)
             else
               puts "#{new_fname} could not be resolved for expansion"
             end
@@ -118,7 +216,7 @@ def index_doc(filter_tags, doc_list, get_content)
 
         puts "   build: #{docname}"
 
-        content = expand_content((get_content.call sha), path, get_content_f, generated)
+        content = expand_content((get_content.call sha).force_encoding("UTF-8"), path, get_content_f, generated)
         content.gsub!(/link:technical\/(.*?)\.html\[(.*?)\]/, 'link:\1[\2]')
         asciidoc = Asciidoctor::Document.new(content, attributes: {"sectanchors" => ""}, doctype: "book")
         asciidoc_sha = Digest::SHA1.hexdigest(asciidoc.source)
@@ -139,9 +237,9 @@ def index_doc(filter_tags, doc_list, get_content)
           doc.html  = html
           doc.save
         end
-        dv = DocVersion.where(version_id: stag.id, doc_file_id: file.id).first_or_create
+        dv = DocVersion.where(version_id: stag.id, doc_file_id: file.id, language: "en").first_or_create
         dv.doc_id = doc.id
-	dv.language = 'en'
+        dv.language = "en"
         dv.save
       end
 
@@ -150,23 +248,30 @@ def index_doc(filter_tags, doc_list, get_content)
   end
 end
 
-task preindex: :environment do
-
+def github_index_doc(index_fun, repo)
   Octokit.auto_paginate = true
-  @octokit = Octokit::Client.new(login: ENV["API_USER"], password: ENV["API_PASS"])
+  if ENV["GITHUB_API_TOKEN"]
+    @octokit = Octokit::Client.new(access_token: ENV["GITHUB_API_TOKEN"])
+  else
+    @octokit = Octokit::Client.new(login: ENV["API_USER"], password: ENV["API_PASS"])
+  end
 
-  repo = ENV["GIT_REPO"] || "gitster/git"
+  repo = ENV["GIT_REPO"] || repo
 
   blob_content = Hash.new do |blobs, sha|
     content = Base64.decode64(@octokit.blob(repo, sha, encoding: "base64").content)
-    blobs[sha] = content.encode("utf-8", undef: :replace)
+    blobs[sha] = content.force_encoding("UTF-8")
   end
 
-  tag_filter = -> (tagname) do
+  tag_filter = -> (tagname, gettags = true) do
     # find all tags
-    tags = @octokit.tags(repo).select { |tag| !tag.nil? && tag.name =~ /v\d([\.\d])+$/ }  # just get release tags
-    if tagname
-      tags = tags.select { |t| t.name == tagname }
+    if gettags
+      tags = @octokit.tags(repo).select { |tag| !tag.nil? && tag.name =~ /v\d([\.\d])+$/ }  # just get release tags
+      if tagname
+        tags = tags.select { |t| t.name == tagname }
+      end
+    else
+      tags=[Struct.new(:name).new("heads/master")]
     end
     tags.collect do |tag|
       # extract metadata
@@ -186,20 +291,23 @@ task preindex: :environment do
     tree_info.tree.collect { |ent| [ent.path, ent.sha] }
   end
 
-  index_doc(tag_filter, get_file_list, get_content)
+  send(index_fun, tag_filter, get_file_list, get_content)
 end
 
-task local_index: :environment do
-  dir     = ENV["GIT_REPO"]
+def local_index_doc(index_fun)
+  dir = ENV["GIT_REPO"]
   Dir.chdir(dir) do
 
-    tag_filter = -> (tagname) do
-
-      # find all tags
-      tags = `git tag | egrep 'v1|v2'`.strip.split("\n")
-      tags = tags.select { |tag| tag =~ /v\d([\.\d])+$/ }  # just get release tags
-      if tagname
-        tags = tags.select { |t| t == tagname }
+    tag_filter = -> (tagname, gettags = true) do
+      if gettags
+        # find all tags
+        tags = `git tag | egrep 'v1|v2'`.strip.split("\n")
+        tags = tags.select { |tag| tag =~ /v\d([\.\d])+$/ }  # just get release tags
+        if tagname
+          tags = tags.select { |t| t == tagname }
+        end
+      else
+        tags=["master"]
       end
       tags.collect do |tag|
         # extract metadata
@@ -220,10 +328,27 @@ task local_index: :environment do
       tree = entries. map do |e|
         mode, type, sha, path = e.split(" ")
         [path, sha]
+
       end
     end
 
-    index_doc(tag_filter, get_file_list, get_content)
+    send(index_fun, tag_filter, get_file_list, get_content)
 
   end
+end
+
+task local_index: :environment do
+  local_index_doc(:index_doc)
+end
+
+task local_index_l10n: :environment do
+  local_index_doc(:index_l10n_doc)
+end
+
+task preindex: :environment do
+  github_index_doc(:index_doc, "gitster/git")
+end
+
+task preindex_l10n: :environment do
+  github_index_doc(:index_l10n_doc, "jnavila/git-html-l10n")
 end


### PR DESCRIPTION
This series of patch introduces the localization of manpages

 * A field is added to the DB to manage languages
 * The feeding script `index.rb' is refactored to feed from the repo of translated manpages
 * The manpage page controller and view add a menu to select available translations.

I know next to nothing in RoR, so there may be better ways to do it. I tried to not add a lot of stuff. 