### PR TITLE
[update guis.yml] Git Extensions no longer support Mac and Linux

### DIFF
--- a/resources/guis.yml
+++ b/resources/guis.yml
@@ -32,8 +32,6 @@ guis:
   image_tag: guis/git-extensions@2x.png
   platforms:
   - Windows
-  - Mac
-  - Linux
   price: Free
   license: GNU GPL
   order: 4


### PR DESCRIPTION

## Changes

Changed metadata of one of GIT GUIs (Git Extensions)

## Context

Last version of Git Extensions that supported other OS'es was 2.51  and it is broken currently on Linux, it's almost unusable and crashes a lot.

![image](https://github.com/git/git-scm.com/assets/775038/afe27694-ab67-4dcf-bc49-783655d5a79e)

https://github.com/gitextensions/gitextensions#version-25x