### PR TITLE
Update KDE git instance to the new GitLab instance

### DIFF
--- a/app/views/site/index.html.erb
+++ b/app/views/site/index.html.erb
@@ -75,7 +75,7 @@
     <li><%= link_to "Qt", "https://code.qt.io/cgit/", class: 'qt' %></li>
     <li><%= link_to "Gnome", "https://gitlab.gnome.org/GNOME", class: 'gnome' %></li>
     <li><%= link_to "Eclipse", "https://git.eclipse.org/c/", class: 'eclipse' %></li>
-    <li><%= link_to "KDE", "https://quickgit.kde.org/", class: 'kde' %></li>
+    <li><%= link_to "KDE", "https://invent.kde.org/explore/groups", class: 'kde' %></li>
     <li><%= link_to "X", "https://cgit.freedesktop.org/xorg/xserver/", class: 'x' %></li>
 </ul>
 </section>


### PR DESCRIPTION
Quickgit doesn't exist anymore and was replaced by a GitLab instance