### PR TITLE
Speed up diff stat in manpages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem "octokit"
 gem "puma"
 gem "tilt"
 
-gem "diff-lcs"
+gem "diffy"
 gem "launchy"
 gem "netrc"
 gem "nokogiri"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,6 +80,7 @@ GEM
     database_cleaner (1.8.5)
     debug_inspector (0.0.3)
     diff-lcs (1.4.4)
+    diffy (3.4.0)
     dotenv (2.7.6)
     dotenv-rails (2.7.6)
       dotenv (= 2.7.6)
@@ -310,7 +311,7 @@ DEPENDENCIES
   better_errors
   binding_of_caller
   database_cleaner
-  diff-lcs
+  diffy
   dotenv-rails
   elasticsearch (= 2.0.2)
   fabrication

--- a/app/models/doc.rb
+++ b/app/models/doc.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-require "diff/lcs"
 require "pp"
 require "searchable"
+require "diffy"
 
 # t.text :blob_sha
 # t.text :plain

--- a/app/models/doc_version.rb
+++ b/app/models/doc_version.rb
@@ -24,21 +24,18 @@ class DocVersion < ApplicationRecord
   # 2: 8 - (add + sub)
   def diff(doc_version)
     begin
-      to = self.doc.plain.split("\n")
-      from = doc_version.doc.plain.split("\n")
-      total = adds = mins = 0
-      diff = Diff::LCS.diff(to, from)
-      diff.first.each do |change|
-        adds += 1 if change.action == "+"
-        mins += 1 if change.action == "-"
-        total += 1
-      end
-      if total > 8
+      diff_out = Diffy::Diff.new(self.doc.plain, doc_version.doc.plain)
+      first_chars=diff_out.to_s.gsub(/(.)[^\n]*\n/, '\1')
+      adds = first_chars.count("+")
+      mins = first_chars.count("-")
+      total = mins + adds
+      if total  > 8
         min = (8.0 / total)
-        adds = (adds * min).floor
-        mins = (mins * min).floor
+        adds = (adds * min).round
+        mins = (mins * min).round
+        total = 8
       end
-      [adds, mins, (8 - total)]
+      [adds, mins, 8 - total]
     rescue
       [0, 0, 8]
     end


### PR DESCRIPTION
The diff stat is now done by raw analysis of diff command output. For
instance for git-config man page we switch from:

    Completed 200 OK in 7349ms (Views: 7148.4ms | ActiveRecord: 134.3ms |
 Allocations: 5879568)

to:

    Completed 200 OK in 737ms (Views: 590.1ms | ActiveRecord: 139.2ms |
 Allocations: 658373)

which is a 10x speed up