### PR TITLE
delete CodeReview in Windows

### DIFF
--- a/resources/guis.yml
+++ b/resources/guis.yml
@@ -181,7 +181,6 @@ guis:
   url: https://github.com/FabriceSalvaire/CodeReview/
   image_tag: guis/codereview@2x.png
   platforms:
-  - Windows
   - Mac
   - Linux
   price: Free


### PR DESCRIPTION
after so many times of trying to install CodeReview in Windows(python 3.6 3.7 3.8, msvc 14.0 14.1 14.2 and mingw), I think that it is not suitable to put CodeReview under the Windows list.