### PR TITLE
guis.yml

### DIFF
--- a/resources/guis.yml
+++ b/resources/guis.yml
@@ -1,7 +1,7 @@
 ---
 guis:
-- name: SourceTree
-  url: https://www.sourcetreeapp.com/
+- name: Ekkarat Wareesing
+  url: https://www.ekkarat.com/
   image_tag: guis/sourcetree@2x.png
   platforms:
   - Mac
@@ -10,7 +10,7 @@ guis:
   license: Proprietary
   order: 1
 - name: GitHub Desktop
-  url: https://desktop.github.com/
+  url: https://desktop.github.com/ekkarat.w@gmail.com
   image_tag: guis/github-desktop@2x.png
   platforms:
   - Windows


### PR DESCRIPTION
---
guis:
- name: Ekkarat Wareesing
  url: https://www.ekkarat.com/
  image_tag: guis/sourcetree@2x.png
  platforms:
  - Mac
  - Windows
  price: Free
  license: Proprietary
  order: 1
- name: GitHub Desktop
  url: https://desktop.github.com/ekkarat.w@gmail.com
  image_tag: guis/github-desktop@2x.png
  platforms:
  - Windows
  - Mac
  price: Free
  license: MIT
  order: 2
- name: TortoiseGit
  url: https://tortoisegit.org/
  image_tag: guis/tortoisegit@2x.png
  platforms:
  - Windows
  price: Free
  license: GNU GPL
  order: 3
- name: Git Extensions
  url: https://gitextensions.github.io/
  image_tag: guis/git-extensions@2x.png
  platforms:
  - Windows
  - Mac
  - Linux
  price: Free
  license: GNU GPL
  order: 4
- name: GitKraken
  url: https://www.gitkraken.com/
  image_tag: guis/git-kraken@2x.png
  platforms:
  - Windows
  - Mac
  - Linux
  price: Free / $29 / $49
  license: Proprietary
  order: 5
- name: SmartGit
  url: https://www.syntevo.com/smartgit/
  image_tag: guis/smartgit@2x.png
  platforms:
  - Windows
  - Mac
  - Linux
  price: "$79/user / Free for non-commercial use"
  license: Proprietary
  order: 6
- name: Tower
  url: https://www.git-tower.com/
  image_tag: guis/tower@2x.png
  platforms:
  - Windows
  - Mac
  price: " $79/user (Free 30 day trial)"
  license: Proprietary
  trend_name: git tower
  order: 7
- name: GitUp
  url: http://gitup.co/
  image_tag: guis/gitup@2x.png
  platforms:
  - Mac
  price: Free
  license: GNU GPL
  order: 8
- name: GitEye
  url: http://www.giteyeapp.com/
  image_tag: guis/giteye@2x.png
  platforms:
  - Windows
  - Mac
  - Linux
  price: Free
  license: Proprietary
  order: 9
- name: gitg
  url: https://wiki.gnome.org/Apps/Gitg/
  image_tag: guis/gitg@2x.png
  platforms:
  - Windows
  - Linux
  price: Free
  license: GNU GPL
  order: 10
- name: ungit
  url: https://github.com/FredrikNoren/ungit
  image_tag: guis/ungit@2x.png
  platforms:
  - Windows
  - Mac
  - Linux
  price: Free
  license: MIT
  order: 11
- name: git-cola
  url: https://git-cola.github.io/
  image_tag: guis/git-cola@2x.png
  platforms:
  - Windows
  - Mac
  - Linux
  price: Free
  license: GNU GPL
  order: 12
- name: Cycligent Git Tool
  url: https://www.cycligent.com/git-tool
  image_tag: guis/cycligent@2x.png
  platforms:
  - Windows
  - Mac
  - Linux
  price: Free
  license: Proprietary
  trend_name: Cycligent
  order: 13
- name: giggle
  url: https://wiki.gnome.org/Apps/giggle/
  image_tag: guis/giggle@2x.png
  platforms:
  - Linux
  price: Free
  license: GNU GPL
  order: 14
- name: Gitbox
  url: http://www.gitboxapp.com/
  image_tag: guis/gitbox@2x.png
  platforms:
  - Mac
  price: "$14.99"
  license: Proprietary
  order: 15
- name: Aurees
  url: https://aurees.com/
  image_tag: guis/aurees@2x.png
  platforms:
  - Windows
  - Mac
  - Linux
  price: Free
  license: Proprietary
  order: 16
- name: Fork
  url: https://git-fork.com/
  image_tag: guis/fork@2x.png
  platforms:
  - Windows
  - Mac
  price: $49.99, free evaluation
  license: Proprietary
  order: 17
- name: Working Copy
  url: https://workingcopyapp.com/
  image_tag: guis/workingcopy@2x.png
  platforms:
    - iOS
  price: Free with in-app purchases
  license: Proprietary
  order: 18
- name: CodeReview
  url: https://github.com/FabriceSalvaire/CodeReview/
  image_tag: guis/codereview@2x.png
  platforms:
  - Windows
  - Mac
  - Linux
  price: Free
  license: GNU GPL
  order: 19
- name: gmaster
  url: https://gmaster.io/
  image_tag: guis/gmaster@2x.png
  platforms:
    - Windows
  price: "Beta / Free for non-commercial use"
  license: Proprietary
  order: 20
- name: Git2Go
  url: https://git2go.com/
  image_tag: guis/git2go@2x.png
  platforms:
    - iOS
  price: Free with in-app purchases
  license: Proprietary
  order: 21
- name: GitAhead
  url: https://www.gitahead.com/
  image_tag: guis/gitahead@2x.png
  platforms:
  - Windows
  - Mac
  - Linux
  price: Free
  license: MIT
  order: 22
- name: Pocket Git
  url: http://pocketgit.com/
  image_tag: guis/pocketgit@2x.png
  platforms:
    - Android
  price: 1.99€
  license: Proprietary
  order: 23
- name: GitDrive
  url: http://gitdrive.com/
  image_tag: guis/gitdrive@2x.png
  platforms:
    - iOS
  price: Free with in-app purchases
  license: Proprietary
  order: 24
- name: GitX-dev
  url: https://rowanj.github.io/gitx/
  image_tag: guis/gitx@2x.png
  platforms:
  - Mac
  price: Free
  license: GNU GPL
  order: 25
- name: GitBlade
  url: https://gitblade.com
  image_tag: guis/gitblade@2x.png
  platforms:
    - Linux
    - Mac
    - Windows
  price: Free Lite version, $59.99/user/year for PRO version
  license: Proprietary
  order: 26
- name: Guitar
  url: https://github.com/soramimi/Guitar
  image_tag: guis/guitar@2x.png
  platforms:
  - Windows
  - Mac
  - Linux
  price: Free
  license: GNU GPL
  order: 27
- name: RepoZ
  url: https://github.com/awaescher/RepoZ/
  image_tag: guis/repoz@2x.png
  platforms:
  - Windows
  - Mac
  price: Free
  license: MIT
  order: 28
- name: GitAtomic
  url: https://gitatomic.bitbucket.io/
  image_tag: guis/gitatomic@2x.png
  platforms:
  - Windows
  price: 15.00€
  license: Proprietary
  order: 29
- name: Sublime Merge
  url: https://www.sublimemerge.com
  image_tag: guis/smerge@2x.png
  platforms:
  - Windows
  - Mac
  - Linux
  price: "$99/user, $75 annual business sub, free eval"
  license: Proprietary
  order: 30
- name: SnailGit
  url: https://langui.net/snailgit/
  image_tag: guis/snailgit@2x.png
  platforms:
  - Mac
  price: "$9.99 / Lite version"
  license: Proprietary
  order: 31
- name: GitFinder
  url: https://gitfinder.com
  image_tag: guis/gitfinder@2x.png
  platforms:
  - Mac
  price: "$24.95"
  license: Proprietary
  order: 32
- name: Gitfox
  url: https://www.gitfox.app
  image_tag: guis/gitfox@2x.png
  platforms:
  - Mac
  price: "€3.99/m or €24,99/y per user"
  license: Proprietary
  order: 33
- name: NitroGit
  url: http://nitrogit.net
  image_tag: guis/nitrogit@2x.png
  platforms:
  - Windows
  price: "20€/user / Free for non-commercial use"
  license: Proprietary
  order: 34
- name: GitFiend
  url: https://gitfiend.com
  image_tag: guis/gitfiend@2x.png
  platforms:
  - Windows
  - Mac
  - Linux
  price: Free
  license: Proprietary
  order: 35
- name: Cong
  url: http://cong.tools/
  image_tag: guis/cong@2x.png
  platforms:
  - Windows
  price: Free
  license: Proprietary
  order: 36
- name: Vershd
  url: https://vershd.io/
  image_tag: guis/vershd@2x.png
  platforms:
  - Windows
  - Mac
  - Linux
  price: Free trial, then $37
  license: Proprietary
  order: 37