### PR TITLE
Fix the "Windows GUIs" link at the home page.

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -59,7 +59,7 @@ var DownloadBox = {
       $(".monitor").addClass("windows");
       $("#download-link").text("Download " + $("#installer-version").attr('data-win') + " for Windows").attr("href", "/download/win");
       $("#gui-link").removeClass('mac').addClass('gui');
-      $("#gui-link").text("Windows GUIs").attr("href", "/download/gui/win");
+      $("#gui-link").text("Windows GUIs").attr("href", "/download/gui/windows");
       $("#alt-link").removeClass("windows").addClass("mac");
       $("#alt-link").text("Mac Build").attr("href", "/download/mac");
       $("#gui-os-filter").attr('data-os', 'windows');


### PR DESCRIPTION
The site currently directs users to https://git-scm.com/download/gui/win which displays Git GUI clients for _all_ platforms. The link was changed to https://git-scm.com/download/gui/windows.