### PR TITLE
community: #github is on IRC, not Discord

### DIFF
--- a/app/views/community/index.html.erb
+++ b/app/views/community/index.html.erb
@@ -84,14 +84,14 @@
     The <span class="highlight fixed">#git-devel</span> channel welcomes Git development discussion, and might be able to help you contribute to Git.
   </p>
 
+  <p>
+    If you need specific help about one of the for-profit Git hosting sites, you might try their own IRC channels (such as <span class="highlight fixed">#github</span> or <span class="highlight fixed">#gitlab</span>) on the same IRC server.
+  </p>
+
   <h2> Discord Server </h2>
 
   <p>
     The <a href="https://discord.gg/GRFVkzgxRd">Git Community Discord Server</a> also has many knowledgeable and helpful people. Additionally, it provides a space to be able to voice chat about patches, designs, or anything else Git related.
-  </p>
-
-  <p>
-    If you need specific help about one of the for-profit Git hosting sites, you might try their own IRC channels (such as <span class="highlight fixed">#github</span> or <span class="highlight fixed">#gitlab</span>) on the same IRC server.
   </p>
 
   <h2> Newsletter </h2>


### PR DESCRIPTION
This paragraph accidentally moved to the wrong section in #1800. Thanks to arxanas for noticing.