### PR TITLE
prefer `HEAD` to `master` in update tasks

### DIFF
--- a/lib/tasks/book2.rake
+++ b/lib/tasks/book2.rake
@@ -190,7 +190,7 @@ task remote_genbook2: :environment do
     books = Book.all_books.select { |code, repo| code == ENV["GENLANG"] }
   else
     books = Book.all_books.select do |code, repo|
-      repo_head = @octokit.ref(repo, "heads/master").object[:sha]
+      repo_head = @octokit.commit(repo, "HEAD").commit.sha
       book = Book.where(edition: 2, code: code).first_or_create
       repo_head != book.ebook_html
     end
@@ -210,7 +210,7 @@ task remote_genbook2: :environment do
             blob_content[file_handle[:sha]]
           end
         end
-        repo_head = @octokit.ref(repo, "heads/master").object[:sha]
+        repo_head = @octokit.commit(repo, "HEAD").commit.sha
 
         book = Book.where(edition: 2, code: code).first_or_create
         book.ebook_html = repo_head

--- a/lib/tasks/book2.rake
+++ b/lib/tasks/book2.rake
@@ -202,7 +202,8 @@ task remote_genbook2: :environment do
         content = Base64.decode64(@octokit.blob(repo, sha, encoding: "base64").content)
         blobs[sha] = content.force_encoding("UTF-8")
       end
-      repo_tree = @octokit.tree(repo, "HEAD", recursive: true)
+      repo_head = @octokit.commit(repo, "HEAD").commit
+      repo_tree = @octokit.tree(repo, repo_head.tree.sha, recursive: true)
       Book.transaction do
         genbook(code) do |filename|
           file_handle = repo_tree.tree.detect { |tree| tree[:path] == filename }
@@ -210,10 +211,9 @@ task remote_genbook2: :environment do
             blob_content[file_handle[:sha]]
           end
         end
-        repo_head = @octokit.commit(repo, "HEAD").commit.sha
 
         book = Book.where(edition: 2, code: code).first_or_create
-        book.ebook_html = repo_head
+        book.ebook_html = repo_head.sha
 
         begin
           rel = @octokit.latest_release(repo)

--- a/lib/tasks/index.rake
+++ b/lib/tasks/index.rake
@@ -304,7 +304,7 @@ def github_index_doc(index_fun, repo)
         tags = tags.select { |t| t.name == tagname }
       end
     else
-      tags=[Struct.new(:name).new("heads/master")]
+      tags=[Struct.new(:name).new("HEAD")]
     end
     tags.collect do |tag|
       # extract metadata
@@ -340,7 +340,7 @@ def local_index_doc(index_fun)
           tags = tags.select { |t| t == tagname }
         end
       else
-        tags=["master"]
+        tags=["HEAD"]
       end
       tags.collect do |tag|
         # extract metadata


### PR DESCRIPTION
When we fetch book and manpage data from other repositories, we hard-code `master` as the branch name to use. Let's switch instead to the default-branch `HEAD`, which will do the right thing if those repositories ever change their default branch (e.g., as discussed in #1501).

This isn't _quite_ just `s/master/HEAD/` because of the way GitHub's API works. See 002990557f0412f8b9ea30e87711d3b5e059bcd0 for details. On the plus side, that change helped me identify and fix a possible race condition in the update code (fixed in cee3bf1198eef10634256619fabaf288ed075951).
