### PR TITLE
Git Extensions no longer supports Linux/Mac

### DIFF
--- a/resources/guis.yml
+++ b/resources/guis.yml
@@ -32,8 +32,6 @@ guis:
   image_tag: guis/git-extensions@2x.png
   platforms:
   - Windows
-  - Mac
-  - Linux
   price: Free
   license: GNU GPL
   order: 4


### PR DESCRIPTION
Latest cross-platform version was released about 5 years ago.

https://github.com/gitextensions/gitextensions#version-25x
https://github.com/gitextensions/gitextensions/releases/tag/v2.51.05

## Changes

Remove Git Extension from Linux/Mac platform list

