### PR TITLE
community: recommend lore.kernel.org over public-inbox.org

### DIFF
--- a/app/views/community/index.html.erb
+++ b/app/views/community/index.html.erb
@@ -24,7 +24,7 @@
   </p>
 
   <p>
-    By subscribing (click <a href="mailto:majordomo@vger.kernel.org?body=subscribe git">here</a>), you can make sure you're not missing follow-up discussions and you can also learn about other development in the community.  The list <a href="https://public-inbox.org/git">archive</a> can be found on public-inbox.
+    By subscribing (click <a href="mailto:majordomo@vger.kernel.org?body=subscribe git">here</a>), you can make sure you're not missing follow-up discussions and you can also learn about other development in the community.  The list <a href="https://lore.kernel.org/git/">archive</a> can be found on lore.kernel.org.
   </p>
 
   <p>


### PR DESCRIPTION
## Changes

Similarly to commit [1] in git.git, quote:

> Since lore.kernel.org now has the same archive as public-inbox.org and
> may have more longevity going forward[2], let's recommend people use it
> for finding or referencing messages.

recommend using lore.kernel.org for archives of the Git mailing list on the community page[3].

[1] 46c67492aa (doc: recommend lore.kernel.org over public-inbox.org,
    2019-11-27), see also https://github.com/git/git/commit/46c67492aa3ab2779f9322790ca8fffcd5bfaa80
[2] https://public-inbox.org/git/20191120195556.GA25189@dcvr/
      or if you like:
    https://lore.kernel.org/git/20191120195556.GA25189@dcvr/
[3] https://git-scm.com/community

## Context

I'm not sure if I should open a PR pointing to `v2` or to `main`. `v2` seems to be currently deployed to https://git-scm.com/, but active development seems to happen on `main`. I've also created a backport for `v2`, in case it's needed: https://github.com/git/git-scm.com/compare/v2...rybak:git-scm.com:lore-is-the-archive-v2