### PR TITLE
Use prominent color for "Release notes" link

### DIFF
--- a/app/assets/stylesheets/front-page.scss
+++ b/app/assets/stylesheets/front-page.scss
@@ -146,7 +146,7 @@ $monitor-height: 271px;
   }
 
   a {
-    color: #59d6de;
+    color: #eee;
     font-size: 12px;
   }
 

--- a/app/assets/stylesheets/front-page.scss
+++ b/app/assets/stylesheets/front-page.scss
@@ -148,6 +148,7 @@ $monitor-height: 271px;
   a {
     color: #eee;
     font-size: 12px;
+    text-decoration: underline;
   }
 
   span.release-date {
@@ -171,6 +172,7 @@ $monitor-height: 271px;
     border-left: solid 1px #1f6367;
     transition-duration: 0.3s;
     transition-property: background-image;
+    text-decoration: none;
 
     &:hover {
       background-image: linear-gradient(#1a7e84, #165b60);


### PR DESCRIPTION
The color used for the "Release notes" link in home page has poor contrast
with its background making it hard to notice.

So, use a more prominent color for the link.