### PR TITLE
FIX: hover links should only barely overlap content

### DIFF
--- a/app/assets/stylesheets/reference.scss
+++ b/app/assets/stylesheets/reference.scss
@@ -63,7 +63,8 @@ h3.plumbing {
   dt.hdlist1>a.anchor {
     position: absolute;
     display: block;
-    width: 1.51em;
+    width: 1.01em;
+    padding-left: 0.5em;
     margin-left: -1.5em;
     font-weight: lighter;
     text-align: center;

--- a/app/assets/stylesheets/reference.scss
+++ b/app/assets/stylesheets/reference.scss
@@ -63,7 +63,7 @@ h3.plumbing {
   dt.hdlist1>a.anchor {
     position: absolute;
     display: block;
-    width: 2em;
+    width: 1.51em;
     margin-left: -1.5em;
     font-weight: lighter;
     text-align: center;


### PR DESCRIPTION
Currently, the links for sections which appear on hover substantially overlap the content they are placed to the left of. An overlap is necessary, because it prevents the link from disappearing as the user moves the pointer from the content to the link. However, too large of an overlap results in the user being unable to select the content for which the link is appearing. This is particularly undesirable for command arguments (i.e. things the user is likely to want to select for a copy-and-paste). 

This PR changes the overlap to be 0.01em (i.e. a `width` which is 0.01em larger than the `margin-left`), which brief testing on Firefox indicated was sufficient to accomplish both goals (and is consistent with my *much* more extensive testing when doing exactly the same thing on a different project).