### PR TITLE
Remove sudo: false from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: ruby
 
-sudo: false
-
 before_script:
   - bundle exec rake db:create db:schema:load
 


### PR DESCRIPTION
From the build config validation on travis-ci.org
root: deprecated key sudo (The key `sudo` has no effect anymore.)