### PR TITLE
community: link to SourceHut's plain text email guide

### DIFF
--- a/app/views/community/index.html.erb
+++ b/app/views/community/index.html.erb
@@ -20,7 +20,7 @@
   </p>
 
   <p>
-    You do not need to subscribe: you will be Cc&apos;d in replies. Please keep the Cc list intact when replying (use &quot;Reply to all&quot;). Greylisting may delay your first post for a few hours.  Note also that the list only accepts plain-text email; please disable HTML in your outgoing messages.
+    You do not need to subscribe: you will be Cc&apos;d in replies. Please keep the Cc list intact when replying (use &quot;Reply to all&quot;). Greylisting may delay your first post for a few hours.  Note also that the list only accepts <a href="https://useplaintext.email/">plain-text email</a>; please disable HTML in your outgoing messages.
   </p>
 
   <p>


### PR DESCRIPTION
SourceHut maintains a nice guide at https://useplaintext.email/
explaining how to set up different email client to send plain text
email.

Let's add a link to it when we mention that the Git mailing list only
accepts plain text, to help our readers.

