### PR TITLE
chore: improve GitHub templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,8 +1,0 @@
-Please ONLY submit issues related to the git-scm Website (e.g. website-specific content, JS, or CSS that doesn't seem to be doing its job correctly) !
-
-Make sure this is NOT an issue about :
-
-     - the Git documentation (a.k.a. man/help pages, i.e. anything with a URL starting with https://git-scm.com/docs), which should be raised with the community at https://git-scm.com/community,
-     - the contents of the Pro Git book (i.e. anything with a URL starting with https://git-scm.com/book or its PDF versions), which should be raised at https://github.com/progit/progit2/issues.
-     - Git itself, which should also be raised with the community at https://git-scm.com/community, or
-     - Git for Windows, which should be raised at https://github.com/git-for-windows/git.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,17 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Problems/questions/bugs about Git program
+    url: https://git-scm.com/community
+    about: Start a discussion on the community mailing list.
+
+  - name: Problems about Git for Windows program
+    url: https://github.com/git-for-windows/git/issues
+    about: Report problems with the Git for Windows program.
+
+  - name: Git documentation (man/help pages)
+    url: https://git-scm.com/community
+    about: Git documentation (anything with a URL starting with https://git-scm.com/docs).
+
+  - name: Pro Git 2 book content
+    url: https://github.com/progit/progit2/issues
+    about: Report problems with the ProGit 2 book content.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -10,7 +10,10 @@ contact_links:
 
   - name: Git documentation (man/help pages)
     url: https://git-scm.com/community
-    about: Git documentation (anything with a URL starting with https://git-scm.com/docs).
+    about: >
+      The Git documentation under https://git-scm.com/docs is imported
+      from the Git project itself. Any content problems or suggestions
+      should be reported there.
 
   - name: Pro Git 2 book content
     url: https://github.com/progit/progit2/issues

--- a/.github/ISSUE_TEMPLATE/downloads.md
+++ b/.github/ISSUE_TEMPLATE/downloads.md
@@ -1,35 +1,32 @@
 ---
-name: 'Downloads on git-scm not working'
-about: 'If you are experiencing problems downloading git from git-scm.com'
+name: "Downloads on git-scm not working"
+about: "If you are experiencing problems downloading Git from git-scm.com"
 ---
 
-<!--- 
-Please follow the instructions below. 
-An issue properly explained is solved much faster! 
-
-* If you are experiencing problems/questions/bugs with git itself, start a discussion on the [community mailing list](https://git-scm.com/community).
-* If you are experiencing problems on your git for windows program, please open an issue at [git-for-windows/git](https://github.com/git-for-windows/git).
-* Please open Git documentation (a.k.a. man/help pages, i.e. anything with a URL starting with `https://git-scm.com/docs`) specific issues with the [community](https://git-scm.com/community),
-* Please open Pro Git book contents issues (i.e. anything with a URL starting with `https://git-scm.com/book` or its PDF versions) at [progit/progit2](https://github.com/progit/progit2/issues).
-
+<!---
+Please follow the instructions below.
+An issue properly explained is solved much faster!
 -->
 
-<!--- Provide a brief summary of the issue in the title above -->
+<!--- Provide a brief summary of the issue in the issue title -->
 
 ### Which download is failing?
-<!--- Tell us in which page and version is the download broken  -->
+
+<!--- Tell us in which page and version is the download broken -->
 
 ### Problem
-<!--- Tell us the problem as clear as possible -->
 
-### Context
+<!--- Explain the problem clearly -->
+
+### Operating system and browser
+
 <!--- Which operating system and browser are you using? -->
-<!--- Providing context helps us come up with a solution that is most useful in the real world -->
 
-### Steps to Reproduce 
+### Steps to reproduce
+
 <!--- Provide a detailed list of steps. -->
-<!--- In the rare cases where this is infeasible, we will also accept a detailed set of instructions. -->
+<!--- In the rare cases where this is not possible, we will accept a detailed set of instructions. -->
 
 ### Other details
-<!--- Include as many relevant details you may find relevant -->
 
+<!--- Include as many relevant details you may find relevant -->

--- a/.github/ISSUE_TEMPLATE/ui.md
+++ b/.github/ISSUE_TEMPLATE/ui.md
@@ -1,35 +1,34 @@
 ---
-name: 'git-scm UI broken'
-about: 'git-scm.com UI is not working'
+name: "git-scm user interface broken"
+about: "git-scm.com user interface is not working"
 ---
 
-<!--- 
-Please follow the instructions below. 
-An issue properly explained is solved much faster! 
+<!---
+Please follow the instructions below.
+An issue properly explained is solved much faster!
 
-* If you are experiencing problems/questions/bugs with git itself, start a discussion on the [community mailing list](https://git-scm.com/community).
-* If you are experiencing problems on your git for windows program, please open an issue at [git-for-windows/git](https://github.com/git-for-windows/git).
-* Please open Git documentation (a.k.a. man/help pages, i.e. anything with a URL starting with `https://git-scm.com/docs`) specific issues with the [community](https://git-scm.com/community),
-* Please open Pro Git book contents issues (i.e. anything with a URL starting with `https://git-scm.com/book` or its PDF versions) at [progit/progit2](https://github.com/progit/progit2/issues).
-
+Only report problems with the git-scm.com site's JavaScript, CSS or content that doesn't seem to be doing its job correctly!
 -->
 
-<!--- Provide a brief summary of the issue in the title above -->
+<!--- Provide a brief summary of the issue in the issue title -->
 
 ### URL for broken page
-<!--- Tell us in which page is the website broken  -->
+
+<!--- Give us the link to the broken page -->
 
 ### Problem
-<!--- Tell us the problem as clear as possible -->
 
-### Context
+<!--- Explain the problem clearly -->
+
+### Operating system and browser
+
 <!--- Which operating system and browser are you using? -->
-<!--- Providing context helps us come up with a solution that is most useful in the real world -->
 
-### Steps to Reproduce 
+### Steps to reproduce
+
 <!--- Provide a detailed list of steps. -->
-<!--- In the rare cases where this is infeasible, we will also accept a detailed set of instructions. -->
+<!--- In the rare cases where this is not possible, we will accept a detailed set of instructions. -->
 
 ### Other details
-<!--- Include as many relevant details you may find relevant -->
 
+<!--- Include as many relevant details you may find relevant -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,9 @@
+## Changes
+
+<!-- List the changes this PR makes. -->
+
+-
+
+## Context
+
+<!-- Explain why you're making these changes. -->


### PR DESCRIPTION
## Changes:

- Create pull request template
- Prevent contributors opening empty issues
- Remove old ISSUE_TEMPLATE file that's no longer needed
- Redirect unwanted bug reports with `config.yml` file
- Remove wall of text in templates that used to redirect unwanted stuff
- Use clearer headings for operating system/browser section
- Use clear language
- Capitalize noun Git where it's used
- Fix whitespace and file formatting

## Context:

I think the GitHub templates are due a big upgrade, so I'm taking the liberty to improve the lot. 😄 

The main idea is to redirect unwanted stuff from the GitHub issue create screen, instead of in Markdown comments that nobody will read. The new redirects are way easier, because you can just click a button and go to the right place.
I've made a throwaway repository so you can get a preview of how the issue select screen will look once you merge this PR: https://github.com/HonkingGoose/git-scm-template-preview/issues/new/choose

I think that we should have (and use) templates for all valid contributions, so I'm disallowing empty issues from being opened.

Also we didn't have a pull request template, so I'm making one. 😄 

Feel free to tell me to undo stuff you don't want/care about. 😉 