### PR TITLE
Revert "re-add conservancy banner"

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -29,13 +29,6 @@
 
 <body id="<%= @section %>">
 
-  <%= render layout: "shared/banner", locals: { id: "conservancy2020", dismissable: true } do %>
-      Git is a member of Software Freedom Conservancy, which handles
-      legal and financial needs for the project.  Conservancy is
-      currently raising funds to continue their mission. Consider
-      <a href="https://sfconservancy.org/supporter/">becoming a supporter</a>!
-  <% end %>
-
   <div class="inner">
     <%= render partial: "shared/header" %>
   </div> <!-- .inner -->


### PR DESCRIPTION
This reverts commit aea275172b35fa54ec24b80baf8e87a46ee70e5d.

The intent was just to run it from December through year-end, and now it's January. Note that this isn't a pure revert, as it also covers the fix from 1208d164 (banner: really bump year, 2019-12-17).
