### PR TITLE
Fix building of Scalar docs & include a temporary workaround for overlapping names

### DIFF
--- a/lib/tasks/index.rake
+++ b/lib/tasks/index.rake
@@ -262,6 +262,8 @@ def index_doc(filter_tags, doc_list, get_content)
         path, sha = entry
         ids = Set.new([])
         docname = File.basename(path, ".txt")
+        # TEMPORARY: skip the scalar technical doc until it has a non-overlapping name
+        next if path == "Documentation/technical/scalar.txt"
         next if doc_limit && path !~ /#{doc_limit}/
 
         file = DocFile.where(name: docname).first_or_create

--- a/lib/tasks/index.rake
+++ b/lib/tasks/index.rake
@@ -56,7 +56,8 @@ def index_l10n_doc(filter_tags, doc_list, get_content)
       ent.first =~
         /^([-_\w]+)\/(
           (
-            git.*
+            git.* |
+            scalar
         )\.txt)/x
     end
 
@@ -198,6 +199,7 @@ def index_doc(filter_tags, doc_list, get_content)
             rev.* |
             pretty.* |
             pull.* |
+            scalar |
             technical\/.*
         )\.txt)/x
     end


### PR DESCRIPTION
## Changes

- Include `scalar` in the doc-matching regex in `index.rake` so that `Documentation/scalar.txt` is built.
- Because `Documentation/scalar.txt` and `Documentation/technical/scalar.txt` have the same basename, the latter will overwrite the former when running `index.rake`. Avoid this by skipping the technical doc rendering entirely (it's not super important to have on the site, and can be fixed permanently in Git; see "Context").

## Context

- Noticed that https://git-scm.com/docs/scalar currently renders the Scalar technical document, but the command documentation is more important/relevant and should be rendered instead.
- The basename overlap can most easily be permanently fixed by renaming `Documentation/technical/scalar.txt` in Git. However, even if this change is part of the next release, the site won't be updated with it until then. So, in the meantime, it's easiest to skip rendering the technical doc
  - Note that "skip building `technical/scalar.txt`" is preferred over "rename `technical/scalar.txt`'s URL" because I don't necessarily want to wait on confirming the new name to merge this PR.
  - After this is fixed in Git & the site is updated with the next version's docs, the "skip building 'technical/scalar.txt' can be reverted.

## Testing
I ran the site locally, and the `scalar` command page came up as expected.

CC: @ttaylorr 