### PR TITLE
list credential helpers

### DIFF
--- a/app/controllers/doc_controller.rb
+++ b/app/controllers/doc_controller.rb
@@ -42,6 +42,8 @@ class DocController < ApplicationController
 
   def ext; end
 
+  def credential_helpers; end
+
   private
 
   def set_caching

--- a/app/views/doc/credential_helpers.html.erb
+++ b/app/views/doc/credential_helpers.html.erb
@@ -28,7 +28,7 @@
   <p>The following cross-platform helpers support authentication using OAuth. Initial authentication opens a browser window to the host. Subsequent authentication happens in the background.</p>
 
   <ul>
-    <li><a href="https://github.com/GitCredentialManager/git-credential-manager">Git Credential Manager</a>: included with Git for Windows.</li>
+    <li><a href="https://github.com/git-ecosystem/git-credential-manager">Git Credential Manager</a>: included with Git for Windows.</li>
     <li><a href="https://github.com/hickford/git-credential-oauth">git-credential-oauth</a>: included in many Linux distributions.</li>
   </ul>
 

--- a/app/views/doc/credential_helpers.html.erb
+++ b/app/views/doc/credential_helpers.html.erb
@@ -1,0 +1,48 @@
+<%- @section    = 'documentation' %>
+<%- @subsection = 'credential-helpers' %>
+<%- @page_title = 'Git credential helpers' %>
+
+<div id="main">
+  <h1>Git credential helpers</h1>
+
+  <p>This page lists available <a href="https://git-scm.com/docs/gitcredentials">credential helpers</a>.</p>
+
+  <h2>Included in Git</h2>
+
+  <ul>
+    <li><a href="https://git-scm.com/docs/git-credential-cache">git-credential-store</a>: saves credentials in plaintext.</li>
+    <li><a href="https://git-scm.com/docs/git-credential-cache">git-credential-cache</a>: holds credentials temporarily in process memory. <a href="https://github.com/git-for-windows/git/issues/3892">Not available on Windows</a>. (NB. Since credentials are lost when the cache expires, this is inconvenient to store personal access tokens.)</li>
+  </ul>
+
+  <h2>Platform specific storage</h2>
+  <p></p>
+  <ul>
+    <li>git-credential-wincred: included with Git for Windows.</li>
+    <li>git-credential-osxkeychain: stores in macOS keychain.</li>
+    <li><a href="https://pkgs.org/search/?q=git-credential-libsecret">git-credential-libsecret</a>: stores in Linux secret service such as gnome-keyring or ksecret.</li>
+    <li><s>git-credential-gnome-keyring</s>: deprecated, replaced by git-credential-libsecret.</li>
+  </ul>
+
+  <h2>OAuth</h2>
+
+  <p>The following cross-platform helpers support authentication using OAuth. Initial authentication opens a browser window to the host. Subsequent authentication happens in the background.</p>
+
+  <ul>
+    <li><a href="https://github.com/GitCredentialManager/git-credential-manager">Git Credential Manager</a>: included with Git for Windows.</li>
+    <li><a href="https://github.com/hickford/git-credential-oauth">git-credential-oauth</a>: included in many Linux distributions.</li>
+  </ul>
+
+  <h2>Storage specific</h2>
+  <ul>
+    <li><a href="https://github.com/gopasspw/git-credential-gopass">git-credential-gopass</a>: stores in gopass password manager.</li>
+    <li><a href="https://github.com/lastpass/lastpass-cli/blob/master/contrib/examples/git-credential-lastpass">git-credential-lastpass</a>: stores in lastpass password manager.</li>
+    <li><a href="https://github.com/develerik/git-credential-1password">git-credential-1password</a>: stores in 1password password manager.</li>
+    <li><a href="https://github.com/Frederick888/git-credential-keepassxc">git-credential-keepassxc</a>: stores in KeePassXC password manager.</li>
+  </ul>
+
+  <h2>Host specific</h2>
+  <ul>
+    <li><a href="https://github.com/netlify/netlify-credential-helper">git-credential-netlify</a>: authenticates to Netlify.</li>
+  </ul>
+
+</div>

--- a/app/views/doc/credential_helpers.html.erb
+++ b/app/views/doc/credential_helpers.html.erb
@@ -11,15 +11,15 @@
 
   <ul>
     <li><a href="https://git-scm.com/docs/git-credential-store">git-credential-store</a>: saves credentials in plaintext.</li>
-    <li><a href="https://git-scm.com/docs/git-credential-cache">git-credential-cache</a>: holds credentials temporarily in process memory. <a href="https://github.com/git-for-windows/git/issues/3892">Not available on Windows</a>. (NB. Since credentials are lost when the cache expires, this is inconvenient to store personal access tokens.)</li>
+    <li><a href="https://git-scm.com/docs/git-credential-cache">git-credential-cache</a>: holds credentials temporarily in process memory. <a href="https://github.com/git-for-windows/git/issues/3892">Not available on Windows</a>. (Note that since credentials are lost when the cache expires or system restarts, this is inconvenient to store long-lived personal access tokens.)</li>
   </ul>
 
   <h2>Platform specific storage</h2>
   <p></p>
   <ul>
-    <li>git-credential-wincred: included with Git for Windows.</li>
-    <li>git-credential-osxkeychain: stores in macOS keychain.</li>
-    <li><a href="https://pkgs.org/search/?q=git-credential-libsecret">git-credential-libsecret</a>: stores in Linux secret service such as GNOME Keyring or KDE Wallet.</li>
+    <li>git-credential-osxkeychain: stores in <a href="https://support.apple.com/en-gb/guide/keychain-access/kyca1083/mac">macOS keychain</a>. Included in macOS Git installations.</li>
+    <li>git-credential-libsecret: stores in Linux secret service such as GNOME Keyring or KDE Wallet. <a href="https://pkgs.org/search/?q=git-credential-libsecret">Packaged in many Linux distributions</a>.</li>
+    <li>git-credential-wincred: stores in <a href="https://support.microsoft.com/en-us/windows/accessing-credential-manager-1b5c916a-6a16-889f-8581-fc16e8165ac0">Windows Credential Manager</a>. Included with Git for Windows.</li>
   </ul>
 
   <h2>OAuth</h2>
@@ -34,7 +34,7 @@
   <h2>Storage specific</h2>
   <ul>
     <li><a href="https://github.com/gopasspw/git-credential-gopass">git-credential-gopass</a>: stores in gopass password manager.</li>
-    <li><a href="https://github.com/lastpass/lastpass-cli/blob/master/contrib/examples/git-credential-lastpass">git-credential-lastpass</a>: stores in lastpass password manager.</li>
+    <li><a href="https://github.com/lastpass/lastpass-cli/blob/master/contrib/examples/git-credential-lastpass">git-credential-lastpass</a>: stores in LastPass password manager.</li>
     <li><a href="https://github.com/develerik/git-credential-1password">git-credential-1password</a>: stores in 1Password password manager.</li>
     <li><a href="https://github.com/Frederick888/git-credential-keepassxc">git-credential-keepassxc</a>: stores in KeePassXC password manager.</li>
   </ul>

--- a/app/views/doc/credential_helpers.html.erb
+++ b/app/views/doc/credential_helpers.html.erb
@@ -19,8 +19,7 @@
   <ul>
     <li>git-credential-wincred: included with Git for Windows.</li>
     <li>git-credential-osxkeychain: stores in macOS keychain.</li>
-    <li><a href="https://pkgs.org/search/?q=git-credential-libsecret">git-credential-libsecret</a>: stores in Linux secret service such as gnome-keyring or ksecret.</li>
-    <li><s>git-credential-gnome-keyring</s>: deprecated, replaced by git-credential-libsecret.</li>
+    <li><a href="https://pkgs.org/search/?q=git-credential-libsecret">git-credential-libsecret</a>: stores in Linux secret service such as GNOME Keyring or KDE Wallet.</li>
   </ul>
 
   <h2>OAuth</h2>

--- a/app/views/doc/credential_helpers.html.erb
+++ b/app/views/doc/credential_helpers.html.erb
@@ -10,7 +10,7 @@
   <h2>Included in Git</h2>
 
   <ul>
-    <li><a href="https://git-scm.com/docs/git-credential-cache">git-credential-store</a>: saves credentials in plaintext.</li>
+    <li><a href="https://git-scm.com/docs/git-credential-store">git-credential-store</a>: saves credentials in plaintext.</li>
     <li><a href="https://git-scm.com/docs/git-credential-cache">git-credential-cache</a>: holds credentials temporarily in process memory. <a href="https://github.com/git-for-windows/git/issues/3892">Not available on Windows</a>. (NB. Since credentials are lost when the cache expires, this is inconvenient to store personal access tokens.)</li>
   </ul>
 
@@ -27,7 +27,7 @@
   <p>The following cross-platform helpers support authentication using OAuth. Initial authentication opens a browser window to the host. Subsequent authentication happens in the background.</p>
 
   <ul>
-    <li><a href="https://github.com/git-ecosystem/git-credential-manager">Git Credential Manager</a>: included with Git for Windows.</li>
+    <li><a href="https://github.com/git-ecosystem/git-credential-manager">Git Credential Manager</a>: included with Git for Windows. Supports multiple credential stores.</li>
     <li><a href="https://github.com/hickford/git-credential-oauth">git-credential-oauth</a>: included in many Linux distributions.</li>
   </ul>
 
@@ -35,7 +35,7 @@
   <ul>
     <li><a href="https://github.com/gopasspw/git-credential-gopass">git-credential-gopass</a>: stores in gopass password manager.</li>
     <li><a href="https://github.com/lastpass/lastpass-cli/blob/master/contrib/examples/git-credential-lastpass">git-credential-lastpass</a>: stores in lastpass password manager.</li>
-    <li><a href="https://github.com/develerik/git-credential-1password">git-credential-1password</a>: stores in 1password password manager.</li>
+    <li><a href="https://github.com/develerik/git-credential-1password">git-credential-1password</a>: stores in 1Password password manager.</li>
     <li><a href="https://github.com/Frederick888/git-credential-keepassxc">git-credential-keepassxc</a>: stores in KeePassXC password manager.</li>
   </ul>
 

--- a/app/views/shared/_sidebar.html.erb
+++ b/app/views/shared/_sidebar.html.erb
@@ -41,9 +41,6 @@
             <%= link_to "Videos", "/videos", sidebar_link_options("videos") %>
           </li>
           <li>
-            <%= link_to "Credential helpers", "/doc/credential-helpers", sidebar_link_options("credential-helpers") %>
-          </li>
-          <li>
             <%= link_to "External Links", "/doc/ext", sidebar_link_options("external-links") %>
           </li>
         </ul>

--- a/app/views/shared/_sidebar.html.erb
+++ b/app/views/shared/_sidebar.html.erb
@@ -41,6 +41,9 @@
             <%= link_to "Videos", "/videos", sidebar_link_options("videos") %>
           </li>
           <li>
+            <%= link_to "Credential helpers", "/doc/credential-helpers", sidebar_link_options("credential-helpers") %>
+          </li>
+          <li>
             <%= link_to "External Links", "/doc/ext", sidebar_link_options("external-links") %>
           </li>
         </ul>

--- a/app/views/shared/ref/_setup.html.erb
+++ b/app/views/shared/ref/_setup.html.erb
@@ -4,4 +4,5 @@
   <li><%= man('git-config') %></li>
   <li><%= man('git-help') %></li>
   <li><%= man('git-bugreport') %></li>
+  <%= link_to "Credential helpers", "/doc/credential-helpers", sidebar_link_options("credential-helpers") %>
 </ul>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,7 @@ Rails.application.routes.draw do
   scope :doc, as: :doc do
     get "/"    => "doc#index"
     get "/ext" => "doc#ext"
+    get "/credential-helpers" => "doc#credential_helpers"
   end
 
   scope :docs, as: :docs do


### PR DESCRIPTION
New page listing available credential helpers

The aim of this change is to introduce a discoverable, helpful, community-maintained, comprehensive list of credential helpers. Questions about Git credentials such as https://stackoverflow.com/questions/35942754/how-can-i-save-username-and-password-in-git (3.5m views) are among the most viewed questions on StackOverflow. Users are desperate for information about credential helpers, but the Git docs only discuss credential-cache and credential-store

see discussion with @ldennington @peff @ttaylorr at https://lore.kernel.org/git/CAGJzqskaM80+8+79yUf435tP93Sk8sFu7marCvyimE=2gOKnog@mail.gmail.com/T/#m825e5fe599f14efa020e31d01864529f7bbd02ee

