### PR TITLE
docs: add a link to the list of all guides

### DIFF
--- a/app/views/shared/ref/_guides.html.erb
+++ b/app/views/shared/ref/_guides.html.erb
@@ -5,7 +5,7 @@
   <li><%= man('giteveryday', 'Everyday Git') %></li>
   <li><%= man('gitfaq', 'Frequently Asked Questions (FAQ)') %></li>
   <li><%= man('gitglossary', 'Glossary') %></li>
-  <li><%= man('githooks') %></li>
+  <li><%= man('githooks', 'Hooks') %></li>
   <li><%= man('gitignore') %></li>
   <li><%= man('gitmodules') %></li>
   <li><%= man('gitrevisions', 'Revisions') %></li>

--- a/app/views/shared/ref/_guides.html.erb
+++ b/app/views/shared/ref/_guides.html.erb
@@ -12,4 +12,5 @@
   <li><%= man('gitsubmodules', 'Submodules') %></li>
   <li><%= man('gittutorial', 'Tutorial') %></li>
   <li><%= man('gitworkflows', 'Workflows') %></li>
+  <li><a href="/docs/git#_guides">All guides...<a/></li>
 </ul>


### PR DESCRIPTION
Since git/git@f442f28a81 (git.txt: add list of guides, 2020-08-05), the
git(1) man page includes a list of all Git guides.

Add a link to this section of the man page at the bottom of the 'Guides'
section of the main documentation page, to improve discoverability.

While at it, make the link to 'githooks' more beginner-friendly.

This PR is in preparation for Git 2.29.

**Note**: I did not use the `man` function, so the link will be to the English version of the `git` man page, even if the currently viewed page is in another language. I couldn't figure out how to easily link to a section of the page in another language since the anchors are localized and I couldn't figure out how to get the correct localized anchor from the English anchor "`_guides`" (in fact I think it's not possible). I don't think it's such a big deal because anyway the `git(1)` man page is not localized in any language.

@peff @jnavila 