### PR TITLE
Slim gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,6 @@ gem "diffy"
 gem "nokogiri"
 
 # Assets
-gem "listen"
 gem "sass-rails"
 gem "uglifier"
 
@@ -28,6 +27,7 @@ end
 
 group :development, :test do
   gem "dotenv-rails"
+  gem "listen"
   gem "pry-byebug"
   gem "rubocop-github"
   gem "ruby-prof"

--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,6 @@ gem "tilt"
 
 gem "diffy"
 gem "nokogiri"
-gem "redcarpet"
 gem "yajl-ruby"
 
 # Assets

--- a/Gemfile
+++ b/Gemfile
@@ -15,8 +15,6 @@ gem "puma"
 gem "tilt"
 
 gem "diffy"
-gem "launchy"
-gem "netrc"
 gem "nokogiri"
 gem "redcarpet"
 gem "yajl-ruby"

--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,6 @@ gem "faraday_middleware"
 gem "iso8601"
 gem "octokit"
 gem "puma"
-gem "tilt"
 
 gem "diffy"
 gem "nokogiri"

--- a/Gemfile
+++ b/Gemfile
@@ -7,15 +7,12 @@ gem "rails", "~> 6.0"
 
 gem "asciidoctor", "~> 2.0.0"
 gem "elasticsearch", "2.0.2"
-gem "faraday"
-gem "faraday_middleware"
 gem "iso8601"
 gem "octokit"
 gem "puma"
 
 gem "diffy"
 gem "nokogiri"
-gem "yajl-ruby"
 
 # Assets
 gem "listen"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -342,7 +342,6 @@ DEPENDENCIES
   sass-rails
   shoulda
   sqlite3
-  tilt
   uglifier
   vcr
   webmock

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -112,8 +112,6 @@ GEM
       multipart-post (>= 1.2, < 3)
       ruby2_keywords
     faraday-net_http (1.0.1)
-    faraday_middleware (1.0.0)
-      faraday (~> 1.0)
     ffi (1.15.0)
     foreman (0.87.2)
     globalid (0.4.2)
@@ -304,7 +302,6 @@ GEM
     websocket-driver (0.7.3)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yajl-ruby (1.4.1)
     zeitwerk (2.4.2)
 
 PLATFORMS
@@ -321,8 +318,6 @@ DEPENDENCIES
   elasticsearch (= 2.0.2)
   fabrication
   factory_bot_rails
-  faraday
-  faraday_middleware
   foreman
   iso8601
   listen
@@ -345,7 +340,6 @@ DEPENDENCIES
   uglifier
   vcr
   webmock
-  yajl-ruby
 
 RUBY VERSION
    ruby 2.7.3p183

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -202,7 +202,6 @@ GEM
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    redcarpet (3.5.1)
     redis (4.2.5)
     redis-actionpack (5.2.0)
       actionpack (>= 5, < 7)
@@ -336,7 +335,6 @@ DEPENDENCIES
   rails (~> 6.0)
   rails-controller-testing
   rails_12factor
-  redcarpet
   redis-rails
   rspec-rails
   rubocop-github

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -122,8 +122,6 @@ GEM
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
     iso8601 (0.13.0)
-    launchy (2.5.0)
-      addressable (~> 2.7)
     listen (3.5.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -139,7 +137,6 @@ GEM
     minitest (5.14.4)
     multi_json (1.15.0)
     multipart-post (2.1.1)
-    netrc (0.11.0)
     nio4r (2.5.7)
     nokogiri (1.11.5)
       mini_portile2 (~> 2.5.0)
@@ -329,9 +326,7 @@ DEPENDENCIES
   faraday_middleware
   foreman
   iso8601
-  launchy
   listen
-  netrc
   nokogiri
   octokit
   pg


### PR DESCRIPTION
This PR drops a bunch of production-environment gems from the `Gemfile` that I believe are not being used. See the individual commits for the list of gems and explanations.

There are a few left that I'm not sure on:

  - we include the `uglifier` gem, but it doesn't appear to be used. I think this was unintentionally dropped as part of my 97d2d9a9d952dd755dfd556b78a580f075c3a6cd. We should probably look into whether it's worth switching back (i.e., if it was doing a substantially better job of compressing javascript than the rails defaults).
  - we use `sass-rails`; we do have scss files, so presumably this is in use, but I don't see us actually configuring or requiring it anywhere. There is presumably some behind-the-scenes rails magic at work, and we probably do need this.
  - I still don't know if the `listen` gem is required. I added it in 6ae11f9655b22709a72503b519e67fb401f43ed4 as a bit of hackery. It feels like maybe this should be in the `development` section?
  - We can probably get rid of `rails_12factor`. I'm not sure it's doing anything useful in the first place, but even if it is, it looks like it can be replaced with a few lines of config in Rails 5: https://github.com/heroku/rails_12factor#migrating-to-rails-5.

I didn't look at the test or development lists at all. Those could use some paring down, but my main goal was to keep the production list as small as possible.