### PR TITLE
Add MacPorts to Downloads for macOS

### DIFF
--- a/app/views/downloads/download_mac.html.erb
+++ b/app/views/downloads/download_mac.html.erb
@@ -17,6 +17,10 @@
   <p>Install <a href="https://brew.sh/">homebrew</a> if you don't already have it, then:<br>
   <code>$ brew install git</code></p>
 
+  <h3>MacPorts</h3>
+  <p>Install <a href="https://www.macports.org">MacPorts</a> if you don't already have it, then:<br>
+  <code>$ sudo port install git</code></p>
+
   <h3>Xcode</h3>
   <p>Apple ships a binary package of Git with <a href="https://developer.apple.com/xcode/">Xcode</a>.</p>
 


### PR DESCRIPTION
## Changes

- Add MacPorts to Downloads for macOS

## Context

MacPorts is an important package manager for macOS and missing here.