### PR TITLE
book2: match ebook release assets by name, not content-type

### DIFF
--- a/lib/tasks/book2.rake
+++ b/lib/tasks/book2.rake
@@ -222,17 +222,17 @@ task remote_genbook2: :environment do
 
         begin
           rel = @octokit.latest_release(repo)
-          get_url =   -> (content_type) do
-            asset = rel.assets.find { |asset| asset.content_type==content_type }
+          get_url =   -> (name_re) do
+            asset = rel.assets.find { |asset| name_re.match(asset.name) }
             if asset
               asset.browser_download_url
             else
               nil
             end
           end
-          book.ebook_pdf  = get_url.call("application/pdf")
-          book.ebook_epub = get_url.call("application/epub+zip")
-          book.ebook_mobi  = get_url.call("application/x-mobipocket-ebook")
+          book.ebook_pdf  = get_url.call(/\.pdf$/)
+          book.ebook_epub = get_url.call(/\.epub$/)
+          book.ebook_mobi  = get_url.call(/\.mobi$/)
         rescue Octokit::NotFound
           book.ebook_pdf  = nil
           book.ebook_epub = nil


### PR DESCRIPTION
Since progit2 2.1.309 switched to using a GitHub Action to generate releases, it no longer sets the content-type field of the release assets. And thus we fail to find any ebooks to link, since we are looking for assets with "application/pdf", and so on.

Instead, let's do a suffix match against the name of each asset, looking for the appropriate file extension. This works fine, since the names are all obvious ("progit.epub", and so on). And it should be backwards-compatible with older translations that haven't yet picked up the new Actions-based workflow, since they used the same sensible names.

We may revert this later if the assets start generating with correct content-types again. But it looks to be non-trivial (there's some discussion in #1498), so this seems like a good solution in the meantime.

/cc @HonkingGoose 