### PR TITLE
resources/guis.yml: remove stray trailing space characters

### DIFF
--- a/resources/guis.yml
+++ b/resources/guis.yml
@@ -173,7 +173,7 @@ guis:
   platforms:
   - Windows
   - Mac
-  - Linux  
+  - Linux
   price: Free
   license: MIT
   order: 46
@@ -395,7 +395,7 @@ guis:
   platforms:
     - Windows
     - Mac
-  price: Free / 20€ 
+  price: Free / 20€
   license: Proprietary
   trend_name: anchorpoint
   order: 22


### PR DESCRIPTION
When working in this file, I noticed a pair of lines that have extra space characters before their line ending. These were introduced in

  - 47c3473 (add gittyup, 2022-04-22), and
  - da839bc (Add Anchorpoint to GUI Clients Page, 2022-07-31)

, respectively. To avoid an editor's automatic space removal from accidentally introducing these changes into a different commit, let's clean them up now.

Signed-off-by: Taylor Blau <me@ttaylorr.com>