### PR TITLE
re-add conservancy banner

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -29,6 +29,13 @@
 
 <body id="<%= @section %>">
 
+  <%= render layout: "shared/banner", locals: { id: "conservancy2019", dismissable: true } do %>
+      Git is a member of Software Freedom Conservancy, which handles
+      legal and financial needs for the project.  Conservancy is
+      currently raising funds to continue their mission. Consider
+      <a href="https://sfconservancy.org/supporter/">becoming a supporter</a>!
+  <% end %>
+
   <div class="inner">
     <%= render partial: "shared/header" %>
   </div> <!-- .inner -->


### PR DESCRIPTION
It's end-of-year donation time again, so let's point visitors to Conservancy's donation page.

This is basically a cherry-pick of c6154378 (re-add conservancy banner, 2019-12-17), but with the year bumped for the dismissal storage.
