### PR TITLE
docs: Force asciidoctor in compat mode

### DIFF
--- a/lib/tasks/index.rake
+++ b/lib/tasks/index.rake
@@ -10,6 +10,7 @@ def make_asciidoc(content)
                               attributes: {
                                 "sectanchors" => "",
                                 "litdd" => "&\#x2d;&\#x2d;",
+				"compat-mode" => "",
                               },
                               doctype: "book")
 end

--- a/lib/tasks/index.rake
+++ b/lib/tasks/index.rake
@@ -10,7 +10,7 @@ def make_asciidoc(content)
                               attributes: {
                                 "sectanchors" => "",
                                 "litdd" => "&\#x2d;&\#x2d;",
-				"compat-mode" => "",
+                                "compat-mode" => "",
                               },
                               doctype: "book")
 end


### PR DESCRIPTION
This is needed because some documents are now using the new style of
section title but are still relying on formatting behaviours that are
no longer the default of asciidoctor.

See discussion in #1452