### PR TITLE
remove mention(s) of Heroku credits

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -30,8 +30,7 @@ The app itself is served by Heroku. The app name is `git-scm` (so you
 can visit it directly as https://git-scm.herokuapp.com). The site is
 owned by the git-scm.com team. If you want to be involved in managing
 uptime/deploys/etc, you'll need a Heroku account and request to be added
-to that team. The git-scm team receives credits from Heroku so that the
-hosting is free.
+to that team.
 
 We use a few Heroku add-ons:
 

--- a/app/views/site/about.html.erb
+++ b/app/views/site/about.html.erb
@@ -64,7 +64,6 @@
   services to keep the site running, including:
 
   <ul>
-    <li><a href="https://heroku.com">Heroku</a>
     <li><a href="https://cloudflare.com">Cloudflare</a>
     <li><a href="https://bonsai.io/">Bonsai</a>
   </ul>


### PR DESCRIPTION
This pull request removes any mention of credits provided by Heroku, since Heroku no longer provides free hosting credits to the Git project.

In the meantime, we'll use the Git project's funds in order to keep the website up and running until we figure out a more permanent solution.

##

/cc @pedrorijo91 