### PR TITLE
man-pages.scss: drop listingblock formatting

### DIFF
--- a/app/assets/stylesheets/man-pages.scss
+++ b/app/assets/stylesheets/man-pages.scss
@@ -53,12 +53,6 @@
     }
   }
 
-  .listingblock {
-    .content {
-      @extend code;
-    }
-  }
-
   .quoteblock {
     padding-left: 1em;
     margin-left: 1em;


### PR DESCRIPTION
The content is all inside a `<pre>` block, which already gets the same formatting via our rule in application.scss. The result with the duplication looks bad, with an extra bit of empty bordered content before and after each block.

Here are before/after shots:

![Screenshot_2019-08-16 Git - git-commit Documentation(1)](https://user-images.githubusercontent.com/45925/63195015-7a5e8c00-c03f-11e9-923b-065dae344982.png)

![Screenshot_2019-08-16 Git - git-commit Documentation](https://user-images.githubusercontent.com/45925/63195021-7d597c80-c03f-11e9-8c8f-4e2877923fa5.png)

I admit to not fully understanding the cause of the weird extra lines, but this solution does work, and doesn't seem to have any big drawbacks (unless we're planning to style listing blocks totally differently, but we can cross that bridge when we come to it. And I'd suspect that would be part of the larger style refresh anyway, so we'd be starting from scratch).

Noticed by @jnavila in https://github.com/git/git-scm.com/pull/1363#issuecomment-522126334.
