### PR TITLE
Align Callout on Reference page with changes on Documentation page

### DIFF
--- a/app/views/doc/ref.html.erb
+++ b/app/views/doc/ref.html.erb
@@ -8,8 +8,9 @@
     <p>
       Quick reference guides:
       <a href="https://github.github.com/training-kit/downloads/github-git-cheat-sheet.pdf">GitHub Cheat Sheet</a>
-      <small class='light'>(PDF) &nbsp;|&nbsp;</small>
-      <a href="http://ndpsoftware.com/git-cheatsheet.html">Visual Git Cheat Sheet</a>
+      <small class='light'>(PDF)</small>
+      |
+      <a href="https://ndpsoftware.com/git-cheatsheet.html">Visual Git Cheat Sheet</a>
       <small class='light'>(SVG | PNG)</small>
     </p>
   </div>


### PR DESCRIPTION
This PR brings the callout on [\docs](https://git-scm.com/docs) in line with the canges to [\doc](https://git-scm.com/doc) made in #1388.

* Use `https` for "Visual Git Cheat Sheet" link
* Divider between cheat sheets uses regular text

I tried to keep the change as minimal as possible, but that means that there are some differences between [this file](https://github.com/git/git-scm.com/blob/master/app/views/doc/ref.html.erb) and the [`doc`-file](https://github.com/git/git-scm.com/blob/master/app/views/doc/index.html.erb):
* Single quotes instead of double quotes for HTML attributes
* `a` tags instead of `<%= link_to`
Should these be unified? If so, in which direction?