### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/downloads.md
+++ b/.github/ISSUE_TEMPLATE/downloads.md
@@ -1,5 +1,5 @@
 ---
-name: 'Donwloads on git-scm not working'
+name: 'Downloads on git-scm not working'
 about: 'If you are experiencing problems downloading git from git-scm.com'
 ---
 

--- a/.github/ISSUE_TEMPLATE/downloads.md
+++ b/.github/ISSUE_TEMPLATE/downloads.md
@@ -1,0 +1,35 @@
+---
+name: 'Donwloads on git-scm not working'
+about: 'If you are experiencing problems downloading git from git-scm.com'
+---
+
+<!--- 
+Please follow the instructions below. 
+An issue properly explained is solved much faster! 
+
+* If you are experiencing problems/questions/bugs with git itself, start a discussion on the [community mailing list](https://git-scm.com/community).
+* If you are experiencing problems on your git for windows program, please open an issue at [git-for-windows/git](https://github.com/git-for-windows/git).
+* Please open Git documentation (a.k.a. man/help pages, i.e. anything with a URL starting with `https://git-scm.com/docs`) specific issues with the [community](https://git-scm.com/community),
+* Please open Pro Git book contents issues (i.e. anything with a URL starting with `https://git-scm.com/book` or its PDF versions) at [progit/progit2](https://github.com/progit/progit2/issues).
+
+-->
+
+<!--- Provide a brief summary of the issue in the title above -->
+
+### Which download is failing?
+<!--- Tell us in which page and version is the download broken  -->
+
+### Problem
+<!--- Tell us the problem as clear as possible -->
+
+### Context
+<!--- Which operating system and browser are you using? -->
+<!--- Providing context helps us come up with a solution that is most useful in the real world -->
+
+### Steps to Reproduce 
+<!--- Provide a detailed list of steps. -->
+<!--- In the rare cases where this is infeasible, we will also accept a detailed set of instructions. -->
+
+### Other details
+<!--- Include as many relevant details you may find relevant -->
+

--- a/.github/ISSUE_TEMPLATE/ui.md
+++ b/.github/ISSUE_TEMPLATE/ui.md
@@ -1,0 +1,35 @@
+---
+name: 'git-scm UI broken'
+about: 'git-scm.com UI is not working'
+---
+
+<!--- 
+Please follow the instructions below. 
+An issue properly explained is solved much faster! 
+
+* If you are experiencing problems/questions/bugs with git itself, start a discussion on the [community mailing list](https://git-scm.com/community).
+* If you are experiencing problems on your git for windows program, please open an issue at [git-for-windows/git](https://github.com/git-for-windows/git).
+* Please open Git documentation (a.k.a. man/help pages, i.e. anything with a URL starting with `https://git-scm.com/docs`) specific issues with the [community](https://git-scm.com/community),
+* Please open Pro Git book contents issues (i.e. anything with a URL starting with `https://git-scm.com/book` or its PDF versions) at [progit/progit2](https://github.com/progit/progit2/issues).
+
+-->
+
+<!--- Provide a brief summary of the issue in the title above -->
+
+### URL for broken page
+<!--- Tell us in which page is the website broken  -->
+
+### Problem
+<!--- Tell us the problem as clear as possible -->
+
+### Context
+<!--- Which operating system and browser are you using? -->
+<!--- Providing context helps us come up with a solution that is most useful in the real world -->
+
+### Steps to Reproduce 
+<!--- Provide a detailed list of steps. -->
+<!--- In the rare cases where this is infeasible, we will also accept a detailed set of instructions. -->
+
+### Other details
+<!--- Include as many relevant details you may find relevant -->
+


### PR DESCRIPTION
I noticed gradle provides different issue templates at https://github.com/gradle/gradle/issues/new/choose

I'm hoping this helps reducing the amount of wrong issues opened (which has been decreasing to be fair)

![image](https://user-images.githubusercontent.com/1999050/66343909-83375400-e944-11e9-966d-44a7be057c9a.png)
