### PR TITLE
Add information about Git Rev News

### DIFF
--- a/app/views/community/index.html.erb
+++ b/app/views/community/index.html.erb
@@ -79,6 +79,12 @@
     If you need specific help about one of the for-profit Git hosting sites, you might try their own IRC channels (such as <span class="highlight fixed">#github</span> or <span class="highlight fixed">#gitlab</span>) on the same IRC server.
   </p>
 
+  <h2> Newsletter </h2>
+
+  <p>
+    There is a monthly community newsletter called <a href="https://git.github.io/rev_news/rev_news/">"Git Rev News"</a>, with <a href="https://git.github.io/rev_news/archive/">its archive</a> and <a href="https://git.github.io/rev_news/">its latest edition</a>. Information on how to subscribe can be found on the <a href="https://git.github.io/rev_news/rev_news/">dedicated webpage</a>.
+  </p>
+
   <h2> Contributing to Git </h2>
 
   <p>


### PR DESCRIPTION
Add a "News Letter" section with information about Git Rev News.

Closes https://github.com/git/git-scm.com/issues/1476

cc @phil-blain @pedrorijo91 