### PR TITLE
app/vites/site/about: add FusionAuth as a sponsor

### DIFF
--- a/app/views/site/about.html.erb
+++ b/app/views/site/about.html.erb
@@ -64,6 +64,11 @@
   services to keep the site running, including:
 
   <ul>
+    <li>
+      <a href="https://fusionauth.io">FusionAuth</a>, whose annual
+      donation to the Git project pays for the hosting costs of this
+      website.
+    </li>
     <li><a href="https://cloudflare.com">Cloudflare</a>
     <li><a href="https://bonsai.io/">Bonsai</a>
   </ul>


### PR DESCRIPTION
Per [1], Dan Moore of FusionAuth has graciously offered (and the Git
project accepted) to make an annual donation to the Git project which
is used to cover our Heroku costs to run git-scm.com.

Include a link to their company's website in the "sponsors" section of
the /site/about page, as well as a small blurb about their donation.

Thanks, FusionAuth!

\[1\]: https://lore.kernel.org/git/CAKUhyqHSwUb3UL=sKxqNrZsRNbf=wuzsk06LFfE=UwdN4JN37g@mail.gmail.com/