### PR TITLE
rubocop: turn off Rails/ContentTag

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -73,3 +73,6 @@ Lint/EmptyBlock:
   Exclude:
     - spec/**/*
     - test/**/*
+
+Rails/ContentTag:
+  Enabled: false


### PR DESCRIPTION
This cop suggests (and even autocorrects!) an instance of:

```
  tag("img", options)
```

to change into:

```
  tag.img(options)
```

But as discussed in https://github.com/git/git-scm.com/pull/1742, this actually breaks the call!

I'm still puzzled about why this is. But I find that I don't care enough to investigate deeply, and it would be useful to have CI on `main` actually pass, so unrelated pull requests aren't confused into thinking they broke something. So let's just disable the cop for now.
