### PR TITLE
Gemfile: drop json gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,6 @@ gem "puma"
 gem "tilt"
 
 gem "diff-lcs"
-gem "json"
 gem "launchy"
 gem "netrc"
 gem "nokogiri"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,7 +107,6 @@ GEM
       concurrent-ruby (~> 1.0)
     iso8601 (0.10.1)
     jaro_winkler (1.5.1)
-    json (2.1.0)
     launchy (2.4.3)
       addressable (~> 2.3)
     loofah (2.3.1)
@@ -281,7 +280,6 @@ DEPENDENCIES
   faraday_middleware
   foreman
   iso8601
-  json
   launchy
   netrc
   nokogiri
@@ -311,4 +309,4 @@ RUBY VERSION
    ruby 2.4.2p198
 
 BUNDLED WITH
-   1.17.1
+   1.17.3


### PR DESCRIPTION
This is an alternative to #1441, as we don't seem to be using the gem at all. There's no `require 'json'` line, though we do have one call to `JSON.generate()` for the taglines on the main page. This _seems_ to work anyway, though.
