### PR TITLE
Add information about Git Developer Pages

### DIFF
--- a/app/views/community/index.html.erb
+++ b/app/views/community/index.html.erb
@@ -84,3 +84,7 @@
   <p>
     The <a href="https://github.com/git/git/tree/master/Documentation">Documentation directory</a> in the Git source code has several files of interest to developers who are looking to help contribute. After reading the <a href="https://github.com/git/git/blob/master/Documentation/CodingGuidelines">coding guidelines</a>, you can learn <a href="/docs/SubmittingPatches">how to submit patches</a>. If you are just starting out, you can read the <a href="/docs/MyFirstContribution">My First Contribution tutorial</a>. For those looking to get more deeply involved, there is a <a href="https://github.com/git/git/blob/master/Documentation/howto/maintain-git.txt">howto for Git maintainers</a>.
   </p>
+
+  <p>
+    The <a href="https://git.github.io/">Git Developer Pages</a> have a <a href="https://git.github.io/Hacking-Git/">Hacking Git page</a> which lists useful development resources. They also have <a href="https://git.github.io/General-Application-Information/">information</a> for people applying to work on Git as part of programs like <a href="https://www.outreachy.org/">Outreachy</a> or the <a href="https://summerofcode.withgoogle.com/">Google Summer of Code</a>.
+  </p>


### PR DESCRIPTION
The Git Developer Pages contain interesting information for potential developers, so let's add a few links to them in the Contributing to Git section.

cc @phil-blain @pedrorijo91 @peff 