### PR TITLE
re-add conservancy banner

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -29,6 +29,13 @@
 
 <body id="<%= @section %>">
 
+  <%= render layout: "shared/banner", locals: { id: "conservancy2019", dismissable: true } do %>
+      Git is a member of Software Freedom Conservancy, which handles
+      legal and financial needs for the project.  Conservancy is
+      currently raising funds to continue their mission. Consider
+      <a href="https://sfconservancy.org/supporter/">becoming a supporter</a>!
+  <% end %>
+
   <div class="inner">
     <%= render partial: "shared/header" %>
   </div> <!-- .inner -->


### PR DESCRIPTION
It's end-of-year donation time again, so let's point visitors to Conservancy's donation page.

This is effectively a revert of aa0c5d0 (drop conservancy donation banner, 2019-01-09), but with the year in the dismissal tag bumped to 2019.

There's actually a pretty cute ascii-art banner they're providing at https://sfconservancy.org/img/banners/2019-member-projects-banner.png, but I had trouble making it look good on the site (it's quite tall if you let it take the whole width).
