### PR TITLE
GUIs: Remove some old unmaintained clients, update pricings

### DIFF
--- a/resources/guis.yml
+++ b/resources/guis.yml
@@ -152,14 +152,6 @@ guis:
   license: Proprietary
   trend_name: Working Copy iOS
   order: 22
-- name: Git2Go
-  url: https://git2go.com/
-  image_tag: guis/git2go@2x.png
-  platforms:
-    - iOS
-  price: Free with in-app purchases
-  license: Proprietary
-  order: 31
 - name: GitAhead (no longer under active development)
   url: https://gitahead.github.io/gitahead.com/
   image_tag: guis/gitahead@2x.png

--- a/resources/guis.yml
+++ b/resources/guis.yml
@@ -44,7 +44,7 @@ guis:
   - Windows
   - Mac
   - Linux
-  price: Free / $29 / $49
+  price: Free for local and public repos / $59+/user annually (free 7-day trial)
   license: Proprietary
   order: 5
 - name: Magit

--- a/resources/guis.yml
+++ b/resources/guis.yml
@@ -250,7 +250,7 @@ guis:
   image_tag: guis/gitatomic@2x.png
   platforms:
   - Windows
-  price: 15.00€
+  price: 15.00€/year
   license: Proprietary
   order: 39
 - name: Gitfox

--- a/resources/guis.yml
+++ b/resources/guis.yml
@@ -73,7 +73,7 @@ guis:
   platforms:
   - Windows
   - Mac
-  price: " $69/user (Free 30 day trial)"
+  price: "Free for students and educators / $69/user annually / $99/user annually (Free 30 day trial)"
   license: Proprietary
   trend_name: git tower
   order: 8

--- a/resources/guis.yml
+++ b/resources/guis.yml
@@ -64,7 +64,7 @@ guis:
   - Windows
   - Mac
   - Linux
-  price: "$79/user / Free for non-commercial use"
+  price: "Free for non-commercial use / $59/user annually"
   license: Proprietary
   order: 7
 - name: Tower

--- a/resources/guis.yml
+++ b/resources/guis.yml
@@ -208,8 +208,8 @@ guis:
   price: Free with in-app purchases
   license: Proprietary
   order: 31
-- name: GitAhead
-  url: https://www.gitahead.com/
+- name: GitAhead (no longer under active development)
+  url: https://gitahead.github.io/gitahead.com/
   image_tag: guis/gitahead@2x.png
   platforms:
   - Windows

--- a/resources/guis.yml
+++ b/resources/guis.yml
@@ -182,14 +182,6 @@ guis:
   license: GNU GPL
   trend_name: Git CodeReview
   order: 30
-- name: gmaster
-  url: https://gmaster.io/
-  image_tag: guis/gmaster@2x.png
-  platforms:
-    - Windows
-  price: "Beta / Free for non-commercial use"
-  license: Proprietary
-  order: 19
 - name: Git2Go
   url: https://git2go.com/
   image_tag: guis/git2go@2x.png

--- a/resources/guis.yml
+++ b/resources/guis.yml
@@ -44,7 +44,8 @@ guis:
   - Windows
   - Mac
   - Linux
-  price: Free for local and public repos / $59+/user annually (free 7-day trial)
+  # Free tier only works with local and public repositories
+  price: Free / $59+/user annually
   license: Proprietary
   order: 5
 - name: Magit
@@ -73,7 +74,8 @@ guis:
   platforms:
   - Windows
   - Mac
-  price: "Free for students and educators / $69/user annually / $99/user annually (Free 30 day trial)"
+  # Free for students and educators
+  price: "$69+/user annually (Free 30-day trial)"
   license: Proprietary
   trend_name: git tower
   order: 8
@@ -139,7 +141,8 @@ guis:
   platforms:
   - Windows
   - Mac
-  price: $49.99, free evaluation
+  # No details on the evaluation limits or terms
+  price: $49.99 (Free evaluation)
   license: Proprietary
   trend_name: Fork Git client
   order: 12
@@ -148,7 +151,9 @@ guis:
   image_tag: guis/workingcopy@2x.png
   platforms:
     - iOS
-  price: Free with in-app purchases
+  # The $19.99 price is for one year of feature updates, new paid features added more
+  # than a year after purchase will be locked out (but updates and patches continue)
+  price: Free / $19.99
   license: Proprietary
   trend_name: Working Copy iOS
   order: 22
@@ -177,7 +182,7 @@ guis:
   image_tag: guis/pocketgit@2x.png
   platforms:
     - Android
-  price: €2.49 / $1.99
+  price: €2.49/$1.99
   license: Proprietary
   order: 21
 - name: GitDrive
@@ -185,7 +190,8 @@ guis:
   image_tag: guis/gitdrive@2x.png
   platforms:
     - iOS
-  price: Free with in-app purchases
+  # No details what the $6.99 in-app purchase does, all it says is "Unlimited Version"
+  price: Free / $6.99
   license: Proprietary
   order: 37
 - name: Guitar
@@ -224,7 +230,9 @@ guis:
   - Windows
   - Mac
   - Linux
-  price: "$99/user, $75 annual business sub, free eval"
+  # Evaluation has no time limit, but will nag the user to buy a license
+  # License is only valid for 3 years of updates
+  price: "$99/user / $75/user annually (Free evaluation)"
   license: Proprietary
   order: 10
 - name: LazyGit
@@ -242,7 +250,8 @@ guis:
   image_tag: guis/snailgit@2x.png
   platforms:
   - Mac
-  price: "$9.99 / Lite version"
+  # Lite version is limited to just one repository
+  price: "Free (limited) / $9.99"
   license: Proprietary
   order: 32
 - name: GitAtomic
@@ -250,7 +259,7 @@ guis:
   image_tag: guis/gitatomic@2x.png
   platforms:
   - Windows
-  price: 15.00€/year
+  price: $17.99+/user annually (Free 30-day trial)
   license: Proprietary
   order: 39
 - name: Gitfox
@@ -258,7 +267,7 @@ guis:
   image_tag: guis/gitfox@2x.png
   platforms:
   - Mac
-  price: "€39,99/year or €79,99 once"
+  price: "€39,99/user annually / €79,99 (Free 30-day trial)"
   license: Proprietary
   trend_name: Gitfox Git Client
   order: 23
@@ -277,7 +286,7 @@ guis:
   image_tag: guis/nitrogit@2x.png
   platforms:
   - Windows
-  price: "20€/user / Free for non-commercial use"
+  price: "Free for non-commercial use / 20€/user"
   license: Proprietary
   order: 40
 - name: GitFinder
@@ -285,7 +294,8 @@ guis:
   image_tag: guis/gitfinder@2x.png
   platforms:
   - Mac
-  price: "$29.95"
+  # After the trial ends, GitFinder will only work with one git repository
+  price: "Free (limited) / $29.95 (Free 30-day trial)"
   license: Proprietary
   order: 41
 - name: Vershd
@@ -295,7 +305,7 @@ guis:
   - Windows
   - Mac
   - Linux
-  price: Free for personal use, otherwise $37/year/user
+  price: Free for non-commercial use / $37/user annually
   license: Proprietary
   order: 42
 - name: GitUI
@@ -313,7 +323,9 @@ guis:
   image_tag: guis/polygit@2x.png
   platforms:
   - iOS
-  price: Free (3 pushes per day) / $15/year (unlimited pushes + extra features)
+  # Free tier only allows 3 pushes per day
+  # Price on the website ($15) doesn't match prices in the app store (below)
+  price: Free (limited) / $11.99/year / $39.99
   license: Proprietary
   order: 44
 - name: GitVine
@@ -373,6 +385,7 @@ guis:
   platforms:
     - Mac
     - iOS
-  price: Free with in-app purchases
+  # No details on the limitations with the free version
+  price: Free / $6.99 (Free 7-day trial)
   license: Proprietary
   order: 48

--- a/resources/guis.yml
+++ b/resources/guis.yml
@@ -85,16 +85,6 @@ guis:
   price: Free
   license: GNU GPL
   order: 11
-- name: GitEye
-  url: http://www.giteyeapp.com/
-  image_tag: guis/giteye@2x.png
-  platforms:
-  - Windows
-  - Mac
-  - Linux
-  price: Free
-  license: Proprietary
-  order: 17
 - name: gitg
   url: https://wiki.gnome.org/Apps/Gitg/
   image_tag: guis/gitg@2x.png

--- a/resources/guis.yml
+++ b/resources/guis.yml
@@ -313,7 +313,7 @@ guis:
   image_tag: guis/polygit@2x.png
   platforms:
   - iOS
-  price: Free with in-app purchases
+  price: Free (3 pushes per day) / $15/year (unlimited pushes + extra features)
   license: Proprietary
   order: 44
 - name: GitVine

--- a/resources/guis.yml
+++ b/resources/guis.yml
@@ -152,17 +152,6 @@ guis:
   license: Proprietary
   trend_name: Working Copy iOS
   order: 22
-- name: CodeReview
-  url: https://github.com/FabriceSalvaire/CodeReview/
-  image_tag: guis/codereview@2x.png
-  platforms:
-  - Windows
-  - Mac
-  - Linux
-  price: Free
-  license: GNU GPL
-  trend_name: Git CodeReview
-  order: 30
 - name: Git2Go
   url: https://git2go.com/
   image_tag: guis/git2go@2x.png

--- a/resources/guis.yml
+++ b/resources/guis.yml
@@ -123,14 +123,6 @@ guis:
   license: GNU GPL
   trend_name: Git giggle
   order: 27
-- name: Gitbox
-  url: http://www.gitboxapp.com/
-  image_tag: guis/gitbox@2x.png
-  platforms:
-  - Mac
-  price: "$14.99"
-  license: Proprietary
-  order: 29
 - name: Aurees
   url: https://aurees.com/
   image_tag: guis/aurees@2x.png

--- a/resources/guis.yml
+++ b/resources/guis.yml
@@ -285,7 +285,7 @@ guis:
   image_tag: guis/gitfinder@2x.png
   platforms:
   - Mac
-  price: "$24.95"
+  price: "$29.95"
   license: Proprietary
   order: 41
 - name: Vershd

--- a/resources/guis.yml
+++ b/resources/guis.yml
@@ -114,17 +114,6 @@ guis:
   price: Free
   license: GNU GPL
   order: 24
-- name: Cycligent Git Tool
-  url: https://www.cycligent.com/git-tool
-  image_tag: guis/cycligent@2x.png
-  platforms:
-  - Windows
-  - Mac
-  - Linux
-  price: Free
-  license: Proprietary
-  trend_name: Cycligent
-  order: 25
 - name: giggle
   url: https://wiki.gnome.org/Apps/giggle/
   image_tag: guis/giggle@2x.png

--- a/resources/guis.yml
+++ b/resources/guis.yml
@@ -295,7 +295,7 @@ guis:
   - Windows
   - Mac
   - Linux
-  price: Free for personal use, otherwise $37
+  price: Free for personal use, otherwise $37/year/user
   license: Proprietary
   order: 42
 - name: GitUI

--- a/resources/guis.yml
+++ b/resources/guis.yml
@@ -188,14 +188,6 @@ guis:
   price: Free with in-app purchases
   license: Proprietary
   order: 37
-- name: GitX-dev
-  url: https://rowanj.github.io/gitx/
-  image_tag: guis/gitx@2x.png
-  platforms:
-  - Mac
-  price: Free
-  license: GNU GPL
-  order: 33
 - name: GitBlade
   url: https://gitblade.com
   image_tag: guis/gitblade@2x.png

--- a/resources/guis.yml
+++ b/resources/guis.yml
@@ -215,7 +215,7 @@ guis:
   image_tag: guis/pocketgit@2x.png
   platforms:
     - Android
-  price: 1.99€
+  price: €2.49 / $1.99
   license: Proprietary
   order: 21
 - name: GitDrive

--- a/resources/guis.yml
+++ b/resources/guis.yml
@@ -188,16 +188,6 @@ guis:
   price: Free with in-app purchases
   license: Proprietary
   order: 37
-- name: GitBlade
-  url: https://gitblade.com
-  image_tag: guis/gitblade@2x.png
-  platforms:
-    - Linux
-    - Mac
-    - Windows
-  price: Free Lite version, $59.99/user/year for PRO version
-  license: Proprietary
-  order: 34
 - name: Guitar
   url: https://github.com/soramimi/Guitar
   image_tag: guis/guitar@2x.png


### PR DESCRIPTION
I initially just wanted to update the pricing of ONE client, ended up getting sucked in and checking pretty much all of them...

Some notes (why this is draft):

- Each client was updated/removed in a separate commit, in most of them I detailed my sources or reasoning.
- There were no consistent rules when deciding which clients to remove and which to keep. Some were very obviously dead projects, others were a bit in the grey area, and there are definitely examples where I randomly decided to remove one "dead" project but keep a different project that was inactive for much longer. **I want some feedback from maintainers about what rules *should* be applied before I make another pass through them all** (should be easier and faster the second time around)
- I didn't run the sorting script. Come to think of it, sorting them first might make it easier to decide which clients to delete - if a client is inactive *and* very low ranked, it's easier to say it's a dead project than a high ranked inactive one.
- I forgot to remove the orphaned image files - but better do that last after I know for sure which ones (if any) are getting removed.

