### PR TITLE
Fixed link to Learning Git book by Anna Skoulikari

### DIFF
--- a/app/views/doc/_ext_books.erb
+++ b/app/views/doc/_ext_books.erb
@@ -59,7 +59,7 @@
       </li>
       <li>
        <a href="https://www.amazon.com/Learning-Git-Hands-Visual-Basics/dp/1098133919/"><img src="https://learning.oreilly.com/covers/urn:orm:book:9781098133900/400w/"/></a>
-        <h4><a href="/book">Learning Git: A Hands-On and Visual Guide to the Basics of Git</a></h4>
+        <h4><a href="https://www.amazon.com/Learning-Git-Hands-Visual-Basics/dp/1098133919/">Learning Git: A Hands-On and Visual Guide to the Basics of Git</a></h4>
         <p class='description'>
          By Anna Skoulikari
         </p>


### PR DESCRIPTION
## Changes

The link to the recently added book Learning Git by Anna Skoulikari was wrong. This PR fixes it. 


