### PR TITLE
re-enable redis caching in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -59,7 +59,7 @@ Rails.application.configure do
 
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
-  config.cache_store = :redis_store, ENV["REDIS_URL"]
+  config.cache_store = :redis_store, ENV.fetch("REDIS_URL")
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
   # config.active_job.queue_adapter     = :resque

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -59,6 +59,7 @@ Rails.application.configure do
 
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
+  config.cache_store = :redis_store, ENV["REDIS_URL"]
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
   # config.active_job.queue_adapter     = :resque


### PR DESCRIPTION
Heroku is warning us that our redis add-on is using an old version and we should upgrade. The new version requires connecting over TLS. So I poked around to see if we handled that, and behold, it looks like we are not even using redis at all. It was traditionally for rails-level caching, but it was lost by 97d2d9a9, which overwrote the config.

It's a one-liner to turn it back on, and that's what this PR does. But apparently it was off for a few years and we didn't notice. And likewise, after deploying this commit for a few days, I don't see anything interesting in the graphs (not better load or memory, and not better response time). Which kind of makes sense; most of our caching is done at the cloudflare level. I'd have thought there was some rails caching that could still help, but maybe not.

So instead of this PR, a better approach might be just leaving things as-is and disabling the heroku redis add-on. That would save the project a cool $30/mo. @ttaylorr, thoughts?