### PR TITLE
Valid HTML and HTTPS on /doc

### DIFF
--- a/app/views/doc/index.html.erb
+++ b/app/views/doc/index.html.erb
@@ -23,7 +23,7 @@
 
     <%= link_to "GitHub Cheat Sheet", "https://github.github.com/training-kit/downloads/github-git-cheat-sheet.pdf" %>
     <small class="light">(PDF) &nbsp;|&nbsp;</small>
-    <%= link_to "Visual Git Cheat Sheet", "http://ndpsoftware.com/git-cheatsheet.html" %>
+    <%= link_to "Visual Git Cheat Sheet", "https://ndpsoftware.com/git-cheatsheet.html" %>
     <small class="light"> (SVG | PNG)</small>
 
   </p>
@@ -34,7 +34,7 @@
     <h3>Pro Git</h3>
     <p>The entire <strong><a href="/book">Pro Git book</a></strong> written
       by Scott Chacon and Ben Straub is available to <a href="/book">read online for free</a>.
-      Dead tree versions are available on <a href="http://www.amazon.com/Pro-Git-Scott-Chacon/dp/1484200772?ie=UTF8&camp=1789&creative=9325&creativeASIN=1430218339&linkCode=as2&tag=git-sfconservancy-20">Amazon.com</a>.
+      Dead tree versions are available on <a href="https://www.amazon.com/Pro-Git-Scott-Chacon/dp/1484200772?ie=UTF8&camp=1789&creative=9325&creativeASIN=1430218339&linkCode=as2&tag=git-sfconservancy-20">Amazon.com</a>.
     </p>
   </div>
   

--- a/app/views/doc/index.html.erb
+++ b/app/views/doc/index.html.erb
@@ -22,9 +22,10 @@
     Quick reference guides:
 
     <%= link_to "GitHub Cheat Sheet", "https://github.github.com/training-kit/downloads/github-git-cheat-sheet.pdf" %>
-    <small class="light">(PDF) &nbsp;|&nbsp;</small>
+    <small class="light">(PDF)</small>
+    |
     <%= link_to "Visual Git Cheat Sheet", "https://ndpsoftware.com/git-cheatsheet.html" %>
-    <small class="light"> (SVG | PNG)</small>
+    <small class="light">(SVG | PNG)</small>
 
   </p>
 

--- a/app/views/doc/index.html.erb
+++ b/app/views/doc/index.html.erb
@@ -24,7 +24,7 @@
     <%= link_to "GitHub Cheat Sheet", "https://github.github.com/training-kit/downloads/github-git-cheat-sheet.pdf" %>
     <small class="light">(PDF) &nbsp;|&nbsp;</small>
     <%= link_to "Visual Git Cheat Sheet", "http://ndpsoftware.com/git-cheatsheet.html" %>
-    <small class="light"> (SVG | PNG)
+    <small class="light"> (SVG | PNG)</small>
 
   </p>
 
@@ -37,7 +37,10 @@
       Dead tree versions are available on <a href="http://www.amazon.com/Pro-Git-Scott-Chacon/dp/1484200772?ie=UTF8&camp=1789&creative=9325&creativeASIN=1430218339&linkCode=as2&tag=git-sfconservancy-20">Amazon.com</a>.
     </p>
   </div>
-    <h2> Videos </h2>
+  
+  <h2> Videos </h2>
+
+  <div>
 
     <% groups = @videos[0,4].group_by { |i| i[0] % 2 } %>
 


### PR DESCRIPTION
When browsing the website I noticed that the footer on [\doc](https://git-scm.com/doc) is not contained as on the other pages, but takes up the whole width. This is due to invalid HTML (missing closing and opening tags) on the page.

This PR fixes:
* Footer too wide due to missing opening `div`
* Text is displayed as "light" due to missing closing `small`
* Links use `http` instead of `https`
* Divider between cheat sheets is small instead of regular text

Maybe the video length should be displayed as "ligth" text. I can add another commit if desired.

*Before*
![image](https://user-images.githubusercontent.com/2564094/67812920-857d6180-fa5d-11e9-8b79-3e584071a717.png)

*After*
![image](https://user-images.githubusercontent.com/2564094/67812842-5830b380-fa5d-11e9-8501-951b87a80078.png)
