### PR TITLE
Updated Git Book image link

### DIFF
--- a/app/views/doc/_ext_books.erb
+++ b/app/views/doc/_ext_books.erb
@@ -51,7 +51,7 @@
         </p>
       </li>
       <li>
-        <a href="http://gitforteams.com/"><img src="http://akamaicovers.oreilly.com/images/0636920034520/cat.gif"></a>
+        <a href="http://gitforteams.com/"><img src="https://learning.oreilly.com/library/cover/9781491911204/250w"></a>
         <h4><a href="http://gitforteams.com/">Git for Teams</a></h4>
         <p class='description'>
           By Emma Jane Hogbin Westby


### PR DESCRIPTION
Image link was broken.

## Changes

<!-- List the changes this PR makes. -->

- Replaced broken image link with correct one.

## Context

1. Open [External Links](https://git-scm.com/doc/ext)
2. Scroll to 'Git for Teams'

![image](https://user-images.githubusercontent.com/35252877/141477355-da8cdfd2-fd81-4ed4-9383-d3757a91c772.png)
_**Fig. 1: Broken Image link**_

<!-- Explain why you're making these changes. -->
