### PR TITLE
Add scripts to list non-featured commands and guides

### DIFF
--- a/script/check-non-featured-docs.py
+++ b/script/check-non-featured-docs.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+
+import subprocess
+import re
+import argparse
+
+# Parse input
+parser = argparse.ArgumentParser( 
+    description="Compare the commands featured on the reference page of the site to the complete list of Git commands.",
+    epilog='Note: works only for GIT_VERSION >= v2.18.0',
+    formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+parser.add_argument("-g", "--git-version", default='HEAD', help="git.git revision")
+parser.add_argument("-s", "--site-version", default='HEAD', help="Site revision")
+parser.add_argument("-r", "--git-repo", default='../git', help="git.git checkout")
+args = parser.parse_args()
+
+site_version = args.site_version
+git_repo = args.git_repo
+git_version = args.git_version
+
+# Dict of ignored commands per categories
+# See https://git-scm.com/docs/git#_git_commands
+ignored_commands = {
+# Main Porcelain Commands
+'mainporcelain': {
+'name': 'Main Porcelain Commands',
+'commands': {
+'git-citool',
+'git-gui',
+'gitk',
+},},
+# Ancillary Commands / Manipulator
+'ancillarymanipulators': {
+'name': 'Ancillary Commands / Manipulator',
+'commands': {
+'git-fast-export',
+'git-pack-refs',
+'git-prune',
+'git-repack',
+'git-replace',
+},}, 
+# Ancillary Commands / Interrogators
+'ancillaryinterrogators': {
+'name': 'Ancillary Commands / Interrogators',
+'commands': {
+'git-annotate',
+'git-merge-tree', 
+'git-rerere', 
+'git-show-branch', 
+'git-verify-commit', 
+'git-verify-tag' ,
+'git-whatchanged', 
+'gitweb',
+},},
+# Interacting with Others
+'foreignscminterface': {
+'name': 'Interacting with Others',
+'commands': {
+'git-archimport', 
+'git-cvsexportcommit', 
+'git-cvsimport', 
+'git-cvsserver', 
+'git-p4', 
+'git-quiltimport',
+},},
+# Low-level Commands / Manipulators
+'plumbingmanipulators': {
+'name': 'Low-level Commands / Manipulators',
+'commands': {
+'git-commit-graph',
+'git-index-pack',
+'git-merge-file',
+'git-merge-index',
+'git-mktag',
+'git-mktree',
+'git-multi-pack-index',
+'git-pack-objects',
+'git-prune-packed',
+'git-unpack-objects',
+},},
+# Low-level Commands / Interrogators
+'plumbinginterrogators': {
+'name': 'Low-level Commands / Interrogators',
+'commands': {
+'git-cherry',
+'git-diff-files',
+'git-diff-tree',
+'git-get-tar-commit-id',
+'git-ls-remote',
+'git-name-rev',
+'git-pack-redundant',
+'git-show-index',
+'git-unpack-file',
+'git-var',
+},},
+# Low-level Commands / Synching Repositories
+'synchingrepositories': {
+'name': 'Low-level Commands / Synching Repositories',
+'commands': {
+'git-fetch-pack',
+'git-http-backend',
+'git-send-pack',
+},},
+# Low-level Commands / Synching Helpers
+'synchelpers': {
+'name': 'Low-level Commands / Synching Helpers',
+'commands': {
+'git-http-fetch',
+'git-http-push',
+'git-parse-remote',
+'git-receive-pack',
+'git-shell',
+'git-upload-archive',
+'git-upload-pack',
+},},
+# Low-level Commands / Internal Helpers
+'purehelpers': {
+'name': 'Low-level Commands / Internal Helpers',
+'commands': {
+'git-check-attr',
+'git-check-mailmap',
+'git-check-ref-format',
+'git-column',
+'git-credential',
+'git-credential-cache',
+'git-credential-store',
+'git-fmt-merge-msg',
+'git-interpret-trailers',
+'git-mailinfo',
+'git-mailsplit',
+'git-merge-one-file',
+'git-patch-id',
+'git-sh-i18n',
+'git-sh-setup',
+'git-stripspace',
+},},
+# Guides
+'guide': {
+'name': 'Guides',
+'commands': {
+'gitcore-tutorial',
+'gitcvs-migration',
+'gitdiffcore',
+'gitnamespaces',
+'gitrepository-layout',
+'gittutorial-2',
+},},
+}
+
+git_command_regex = 'git[0-9a-z-]+'
+guides_pathspec = 'app/views/shared/ref/_guides.html.erb'
+no_guides_pathspec = ':^' + guides_pathspec
+commands_and_guides_pathspec = 'app/views/shared/ref/'
+git_grep = 'grep -h --only-matching --recursive --no-line-number --no-column --extended-regexp'
+git = ['git']
+
+featured_commands = set(subprocess.check_output(git + git_grep.split() + [git_command_regex, site_version, commands_and_guides_pathspec, no_guides_pathspec], text=True).strip().split('\n'))
+featured_guides   = set(subprocess.check_output(git + git_grep.split() + [git_command_regex, site_version, guides_pathspec], text=True).strip().split('\n'))
+
+command_list_revision = git_version + ':' +  'command-list.txt'
+command_list_lines = subprocess.check_output(git +  ['-C', git_repo, 'show', command_list_revision ], text=True).strip().split('\n')
+
+print("Non-featured commands and guides:\n")
+
+for category, ignored in ignored_commands.items():
+    command_list_regex = re.compile('(' + git_command_regex + ')[ ]+' + category)
+    all_commands = set([match.group(1) for match in (command_list_regex.match(line) for line in command_list_lines) if match])
+    if category == 'guide':
+        featured = featured_guides
+    else:
+        featured = featured_commands
+    interesting = all_commands - ignored['commands']
+    missing = interesting - featured
+    num_missing = len(missing)
+    if num_missing != 0:
+        print(ignored['name'] + ' (' + str(num_missing) + '/' + str(len(all_commands)) + ', ' + str(len(ignored['commands']))  + ' ignored)')
+        for command in missing:
+            print(command)
+        print('')
+


### PR DESCRIPTION
This is kind of an RFC, but I think this script can be useful.

This PR adds a script that will compare the commands and guides listed on the "[Reference](https://git-scm.com/docs)" page of the website to the full list of Git commands and guides.

You can run it like this:
~~~~
GIT_VERSION=v2.23.0 SITE_VERSION=master ./script/check-non-featured-docs
~~~~

Both `GIT_VERSION` and `SITE_VERSION` default to `HEAD`. 

The idea is to use this script at each new Git version to check if new commands were added that we think should be featured on the website. Here is the output of the script: 

~~~bash
$ GIT_VERSION=v2.23.0  ./script/check-non-featured-docs
Non-featured commands:

Main Porcelain Commands (7/41)
   git-citool
   git-gui
   gitk
   git-notes
   git-range-diff
   git-restore
   git-switch

Ancillary Commands / Manipulator (5/11)
   git-fast-export
   git-pack-refs
   git-prune
   git-repack
   git-replace

Ancillary Commands / Interrogators (9/14)
   git-annotate
   git-difftool
   git-merge-tree
   git-rerere
   git-show-branch
   git-verify-commit
   git-verify-tag
   gitweb
   git-whatchanged

Interacting with Others (7/10)
   git-archimport
   git-cvsexportcommit
   git-cvsimport
   git-cvsserver
   git-imap-send
   git-p4
   git-quiltimport

Low-level Commands / Manipulators (10/19)
   git-commit-graph
   git-index-pack
   git-merge-file
   git-merge-index
   git-multi-pack-index
   git-mktag
   git-mktree
   git-pack-objects
   git-prune-packed
   git-unpack-objects

Low-level Commands / Interrogators (10/20)
   git-cherry
   git-diff-files
   git-diff-tree
   git-get-tar-commit-id
   git-ls-remote
   git-name-rev
   git-pack-redundant
   git-show-index
   git-unpack-file
   git-var

Low-level Commands / Synching Repositories (3/5)
   git-fetch-pack
   git-http-backend
   git-send-pack

Low-level Commands / Synching Helpers (7/7)
   git-http-fetch
   git-http-push
   git-parse-remote
   git-receive-pack
   git-shell
   git-upload-archive
   git-upload-pack

Low-level Commands / Internal Helpers (16/17)
   git-check-attr
   git-check-mailmap
   git-check-ref-format
   git-column
   git-credential
   git-credential-cache
   git-credential-store
   git-fmt-merge-msg
   git-interpret-trailers
   git-mailinfo
   git-mailsplit
   git-merge-one-file
   git-patch-id
   git-sh-i18n
   git-sh-setup
   git-stripspace

Non-featured guides (6/16)
   gitcore-tutorial
   gitcvs-migration
   gitdiffcore
   gitnamespaces
   gitrepository-layout
   gittutorial-2
~~~

Note: The script requires Git 2.19 or higher since it uses some `git grep` flags that only became available in this version.


---
Some comments on the current output of the script:
- I think the site should probably feature all the "Main Porcelain" commands (except maybe citool)
- `git mergetool` is featured, but not `git difftool`
- Maybe the Reference page could have a footer like "All commands" that would link to https://git-scm.com/docs/git#_git_commands

I'm looking forward to the discussion. We could take this opportunity to talk about which of the commands listed above should or should not be featured.
P.S. If you think this PR is valuable, should the script be mentioned in the README?