### PR TITLE
Update "Git Beginner's Guide for Dummies" in the External Links section.

### DIFF
--- a/app/views/doc/_ext_tutorials.erb
+++ b/app/views/doc/_ext_tutorials.erb
@@ -27,10 +27,10 @@
         </p>
       </li>
       <li>
-        <h4><a href="https://backlog.com/git-tutorial/en/">Git Beginner's Guide for Dummies</a></h4>
+        <h4><a href="https://backlog.com/git-tutorial/">Backlog Git Tutorial</a></h4>
         <p class='description'>
-          This guide includes an introduction for complete beginners as well as hands-on tutorials for intermediate learners.
-          ( <a href="https://backlog.com/git-tutorial/kr/">Korean</a> / <a href="https://backlog.com/git-tutorial/cn/">Simplified Chinese</a> / <a href="https://backlog.com/git-tutorial/tw/">Traditional Chinese</a> / <a href="https://backlog.com/git-tutorial/vn/">Vietnamese</a> )
+          It includes an introduction for complete beginners as well as hands-on tutorials for intermediate learners.
+          ( <a href="https://backlog.com/git-tutorial/ja/">Japanese</a> / <a href="https://backlog.com/git-tutorial/kr/">Korean</a> / <a href="https://backlog.com/git-tutorial/cn/">Simplified Chinese</a> / <a href="https://backlog.com/git-tutorial/tw/">Traditional Chinese</a> / <a href="https://backlog.com/git-tutorial/vn/">Vietnamese</a> )
         </p>
       </li>
     </ul>


### PR DESCRIPTION
Hi,

I am an employee of a company called Nulab Inc.
We are running https://backlog.com/git-tutorial/ that linked from the External Link section. We updated that site and we also want to update the External Link section.

- Update the link text to "Backlog Git Tutorial" from "Git Beginner's Guide for Dummies".
- Add a link to the Japanese page.

Thank you.