### PR TITLE
book: mention that we are an updated version of the 2nd edition

### DIFF
--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -43,6 +43,10 @@
   <p>
   The entire Pro Git book, written by Scott Chacon and Ben Straub and published by Apress, is available here. All content is licensed under the <a href="https://creativecommons.org/licenses/by-nc-sa/3.0/">Creative Commons Attribution Non Commercial Share Alike 3.0 license</a>. Print versions of the book are available on <a href="https://www.amazon.com/Pro-Git-Scott-Chacon/dp/1484200772?ie=UTF8&camp=1789&creative=9325&creativeASIN=1430218339&linkCode=as2&tag=git-sfconservancy-20">Amazon.com</a>.</>
   </p>
+
+  <p>The version found here has been updated with corrections and additions from <a href="https://github.com/progit/progit2/graphs/contributors">hundreds of contributors</a>. If you see an error or have a suggestion, patches and issues are welcome in its <a href="https://github.com/progit/progit2">GitHub repository</a>.
+  </p>
+
   <ol class='book-toc'>
     <% @book.chapters.includes(:sections).each do |chapter| %>
     <% next if chapter.sections.size == 0 %>


### PR DESCRIPTION
The intro on the main book page doesn't make it clear that this is the 2nd edition plus many years of updates. Let's say so.

I initially thought I'd rework the first paragraph, but I think everything it says is still accurate and something we want to be saying. So I ended up just tacking on an extra note.

The link to the progit repository is a little redundant, since we have one in the sidebar already. But it's easy to miss, and I think makes sense to emphasize here in the book overview.

Fixes #1734.