### PR TITLE
trademark policy: spell out US reg#

### DIFF
--- a/app/views/about/_trademark.html.erb
+++ b/app/views/about/_trademark.html.erb
@@ -14,7 +14,7 @@
   and its free and open source nature is clear to everyone. By
   using this Policy, the Git Project can spread the use of the
   Git software while making sure that the Marks are protected in a
-  way that's consistent with U.S. trademark law.  This Policy is
+  way that's consistent with U.S. trademark law (<a href="https://tsdr.uspto.gov/#caseNumber=4680534&caseSearchType=US_APPLICATION&caseType=DEFAULT&searchType=statusSearch">U.S. Registration 4680534</a>).  This Policy is
   written to allow all clear and appropriate use of the Marks while
   disapproving use of the Marks in ways that could confuse users as
   to where the software came from, or that implies an otherwise non-


### PR DESCRIPTION
People around me at Google weren't aware of the trademark status, and told me that this page looked like a well intentioned science fiction as their search at USPTO did not find our registration filing.

Let's give readers an easy access to these details; the search link may go stale over time, and we may need to keep an eye on it.