### PR TITLE
actually apply manpage stylesheet

### DIFF
--- a/app/assets/stylesheets/man-pages.scss
+++ b/app/assets/stylesheets/man-pages.scss
@@ -1,4 +1,4 @@
-.man-page {
+#documentation #main {
   p {
     em {
       font-family: $fixed-width-font-family !important;


### PR DESCRIPTION
Our `man-pages.scss` file looks for a `.man-page` class, but we do not actually generate any html with that class. It's unclear to me if something changed in asciidoc, or perhaps in our rendering code.

At any rate, none of these styles were being applied. Let's look for `#documentation #main` instead, which seems to match the generated html.

Here are before and after shots of the `git-prune` page. Before:

![Screenshot_2019-08-14 Git - git-prune Documentation(1)](https://user-images.githubusercontent.com/45925/63063357-4b72d980-beca-11e9-8b80-512d4566799d.png)

After:

![Screenshot_2019-08-14 Git - git-prune Documentation](https://user-images.githubusercontent.com/45925/63063369-5af22280-beca-11e9-8cf1-12bc928061f3.png)

It looks like an improvement to me, though since these have been disabled for who knows how long, I'm a little nervous that there may be some corner case where it makes things worse. Probably worth clicking around and eyeballing a few pages on the test deploy.