### PR TITLE
manpage-l10n fix import script to manage zh_HANS-CN

### DIFF
--- a/lib/tasks/index.rake
+++ b/lib/tasks/index.rake
@@ -27,7 +27,7 @@ def index_l10n_doc(filter_tags, doc_list, get_content)
 
     tag_files = doc_list.call(tree_sha)
     doc_files = tag_files.select { |ent| ent.first =~
-        /^([_\w]+)\/(
+        /^([-_\w]+)\/(
           (
             git.*
         )\.txt)/x


### PR DESCRIPTION
The regex must include '-' to import zh HANS pages.