### PR TITLE
Add check for page's referrer before auto download.

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -245,10 +245,17 @@ var Downloads = {
     var ref = document.referrer;
     var src = $('#auto-download-link').attr('href');
 
-    if (ref && src && ref.indexOf(document.location.origin) === 0) {
+    if (this.shouldAutoDownload(ref, src)) {
       $('.downloading .hide').show();
       document.location = src;
     }
+  },
+
+  shouldAutoDownload: function(ref, src) {
+    if (!ref || !src) {
+      return false;
+    }
+    return ref.indexOf(document.location.origin) === 0;
   },
 
   getOSFilter: function() {

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -238,18 +238,16 @@ var Downloads = {
     Downloads.observeGUIOSFilter();
     Downloads.observePopState();
     Downloads.filterGUIS();
-    Downloads.autoDownload();
+    Downloads.triggerAutoDownload();
   },
 
-  autoDownload: function() {
+  triggerAutoDownload: function() {
     var ref = document.referrer;
     var src = $('#auto-download-link').attr('href');
 
     if (ref && src && ref.indexOf(document.location.origin) === 0) {
-      $('.download .hide').removeClass('hide');
-      $('<iframe frameborder="0" height="1" width="1"></iframe>')
-        .attr('src', src)
-        .appendTo('body');
+      $('.downloading .hide').show();
+      document.location = src;
     }
   },
 

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -238,6 +238,19 @@ var Downloads = {
     Downloads.observeGUIOSFilter();
     Downloads.observePopState();
     Downloads.filterGUIS();
+    Downloads.autoDownload();
+  },
+
+  autoDownload: function() {
+    var ref = document.referrer;
+    var src = $('#auto-download-link').attr('href');
+
+    if (ref && src && ref.indexOf(document.location.origin) === 0) {
+      $('.download .hide').removeClass('hide');
+      $('<iframe frameborder="0" height="1" width="1"></iframe>')
+        .attr('src', src)
+        .appendTo('body');
+    }
   },
 
   getOSFilter: function() {

--- a/app/assets/stylesheets/downloads.scss
+++ b/app/assets/stylesheets/downloads.scss
@@ -121,3 +121,7 @@
   display: none;
   color: $orange;
 }
+
+.downloading .hide {
+  display: none;
+}

--- a/app/views/downloads/download_windows.html.erb
+++ b/app/views/downloads/download_windows.html.erb
@@ -9,12 +9,12 @@
 <div id="main">
   <h1>Downloading Git</h1>
   <div class="callout downloading">
-    <h3>Your download is starting...</h3>
+    <h3 class="hide">Your download is starting...</h3>
     <p>
       <%= raw "You are downloading the latest (<strong>#{@download.version.name}</strong>) <strong>#{@bitness}</strong> version of <strong>Git for Windows</strong>. This is the most recent <a href='#{@project_url}'>maintained build</a>. It was released <strong>#{time_ago_in_words @download.release_date} ago</strong>, on #{@download.release_date.strftime("%Y-%m-%d")}." %>
     </p>
     <p>
-      <%= raw "<strong>If your download hasn't started, <a href=\"#{@download.url}\">click here to download manually</a>.</strong>" %>
+      <%= raw "<strong><a id=\"auto-download-link\" href=\"#{@download.url}\">Click here to download manually</a><span class=\"hide\">, if your download hasn't started.</span></strong>" %>
     </p>
     <h3>Other Git for Windows downloads</h3>
     <h4>Git for Windows Setup</h4>
@@ -34,7 +34,6 @@
     <p class="small">
       <%= raw "The current source code release is version <strong>#{@latest.name}</strong>. If you want the newer version, you can build it from <a href=\"#{@source_url}\">the source code</a>." %>
     </p>
-    <iframe frameborder="0" height="1" src="<%= @download.url %>" width="1"></iframe>
   </div>
   <h2>Now What?</h2>
   <p>
@@ -64,4 +63,3 @@
     </li>
   </ul>
 </div>
-

--- a/app/views/downloads/downloading.html.erb
+++ b/app/views/downloads/downloading.html.erb
@@ -9,18 +9,17 @@
 <div id="main">
   <h1>Downloading Git</h1>
   <div class="callout downloading">
-    <h3>Your download is starting...</h3>
+    <h3 class="hide">Your download is starting...</h3>
     <p>
       <%= raw "You are downloading version <strong>#{@download.version.name}</strong> of Git for the <strong>#{@platform.capitalize}</strong> platform. This is the most recent <a href='#{@project_url}'>maintained build</a> for this platform. It was released <strong>#{time_ago_in_words @download.release_date} ago</strong>, on #{@download.release_date.strftime("%Y-%m-%d")}." %>
     </p>
     <p>
-      <%= raw "<strong>If your download hasn't started, <a href=\"#{@download.url}\">click here to download manually</a>.</strong>" %>
+    <%= raw "<strong><a id=\"auto-download-link\" href=\"#{@download.url}\">Click here to download manually</a><span class=\"hide\">, if your download hasn't started.</span></strong>" %>
     </p>
     <p class="small">
       <%= raw "The current source code release is version <strong>#{@latest.name}</strong>. If you want the newer version, you can build it from <a href=\"#{@source_url}\">the source code</a>." %>
     </p>
   </div>
-  <iframe frameborder="0" height="1" src="<%= @download.url %>" width="1"></iframe>
   <h2>Now What?</h2>
   <p>
     Now that you have downloaded Git, it's time to start using it.
@@ -49,4 +48,3 @@
     </li>
   </ul>
 </div>
-


### PR DESCRIPTION
This prevents someone from clicking a Google search result leading to an
automatic download that likely is not necessary.