### PR TITLE
Mac support for Gittyup

### DIFF
--- a/resources/guis.yml
+++ b/resources/guis.yml
@@ -223,6 +223,7 @@ guis:
   image_tag: guis/gittyup@2x.png
   platforms:
   - Windows
+  - Mac
   - Linux  
   price: Free
   license: MIT


### PR DESCRIPTION
## Changes
adds Mac support for Gittyup

## Context
Gittyup has now also a Mac support

mergeable after https://github.com/Murmele/Gittyup/pull/161
