### PR TITLE
Mark current section of the book and reference

### DIFF
--- a/app/assets/stylesheets/book.scss
+++ b/app/assets/stylesheets/book.scss
@@ -132,6 +132,10 @@ ol.book-toc {
 
         a {
           font-weight: normal;
+
+          &.active {
+            font-weight: bold;
+          }
         }
       }
     }

--- a/app/assets/stylesheets/reference.scss
+++ b/app/assets/stylesheets/reference.scss
@@ -201,6 +201,10 @@ h3.plumbing {
   a {
     font-weight: normal;
     padding: 0;
+
+    &.active {
+      font-weight: bold;
+    }
   }
 }
 

--- a/app/controllers/doc_controller.rb
+++ b/app/controllers/doc_controller.rb
@@ -22,6 +22,7 @@ class DocController < ApplicationController
     @version  = @doc_version.version
     @language = @doc_version.language
     @doc      = @doc_version.doc
+    @name     = @doc_file.name
     @page_title = "Git - #{@doc_file.name} Documentation"
     return redirect_to docs_path unless @doc_version
     @last     = @doc_file.doc_versions.latest_version

--- a/app/helpers/doc_helper.rb
+++ b/app/helpers/doc_helper.rb
@@ -4,9 +4,9 @@ module DocHelper
 
   def man(name, text = nil)
     if @language && @language != "en"
-      link_to text || name.gsub(/^git-/, ""), doc_file_path(file: name,) +"/#{@language}"
+      link_to text || name.gsub(/^git-/, ""), doc_file_path(file: name,) +"/#{@language}", class: ("active" if @name == name)
     else
-      link_to text || name.gsub(/^git-/, ""), doc_file_path(file: name)
+      link_to text || name.gsub(/^git-/, ""), doc_file_path(file: name), class: ("active" if @name == name)
     end
   end
 

--- a/app/views/books/_chapter_listings.html.erb
+++ b/app/views/books/_chapter_listings.html.erb
@@ -12,7 +12,7 @@
         <% if !section.title.empty? %>
           <li>
             <%= chapter.cs_number %>.<%= section.number %>
-            <a href="/book/<%= @book.code %>/v<%= @book.edition %>/<%= u(section.slug) %>"><%=raw section.title %></a>
+            <a href="/book/<%= @book.code %>/v<%= @book.edition %>/<%= u(section.slug) %>" <%= 'class=active' if @content.title == section.title %>><%=raw section.title %></a>
           </li>
         <% end %>
       <% end %>


### PR DESCRIPTION
To address #1359 this PR adds an "active" class to the current chapter or section.
The active item is currently styled as bold, but I'm not sure that provides enough contrast to the other entries. I experimented with the git-orange, but that looks too much like a missing link then.


![image](https://user-images.githubusercontent.com/2564094/67911347-77a20c00-fb43-11e9-8955-5f1a58bbca2c.png)

