### PR TITLE
community: remove mention of git-users list

### DIFF
--- a/app/views/community/index.html.erb
+++ b/app/views/community/index.html.erb
@@ -12,9 +12,9 @@
   <h2> Mailing List</h2>
 
   <p>
-    General questions or comments for the Git community can be sent to the mailing list by using the email address <a href="mailto:git@vger.kernel.org">git@vger.kernel.org</a>. 
+    General questions or comments for the Git community can be sent to the mailing list by using the email address <a href="mailto:git@vger.kernel.org">git@vger.kernel.org</a>.
   </p>
-  
+
   <p>
     <strong>If you wish to report any possible bug for Git, please use this mailing list as well.</strong>
   </p>

--- a/app/views/community/index.html.erb
+++ b/app/views/community/index.html.erb
@@ -32,7 +32,6 @@
   </p>
 
   <p>
-    There is also <a href="https://groups.google.com/forum/?fromgroups#!forum/git-users">Git user mailing list</a> on Google Groups which is a nice place for beginners to ask about anything.
     If you're a downstream packager of Git, consider joining the <a href="https://groups.google.com/forum/?fromgroups#!forum/git-packagers">Git packagers mailing list</a> for low-volume announcements from the developers, as well as other discussion related to packaging &amp; porting Git.
   </p>
 


### PR DESCRIPTION
The git-users mailing list has become [spam-infested] lately. This to
the point where Google Groups won’t let you view the forum.

I raised this issue in the following places:

• https://discord.gg/GRFVkzgxRd
• https://github.com/git/git-scm.com/issues/1828
• https://lore.kernel.org/git/20240204084344.jzu2ciulbrdmxz4u@carbon/T/#m16eeb0bd8cd2c30c05836ea134817911ee794ec1

Subscribed members may try to contact the owner of the Google
Group. Konstantin Khomoutov, A regular on that list for many years,
[pointed out] that he has never seen the owner post on the list; he
seems to be “AWOL”.

The only recourse here seems to be to contact Google, which Konstantin
[did].

In the meantime—if anything comes of the support ticket—the mailing list
is useless and there is no point in advertising it.

🔗 spam-infested: https://www.mail-archive.com/git-users@googlegroups.com/
🔗 pointed out: https://lore.kernel.org/git/20240204084344.jzu2ciulbrdmxz4u@carbon/T/#r6d56086655cfc2c94b88d22c7c7c1a7dfceee093
🔗 did: https://support.google.com/groups/thread/256971101

Fixes: #1828