### PR TITLE
rename link "Mac OS X" → macOS in downloads/index

### DIFF
--- a/app/views/downloads/index.html.erb
+++ b/app/views/downloads/index.html.erb
@@ -14,7 +14,7 @@
         <table class="binaries">
           <tr>
             <td>
-              <%= link_to "Mac OS X", "/download/mac", {:class => 'icon mac'} %>
+              <%= link_to "macOS", "/download/mac", {:class => 'icon mac'} %>
             </td>
             <td>
               <%= link_to "Windows", "/download/win", {:class => 'icon windows'} %>


### PR DESCRIPTION
Dear git-scm.com maintainers,

I believe the name of macOS needs an update in the root download page (downloads/index). It's been already updated in the dedicated page https://git-scm.com/download/mac.

I know nothing of the website backend architecture, so please forgive me if I edited the wrong file!

Best,
Pierre