### PR TITLE
ARCHITECTURE.md: update for Cloudflare teams

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -105,13 +105,14 @@ The Cloudflare setup is mostly pretty simple:
    but the long-term goal is to push that logic onto the client side as
    much as possible.
 
-There's a single Cloudflare account/password that controls the site.
-There's no team setup, but the information is in escrow with the Git PLC
-at Software Freedom Conservancy. Cloudflare provides the project with
-enough credits that it doesn't cost anything (though we're not using
-very many features, so it's possible that a free account would be
-sufficient, too).
-
+Both domains (c.f., the section on [DNS](#DNS) below) are owned by a
+Cloudflare "Team", and membership of that team is required to
+administrate the domains. Similar to the Heroku setup, you can ask to
+join this team if you wish to help out. The information about the team
+setup is in escrow with the Git PLC at Software Freedom Conservancy.
+Cloudflare provides the project with enough credits that it doesn't cost
+anything (though we're not using very many features, so it's possible
+that a free account would be sufficient, too).
 
 ## Bonsai Elasticsearch
 


### PR DESCRIPTION
Cloudflare now supports shared ownership of domains, and we use this
feature to administrate both 'git-scm.org' and 'git-scm.com'.

Since our adoption of this feature, the 'DNS' section of the
architecture document is out of date, and instead refers to the
old-style single-account setup.

Update the documentation here to reflect the current architecture, so
that others in the future can volunteer to help if they wish to do so.