### PR TITLE
Update GitHub link

### DIFF
--- a/app/views/doc/_ext_tutorials.erb
+++ b/app/views/doc/_ext_tutorials.erb
@@ -96,7 +96,7 @@
         </p>
       </li>
       <li>
-        <h4><a href="https://help.github.com/">Help.GitHub</a></h4>
+        <h4><a href="https://docs.github.com/">GitHub Docs</a></h4>
         <p class='description'>
           Guides on a variety of Git and GitHub related topics.
         </p>


### PR DESCRIPTION
## Changes

<!-- List the changes this PR makes. -->

Changed the link for GitHub on the external links page to docs.github.com

## Context

<!-- Explain why you're making these changes. -->

Since help.github.com now redirects to GitHub Support, I updated the link to point to docs.github.com