### PR TITLE
Revert "re-add conservancy banner"

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -29,13 +29,6 @@
 
 <body id="<%= @section %>">
 
-  <%= render layout: "shared/banner", locals: { id: "conservancy2019", dismissable: true } do %>
-      Git is a member of Software Freedom Conservancy, which handles
-      legal and financial needs for the project.  Conservancy is
-      currently raising funds to continue their mission. Consider
-      <a href="https://sfconservancy.org/supporter/">becoming a supporter</a>!
-  <% end %>
-
   <div class="inner">
     <%= render partial: "shared/header" %>
   </div> <!-- .inner -->


### PR DESCRIPTION
This reverts commit c6154378a52a36a7ab9da4a368e8ae87074b2afc.

The main goal was to get attention in the December charity season, and it's now almost the end of January. Let's drop the banner for the time being.
