### PR TITLE
css: drop "word-break: break-all" from code blocks

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -30,7 +30,6 @@
 code {
   display: inline;
   padding: 0 5px;
-  word-break: break-all;
 }
 
 pre {


### PR DESCRIPTION
This was added in #1644 (making the site more responsive), but can result in us breaking mid-word, which is ugly.

Fixes #1712.

/cc @johnpaxton as reporter
/cc @adsingh14 in case you have any thoughts
