### PR TITLE
css: color code blocks within links as links

### DIFF
--- a/app/assets/stylesheets/typography.scss
+++ b/app/assets/stylesheets/typography.scss
@@ -260,6 +260,10 @@ code {
   border: solid 1px #efeee6;
 }
 
+a code {
+  color: $link-color;
+}
+
 // Quotes
 q:before,
 q:after,


### PR DESCRIPTION
We normally color code blocks as $orange. But then if you do the
somewhat obvious thing of trying to put a code block in the link text:

  Try the <a href="/docs/git-foo"><code>git-foo</code></a>

it's hard to immediately see that it's actually a link. Let's color
these cases like a normal link.

I have a feeling there's a more elegant CSS solution (possibly using
!important on the link coloring?), but this seems to get the job done,
and the use of scss means we don't have to repeat the actual color
codes.

## Changes

<!-- List the changes this PR makes. -->

-

## Context

<!-- Explain why you're making these changes. -->
