### PR TITLE
prefer query_parameters to params for search endpoint

### DIFF
--- a/app/controllers/site_controller.rb
+++ b/app/controllers/site_controller.rb
@@ -11,14 +11,14 @@ class SiteController < ApplicationController
 
   # called when you start typing into search form
   def search
-    @term = sname = params["search"].to_s.downcase
+    @term = sname = request.query_parameters["search"].to_s.downcase
     @data = search_term(sname)
     render partial: "shared/search"
   end
 
   # called when you submit your search
   def search_results
-    @term = sname = params["search"].to_s.downcase
+    @term = sname = request.query_parameters["search"].to_s.downcase
     data = search_term(sname, true)
     @top = []
     @rest = []


### PR DESCRIPTION
Using params will pull values from the request body (if not present in the query parameters). We shouldn't ever see these in normal use, but somebody could pass them in to poison a cache that only keys on query parameters, not bodies (like Cloudflare). More details in #1551.

I'm still unconvinced this would be a problem in practice, since real users would be sending a search parameter in the query string, and that would skip the poisoned entry. But it's easy enough to workaround anyway, so let's do it.

It would be nice if there were a more systematic solution here, so we don't end up with a similar problem later. But this site really does very little parameter processing in the first place (this seems to be the only case in the whole code base).

Fixes: #1551
