### PR TITLE
asciidoc fixups

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ ruby "2.4.2"
 
 gem "rails", "~> 4.2.11"
 
-gem "asciidoctor", ">=1.5.4"
+gem "asciidoctor", "~> 2.0.0"
 gem "elasticsearch", "2.0.2"
 gem "faraday"
 gem "faraday_middleware"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,7 +38,7 @@ GEM
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
     arel (6.0.4)
-    asciidoctor (1.5.6.1)
+    asciidoctor (2.0.10)
     ast (2.4.0)
     awesome_print (1.8.0)
     better_errors (2.4.0)
@@ -265,7 +265,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  asciidoctor (>= 1.5.4)
+  asciidoctor (~> 2.0.0)
   awesome_print
   better_errors
   binding_of_caller

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -79,17 +79,6 @@ ActiveRecord::Schema.define(version: 20190131210305) do
     t.datetime "release_date"
   end
 
-  create_table "related_items", force: :cascade do |t|
-    t.string   "name"
-    t.string   "content_type"
-    t.string   "content_url"
-    t.string   "related_type"
-    t.string   "related_id"
-    t.integer  "score"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-  end
-
   create_table "sections", force: :cascade do |t|
     t.string   "title"
     t.string   "slug"

--- a/lib/tasks/index.rake
+++ b/lib/tasks/index.rake
@@ -5,6 +5,13 @@ require "octokit"
 require "time"
 require "digest/sha1"
 
+def make_asciidoc(content)
+    Asciidoctor::Document.new(content,
+                              attributes: {
+                                "sectanchors" => "",
+                              },
+                              doctype: "book")
+end
 
 def index_l10n_doc(filter_tags, doc_list, get_content)
 
@@ -78,7 +85,7 @@ def index_l10n_doc(filter_tags, doc_list, get_content)
       categories = {}
       expand!(full_path, content, get_content_f, categories)
       content.gsub!(/link:(?:technical\/)?(\S*?)\.html(\#\S*?)?\[(.*?)\]/m, "link:/docs/\\1/#{lang}\\2[\\3]")
-      asciidoc = Asciidoctor::Document.new(content, attributes: {"sectanchors" => ""}, doctype: "book")
+      asciidoc = make_asciidoc(content)
       asciidoc_sha = Digest::SHA1.hexdigest(asciidoc.source)
       doc = Doc.where(blob_sha: asciidoc_sha).first_or_create
       if rerun || !doc.plain || !doc.html
@@ -241,7 +248,7 @@ def index_doc(filter_tags, doc_list, get_content)
 
         content = expand_content((get_content.call sha).force_encoding("UTF-8"), path, get_content_f, generated)
         content.gsub!(/link:(?:technical\/)?(\S*?)\.html(\#\S*?)?\[(.*?)\]/m, "link:/docs/\\1\\2[\\3]")
-        asciidoc = Asciidoctor::Document.new(content, attributes: {"sectanchors" => ""}, doctype: "book")
+        asciidoc = make_asciidoc(content)
         asciidoc_sha = Digest::SHA1.hexdigest(asciidoc.source)
         doc = Doc.where(blob_sha: asciidoc_sha).first_or_create
         if rerun || !doc.plain || !doc.html

--- a/lib/tasks/index.rake
+++ b/lib/tasks/index.rake
@@ -9,6 +9,7 @@ def make_asciidoc(content)
     Asciidoctor::Document.new(content,
                               attributes: {
                                 "sectanchors" => "",
+                                "litdd" => "&\#x2d;&\#x2d;",
                               },
                               doctype: "book")
 end


### PR DESCRIPTION
This fixes the litdd issue noticed by @jakseb in #1452, and bumps the asciidoctor version to stay closer to what upstream Git is testing with. Plus a few other minor cleanups.