### PR TITLE
community: update links to IRC server

### DIFF
--- a/app/views/community/index.html.erb
+++ b/app/views/community/index.html.erb
@@ -79,7 +79,7 @@
   <h2> IRC Channel </h2>
 
   <p>
-    If the manpages and this book aren’t enough and you need in-person help, you can try the <span class="highlight fixed">#git</span> channel on the Freenode IRC server (<strong>irc.freenode.net</strong>). These channels are regularly filled with hundreds of people who are all very knowledgeable about Git and are often willing to help.
+    If the manpages and this book aren’t enough and you need in-person help, you can try the <span class="highlight fixed">#git</span> channel on the Libera Chat IRC server (<strong>irc.libera.chat:6697</strong>). These channels are regularly filled with hundreds of people who are all very knowledgeable about Git and are often willing to help.
     The <span class="highlight fixed">#git-devel</span> channel welcomes Git development discussion, and might be able to help you contribute to Git.
   </p>
 


### PR DESCRIPTION
The Git project uses the Libera Chat network, and no longer uses
Freenode. Update the links in the community page accordingly.

##

/cc @peff, @nasamuffin 
