### PR TITLE
Mark link to current subsection as active

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -328,6 +328,10 @@ var AboutContent = {
     $('section').hide(0, function(){
       $('section#' + section).show();
     });
+
+    if (section == AboutContent.defaultSection) section = 'about';
+    $('.sidebar nav .expanded a').removeClass('active');
+    $('.sidebar nav .expanded a[href$=' + section + ']').addClass('active')
   },
 
   observeNav: function() {

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -5,9 +5,11 @@ require "iso8601"
 module ApplicationHelper
 
   def sidebar_link_options(section)
-    if %w( about documentation reference book videos
-           external-links downloads guis logos community
-          ).include?(@section) && @section == section
+    if %w( about documentation downloads community
+         ).include?(@section) && @section == section ||
+       %w( reference book videos external-links
+           guis logos
+         ).include?(@subsection) && @subsection == section
       {class: "active"}
     else
       {}

--- a/app/views/shared/_sidebar.html.erb
+++ b/app/views/shared/_sidebar.html.erb
@@ -5,25 +5,25 @@
         <%= link_to "About", "/about", sidebar_link_options("about") %>
         <ul class="<%= @section == "about" ? "expanded" : ""%>">
           <li>
-            <%= link_to "Branching and Merging", "/about", sidebar_link_options("branching-and-merging") %>
+            <%= link_to "Branching and Merging", "/about" %>
           </li>
           <li>
-            <%= link_to "Small and Fast", "/about/small-and-fast", sidebar_link_options("small-and-fast") %>
+            <%= link_to "Small and Fast", "/about/small-and-fast" %>
           </li>
           <li>
-            <%= link_to "Distributed", "/about/distributed", sidebar_link_options("distributed") %>
+            <%= link_to "Distributed", "/about/distributed" %>
           </li>
           <li>
-            <%= link_to "Data Assurance", "/about/info-assurance", sidebar_link_options("info-assurance") %>
+            <%= link_to "Data Assurance", "/about/info-assurance" %>
           </li>
           <li>
-            <%= link_to "Staging Area", "/about/staging-area", sidebar_link_options("staging-area") %>
+            <%= link_to "Staging Area", "/about/staging-area" %>
           </li>
           <li>
-            <%= link_to "Free and Open Source", "/about/free-and-open-source", sidebar_link_options("free-and-open-source") %>
+            <%= link_to "Free and Open Source", "/about/free-and-open-source" %>
           </li>
           <li>
-            <%= link_to "Trademark", "/about/trademark", sidebar_link_options("trademark") %>
+            <%= link_to "Trademark", "/about/trademark" %>
           </li>
         </ul>
       </li>


### PR DESCRIPTION
* Include sub sections in `sidebar_link_options`
* Use JavaScript to mark sub sections of "About" as active
* Remove `sidebar_link_options` calls for sub sections of "About" as they will never return a class

![2EB5F41B-C0AD-484C-897B-48366E15799E](https://user-images.githubusercontent.com/2564094/67911663-8fc65b00-fb44-11e9-984c-ab28c7646ef9.GIF)
