### PR TITLE
index_doc(): loosen match of "git-cmd(1)" on manpages

### DIFF
--- a/lib/tasks/index.rake
+++ b/lib/tasks/index.rake
@@ -200,7 +200,7 @@ def index_doc(filter_tags, doc_list, get_content)
         links = cmd_list[category].map do |cmd, attr|
           if cmd_file = tag_files.detect { |ent| ent.first == "Documentation/#{cmd}.txt" }
             content = get_content.call(cmd_file.second)
-            section = content.match(/^git.*\(([1-9])\)/)[1]
+            section = content.match(/^[a-z0-9-]+\(([1-9])\)/)[1]
             if match = content.match(/NAME\n----\n\S+ - (.*)$/)
               "linkgit:#{cmd}[#{section}]::\n\t#{attr == 'deprecated' ? '(deprecated) ' : ''}#{match[1]}\n"
             end


### PR DESCRIPTION
In v2.38.0, we now have a manpage for scalar, which doesn't start with "git". As a result, our regex to find the section number fails, and the whole manpage is aborted.

Let's loosen this regex to match any alphanumeric command name, plus dashes. That's enough for the current code base. It's conceivable we might introduce more characters, but you get a nice big exception if we do.

/cc @ttaylorr