### PR TITLE
Add Active Record versions to migrations

### DIFF
--- a/db/migrate/20120308153738_create_versions.rb
+++ b/db/migrate/20120308153738_create_versions.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateVersions < ActiveRecord::Migration
+class CreateVersions < ActiveRecord::Migration[4.2]
   def change
     create_table :versions do |t|
       t.string :name

--- a/db/migrate/20120308153855_create_doc_files.rb
+++ b/db/migrate/20120308153855_create_doc_files.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateDocFiles < ActiveRecord::Migration
+class CreateDocFiles < ActiveRecord::Migration[4.2]
   def change
     create_table :doc_files do |t|
       t.string :name

--- a/db/migrate/20120308153921_create_docs.rb
+++ b/db/migrate/20120308153921_create_docs.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateDocs < ActiveRecord::Migration
+class CreateDocs < ActiveRecord::Migration[4.2]
   def change
     create_table :docs do |t|
       t.text :blob_sha

--- a/db/migrate/20120308160013_create_doc_versions.rb
+++ b/db/migrate/20120308160013_create_doc_versions.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateDocVersions < ActiveRecord::Migration
+class CreateDocVersions < ActiveRecord::Migration[4.2]
   def change
     create_table :doc_versions do |t|
       t.belongs_to :version

--- a/db/migrate/20120415151530_add_version_order.rb
+++ b/db/migrate/20120415151530_add_version_order.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddVersionOrder < ActiveRecord::Migration
+class AddVersionOrder < ActiveRecord::Migration[4.2]
   def up
     add_column :versions, :vorder, :float
     Version.all.each do |version|

--- a/db/migrate/20120417001921_add_downloads.rb
+++ b/db/migrate/20120417001921_add_downloads.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddDownloads < ActiveRecord::Migration
+class AddDownloads < ActiveRecord::Migration[4.2]
   def up
     create_table :downloads do |t|
       t.string :url

--- a/db/migrate/20120417220111_change_doc_sha_to_string.rb
+++ b/db/migrate/20120417220111_change_doc_sha_to_string.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class ChangeDocShaToString < ActiveRecord::Migration
+class ChangeDocShaToString < ActiveRecord::Migration[4.2]
   def up
     change_column :docs, :blob_sha, :string
   end

--- a/db/migrate/20120417221951_add_book_stuff.rb
+++ b/db/migrate/20120417221951_add_book_stuff.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddBookStuff < ActiveRecord::Migration
+class AddBookStuff < ActiveRecord::Migration[4.2]
   def up
     create_table :books do |t|
       t.string      :code

--- a/db/migrate/20120417224143_add_book_url.rb
+++ b/db/migrate/20120417224143_add_book_url.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddBookUrl < ActiveRecord::Migration
+class AddBookUrl < ActiveRecord::Migration[4.2]
   def up
     add_column :sections, :source_url, :string
   end

--- a/db/migrate/20120418152515_add_chapter_title_numbers.rb
+++ b/db/migrate/20120418152515_add_chapter_title_numbers.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddChapterTitleNumbers < ActiveRecord::Migration
+class AddChapterTitleNumbers < ActiveRecord::Migration[4.2]
   def up
     add_column :chapters, :number, :integer
     add_column :sections, :number, :integer

--- a/db/migrate/20120925124736_add_release_date_to_downloads.rb
+++ b/db/migrate/20120925124736_add_release_date_to_downloads.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddReleaseDateToDownloads < ActiveRecord::Migration
+class AddReleaseDateToDownloads < ActiveRecord::Migration[4.2]
   def change
     add_column :downloads, :release_date, :timestamp
 

--- a/db/migrate/20121211011752_add_chapter_shas.rb
+++ b/db/migrate/20121211011752_add_chapter_shas.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddChapterShas < ActiveRecord::Migration
+class AddChapterShas < ActiveRecord::Migration[4.2]
   def up
     add_column :chapters, :sha, :string
   end

--- a/db/migrate/20141023113548_add_edition_to_books.rb
+++ b/db/migrate/20141023113548_add_edition_to_books.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddEditionToBooks < ActiveRecord::Migration
+class AddEditionToBooks < ActiveRecord::Migration[4.2]
   def change
     add_column :books, :edition, :integer, default: 1
     add_column :books, :ebook_pdf,  :string

--- a/db/migrate/20141023122217_add_processed_flag.rb
+++ b/db/migrate/20141023122217_add_processed_flag.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddProcessedFlag < ActiveRecord::Migration
+class AddProcessedFlag < ActiveRecord::Migration[4.2]
   def change
     add_column :books, :processed, :boolean
   end

--- a/db/migrate/20141023135655_add_percent_complete.rb
+++ b/db/migrate/20141023135655_add_percent_complete.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddPercentComplete < ActiveRecord::Migration
+class AddPercentComplete < ActiveRecord::Migration[4.2]
   def change
     add_column :books, :percent_complete, :integer
   end

--- a/db/migrate/20141024175303_add_chapter_type.rb
+++ b/db/migrate/20141024175303_add_chapter_type.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddChapterType < ActiveRecord::Migration
+class AddChapterType < ActiveRecord::Migration[4.2]
   def change
     add_column :chapters, :chapter_type, :string, default: "chapter"
     add_column :chapters, :chapter_number, :string

--- a/db/migrate/20141024194605_add_xrefs.rb
+++ b/db/migrate/20141024194605_add_xrefs.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddXrefs < ActiveRecord::Migration
+class AddXrefs < ActiveRecord::Migration[4.2]
   def change
     create_table :xrefs do |t|
       t.datetime "created_at"

--- a/db/migrate/20141027114732_add_language_name.rb
+++ b/db/migrate/20141027114732_add_language_name.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddLanguageName < ActiveRecord::Migration
+class AddLanguageName < ActiveRecord::Migration[4.2]
   def change
     add_column :books, :language, :string
   end

--- a/db/migrate/20190131210305_add_language_to_doc_version.rb
+++ b/db/migrate/20190131210305_add_language_to_doc_version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class AddLanguageToDocVersion < ActiveRecord::Migration
+class AddLanguageToDocVersion < ActiveRecord::Migration[4.2]
   def change
     add_column :doc_versions, :language, :string, default: "en"
   end


### PR DESCRIPTION
[Since Rails 5.1](https://guides.rubyonrails.org/v5.2/5_1_release_notes.html#active-record-notable-changes), specifying a Rails version for which the migration was written for is required. This commit adds the missing versions.