### PR TITLE
drop red/green diffstat from manpage version list

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,6 @@ gem "octokit"
 gem "puma"
 gem "tilt"
 
-gem "diff-lcs"
 gem "launchy"
 gem "netrc"
 gem "nokogiri"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -310,7 +310,6 @@ DEPENDENCIES
   better_errors
   binding_of_caller
   database_cleaner
-  diff-lcs
   dotenv-rails
   elasticsearch (= 2.0.2)
   fabrication

--- a/app/assets/stylesheets/reference.scss
+++ b/app/assets/stylesheets/reference.scss
@@ -243,16 +243,6 @@ ol.reference-previous-versions {
         min-width: 40px;
       }
 
-      span.diff {
-        padding-right: 16px;
-        padding-left: 12px;
-
-        img {
-          display: inline-block;
-          margin-right: -1px;
-        }
-      }
-
       em.date {
         float: right;
         margin-right: 150px;

--- a/app/models/doc.rb
+++ b/app/models/doc.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "diff/lcs"
 require "pp"
 require "searchable"
 

--- a/app/models/doc_file.rb
+++ b/app/models/doc_file.rb
@@ -60,7 +60,7 @@ class DocFile < ApplicationRecord
           end
           unchanged_versions = []
         end
-        changes << {name: doc_version.name, time: doc_version.committed, diff: doc_version.diff(previous_doc_version), changed: true}
+        changes << {name: doc_version.name, time: doc_version.committed, changed: true}
       end
     end
     changes

--- a/app/models/doc_version.rb
+++ b/app/models/doc_version.rb
@@ -18,32 +18,6 @@ class DocVersion < ApplicationRecord
   delegate :name, to: :version
   delegate :committed, to: :version
 
-  # returns an array of the differences with 3 entries
-  # 0: additions
-  # 1: subtractions
-  # 2: 8 - (add + sub)
-  def diff(doc_version)
-    begin
-      to = self.doc.plain.split("\n")
-      from = doc_version.doc.plain.split("\n")
-      total = adds = mins = 0
-      diff = Diff::LCS.diff(to, from)
-      diff.first.each do |change|
-        adds += 1 if change.action == "+"
-        mins += 1 if change.action == "-"
-        total += 1
-      end
-      if total > 8
-        min = (8.0 / total)
-        adds = (adds * min).floor
-        mins = (mins * min).floor
-      end
-      [adds, mins, (8 - total)]
-    rescue
-      [0, 0, 8]
-    end
-  end
-
   def index
     file  = self.doc_file
     doc   = self.doc

--- a/app/views/doc/_versions.html.erb
+++ b/app/views/doc/_versions.html.erb
@@ -12,17 +12,6 @@
       <% if v[:changed] %>
         <li>
         <a href="/docs/<%= @doc_file.name %>/<%= v[:name] %>"><span class="version"><%= v[:name] %></span>
-          <span class="diff">
-            <% v[:diff][0].times do %>
-              <img src="/images/icons/green-dot.png" />
-            <% end %>
-            <% v[:diff][1].times do %>
-              <img src="/images/icons/red-dot.png" />
-            <% end %>
-            <% v[:diff][2].times do %>
-              <img src="/images/icons/grey-dot.png" />
-            <% end %>
-          </span>
           <em class="date"><%= v[:time].strftime("%m/%d/%y") %></em>
         </a>
         </li>


### PR DESCRIPTION
The dropdown box that shows which versions of each manpage are available also figures out which versions actually modified that manpage (versus the previous one). This is helpful to omit versions which are identical.

But it also shows a little diffstat image with the number of added/removed lines. This is cool to look at, but not really all that useful in practice (you might get a sense if there were a lot of changes or just a few, but more likely you just want to go to the version that matches what you have installed locally).

Worse, this diffstat means that an uncached request has to pull down _every_ version of the manpage and do O(n) diffs. This can sometimes cause timeouts for large pages that see frequent modifications (e.g., `git-config` is probably the worst offender; it topped 15s recently, causing server errors in https://github.com/git/git-scm.com/issues/1563).

So let's drop the diffstat entirely. This drops the page-generation time for `docs/git-config` on my laptop from 5000ms to 150ms.

This also lets us drop some css and ruby code, as well as the dependency on the diff-lcs gem.
