### PR TITLE
Highlight active section with the orange color

### DIFF
--- a/app/assets/stylesheets/book.scss
+++ b/app/assets/stylesheets/book.scss
@@ -139,6 +139,7 @@ ol.book-toc {
 
           &.active {
             font-weight: bold;
+            color: $orange;
           }
         }
       }


### PR DESCRIPTION
Every time I either read the book or open it from Google and want to see in which chapter/section I currently am - it's always a struggle to locate it in the table of contents where every link is the same color.

Currently, the active chapter is highlighted with a bold font. Unfortunately, in my opinion this is not enough.

See yourself. Try to find out which section in which chapter I am currently reading at first glance:

<img width="640" alt="Screenshot 2021-02-23 at 10 50 19" src="https://user-images.githubusercontent.com/305786/108826758-fe92b780-75c4-11eb-82cc-1fd37f61c06e.png">


Now, here is the simple improvement I am proposing:

<img width="650" alt="Screenshot 2021-02-23 at 10 50 28" src="https://user-images.githubusercontent.com/305786/108826789-110cf100-75c5-11eb-92c9-4c5f7f7e945a.png">

Thank you.