### PR TITLE
Add 'Git for Teams' to ext book list

### DIFF
--- a/app/views/doc/_ext_books.erb
+++ b/app/views/doc/_ext_books.erb
@@ -50,6 +50,13 @@
           By Kenneth Geisshirt
         </p>
       </li>
+      <li>
+        <a href="http://gitforteams.com/"><img src="http://akamaicovers.oreilly.com/images/0636920034520/cat.gif"></a>
+        <h4><a href="http://gitforteams.com/">Git for Teams</a></h4>
+        <p class='description'>
+          By Emma Jane Hogbin Westby
+        </p>
+      </li>
     </ul>
   </div>
   <div class='column-right'>
@@ -103,13 +110,6 @@
           By Alex Magana, Joseph Muli
         </p>
       </li>      
-      <li>
-        <a href="http://gitforteams.com/"><img src="http://akamaicovers.oreilly.com/images/0636920034520/cat.gif"></a>
-        <h4><a href="http://gitforteams.com/">Git for Teams</a></h4>
-        <p class='description'>
-          By Emma Jane Hogbin Westby
-        </p>
-      </li>
     </ul>
   </div>
 </div>

--- a/app/views/doc/_ext_books.erb
+++ b/app/views/doc/_ext_books.erb
@@ -102,6 +102,13 @@
         <p class='description'>
           By Alex Magana, Joseph Muli
         </p>
+      </li>      
+      <li>
+        <a href="http://gitforteams.com/"><img src="http://akamaicovers.oreilly.com/images/0636920034520/cat.gif"></a>
+        <h4><a href="http://gitforteams.com/">Git for Teams</a></h4>
+        <p class='description'>
+          By Emma Jane Hogbin Westby
+        </p>
       </li>
     </ul>
   </div>


### PR DESCRIPTION
This book is relatively recent, compared to the others in the list, so I was wondering whether it might make a good addition. cc @EmmaJane

The right column is now 1 item larger. If that's an issue, shall we add another recent book to the left, or maybe remove an older one from `column-right`? If the latter, "Pragmatic Version Control Using Git" could be a candidate, because Travis Swicegood's 2nd, more recent book is also in `column-right`.