### PR TITLE
community: add connection info for Libera Chat

### DIFF
--- a/app/views/community/index.html.erb
+++ b/app/views/community/index.html.erb
@@ -79,7 +79,7 @@
   <h2> IRC Channel </h2>
 
   <p>
-    If the manpages and this book aren’t enough and you need in-person help, you can try the <span class="highlight fixed">#git</span> channel on the Libera Chat IRC server (<strong>irc.libera.chat:6697</strong>). These channels are regularly filled with hundreds of people who are all very knowledgeable about Git and are often willing to help.
+    If the manpages and this book aren’t enough and you need in-person help, you can try the <span class="highlight fixed">#git</span> channel on the <a href="https://libera.chat/guides/connect">Libera Chat</a> IRC server (<strong>irc.libera.chat</strong>). These channels are regularly filled with hundreds of people who are all very knowledgeable about Git and are often willing to help.
     The <span class="highlight fixed">#git-devel</span> channel welcomes Git development discussion, and might be able to help you contribute to Git.
   </p>
 


### PR DESCRIPTION
Include a link to Libera's own connection guide, to help users who are
unfamiliar with IRC get started. Likewise, remove the default IRC port
from the server's URL to avoid additional confusion.

Suggested-by: Jeff King \<peff@peff.net\>
Signed-off-by: Taylor Blau \<me@ttaylorr.com\>