### PR TITLE
docs: add gitfaq to the list of guides

### DIFF
--- a/app/views/shared/ref/_guides.html.erb
+++ b/app/views/shared/ref/_guides.html.erb
@@ -3,6 +3,7 @@
   <li><%= man('gitattributes') %></li>
   <li><%= man('gitcli', 'Command-line interface conventions') %></li>
   <li><%= man('giteveryday', 'Everyday Git') %></li>
+  <li><%= man('gitfaq', 'Frequently Asked Questions (FAQ)') %></li>
   <li><%= man('gitglossary', 'Glossary') %></li>
   <li><%= man('githooks') %></li>
   <li><%= man('gitignore') %></li>


### PR DESCRIPTION
Git 2.27 will add a new guide, `gitfaq.txt`, which is a list of frequently asked questions about Git.
Add this new guide to the list of guides in the docs.

This should be merged after 2.27 is out to prevent a 404.