### PR TITLE
Make install directions more explicit to avoid confusing new users.

### DIFF
--- a/app/views/downloads/download_mac.html.erb
+++ b/app/views/downloads/download_mac.html.erb
@@ -13,6 +13,8 @@
   any non-source distributions are provided by third parties, and may
   not be up to date with the latest source release.</p>
 
+  <p><b>Choose one of the following options for installing Git on macOS:</b></p>
+
   <h3>Homebrew</h3>
   <p>Install <a href="https://brew.sh/">homebrew</a> if you don't already have it, then:<br>
   <code>$ brew install git</code></p>


### PR DESCRIPTION
## Changes

- Add more explicit text to help people understand they only need to download one installer, not all

## Context

As a professor, my students were getting confused and installing both brew and macports, causing overwrite issues. Clearer copywriting could solve this confusion. 
