### PR TITLE
reference: add gitcli to guides section

### DIFF
--- a/app/views/shared/ref/_guides.html.erb
+++ b/app/views/shared/ref/_guides.html.erb
@@ -1,6 +1,7 @@
 <h3 class='guides'>Guides</h3>
 <ul class='unstyled'>
   <li><%= man('gitattributes') %></li>
+  <li><%= man('gitcli', 'Command-line interface conventions') %></li>
   <li><%= man('giteveryday', 'Everyday Git') %></li>
   <li><%= man('gitglossary', 'Glossary') %></li>
   <li><%= man('githooks') %></li>


### PR DESCRIPTION
I added a link to the [gitcli man page](https://git-scm.com/docs/gitcli) in the Guides section of the Reference page. I think this page contains enough useful information to be featured there.

Also, should more guides be featured ? in Git 2.23, ` git help -g` shows:
```shell
The common Git guides are:
   attributes          Defining attributes per path
   cli                 Git command-line interface and conventions
   core-tutorial       A Git core tutorial for developers
   cvs-migration       Git for CVS users
   diffcore            Tweaking diff output
   everyday            A useful minimum set of commands for Everyday Git
   glossary            A Git Glossary
   hooks               Hooks used by Git
   ignore              Specifies intentionally untracked files to ignore
   modules             Defining submodule properties
   namespaces          Git namespaces
   repository-layout   Git Repository Layout
   revisions           Specifying revisions and ranges for Git
   tutorial            A tutorial introduction to Git
   tutorial-2          A tutorial introduction to Git: part two
   workflows           An overview of recommended workflows with Git
```

The missing ones on the Reference page are : 
- core-tutorial
- cvs- migration
- diffcore
- namespaces
- repository-layout
- tutorial-2