### PR TITLE
app/helpers/application_helper.rb: fix broken `#image_tag`

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -50,7 +50,7 @@ module ApplicationHelper
 
     options[:src] = "/images/#{image}"
 
-    tag.img(options)
+    tag("img", options)
   end
 
   def banner_duration(duration)


### PR DESCRIPTION
We use the `#image_tag` helper to bypass the asset pipeline machinery in Rails's own `#image_tag`. But Rails no longer spells `tag.img(...)` as such, instead, it writes `tag("img", ...)`.

Update our own helper to reflect the change upstream.

Closes: https://github.com/git/git-scm.com/issues/1741