### PR TITLE
Update links to book images

### DIFF
--- a/app/views/doc/_ext_books.erb
+++ b/app/views/doc/_ext_books.erb
@@ -10,7 +10,7 @@
         </p>
       </li>
       <li>
-        <a href="https://www.packtpub.com/application-development/mastering-git"><img src="https://d1ldz4te4covpm.cloudfront.net/sites/default/files/imagecache/ppv4_main_book_cover/B03537_cover.png"></a>
+        <a href="https://www.packtpub.com/application-development/mastering-git"><img src="https://www.packtpub.com/media/catalog/product/cache/e4d64343b1bc593f1c5348fe05efa4a6/b/0/b03537_cover.png"></a>
         <h4><a href="https://www.packtpub.com/application-development/mastering-git">Mastering Git</a></h4>
         <p class='description'>
           By Jakub Narębski
@@ -30,26 +30,26 @@
           By Peter Savage
       </li>
       <li>
-        <a href="https://www.packtpub.com/git-version-control-for-everyone/book"><img src="https://www.packtpub.com/sites/default/files/7522OS_mockupcover_bg_0.jpg"/></a>
+        <a href="https://www.packtpub.com/git-version-control-for-everyone/book"><img src="https://www.packtpub.com/media/catalog/product/cache/e4d64343b1bc593f1c5348fe05efa4a6/7/5/7522os_0.jpg"/></a>
         <h4><a href="https://www.packtpub.com/git-version-control-for-everyone/book">Git: Version Control for Everyone</a></h4>
         <p class='description'>
           By Ravishankar Somasundaram
         </p>
       </li>
       <li>
-        <a href="https://www.packtpub.com/application-development/git-essentials-second-edition"><img src="https://www.packtpub.com/sites/default/files/B06881.png"/></a>
+        <a href="https://www.packtpub.com/application-development/git-essentials-second-edition"><img src="https://www.packtpub.com/media/catalog/product/cache/e4d64343b1bc593f1c5348fe05efa4a6/b/0/b06881.png"/></a>
         <h4><a href="https://www.packtpub.com/application-development/git-essentials-second-edition">Git Essentials - Second Edition</a></h4>
         <p class='description'>
           By Ferdinando Santacroce
         </p>
       </li>
      <li>
-        <a href="https://www.amazon.com/dp/1789137543"><img src="https://www.packtpub.com/sites/default/files/B10764_MockupCover.png"/></a>
+        <a href="https://www.amazon.com/dp/1789137543"><img src="https://www.packtpub.com/media/catalog/product/cache/e4d64343b1bc593f1c5348fe05efa4a6/b/1/b10764_mockupcover.png"/></a>
         <h4><a href="https://www.amazon.com/dp/1789137543">Git Version Control Cookbook - Second Edition</a></h4>
         <p class='description'>
           By Kenneth Geisshirt
         </p>
-      </li>      
+      </li>
     </ul>
   </div>
   <div class='column-right'>
@@ -83,7 +83,7 @@
         </p>
       </li>
       <li>
-        <a href="https://www.packtpub.com/application-development/git-version-control-cookbook"><img src="https://dgdsbygo8mp3h.cloudfront.net/sites/default/files/imagecache/ppv4_main_book_cover/8454OS_cov.jpg"></a>
+        <a href="https://www.packtpub.com/application-development/git-version-control-cookbook"><img src="https://www.packtpub.com/media/catalog/product/cache/e4d64343b1bc593f1c5348fe05efa4a6/9/7/9781782168454.png"></a>
         <h4><a href="https://www.packtpub.com/application-development/git-version-control-cookbook">Git Version Control Cookbook</a></h4>
         <p class='description'>
           By Aske Olsson and Rasmus Voss
@@ -97,12 +97,12 @@
         </p>
       </li>
       <li>
-        <a href="https://www.packtpub.com/application-development/version-control-git-and-github"><img src="https://d1ldz4te4covpm.cloudfront.net/sites/default/files/imagecache/ppv4_main_book_cover/B12556_Lowres_Cover.png"></a>
+        <a href="https://www.packtpub.com/application-development/version-control-git-and-github"><img src="https://www.packtpub.com/media/catalog/product/cache/e4d64343b1bc593f1c5348fe05efa4a6/b/1/b12556_lowres_cover.png"></a>
         <h4><a href="https://www.packtpub.com/application-development/version-control-git-and-github">Version Control with Git and GitHub</a></h4>
         <p class='description'>
           By Alex Magana, Joseph Muli
         </p>
-      </li>      
+      </li>
     </ul>
   </div>
 </div>


### PR DESCRIPTION
Some links to book preview images on [External Links](https://git-scm.com/doc/ext) are broken.
This PR replaces the broken links with working ones to packtpub.

Some of the other images seem to be served with the website. Should that be done for all of them to prevent this in the future?

![image](https://user-images.githubusercontent.com/2564094/67825912-1b2de680-fa88-11e9-800d-23a3ad71e860.png)
