### PR TITLE
Change git-credential-1password repo

### DIFF
--- a/app/views/doc/credential_helpers.html.erb
+++ b/app/views/doc/credential_helpers.html.erb
@@ -35,7 +35,7 @@
   <ul>
     <li><a href="https://github.com/gopasspw/git-credential-gopass">git-credential-gopass</a>: stores in gopass password manager.</li>
     <li><a href="https://github.com/lastpass/lastpass-cli/blob/master/contrib/examples/git-credential-lastpass">git-credential-lastpass</a>: stores in LastPass password manager.</li>
-    <li><a href="https://github.com/develerik/git-credential-1password">git-credential-1password</a>: stores in 1Password password manager.</li>
+    <li><a href="https://github.com/ethrgeist/git-credential-1password">git-credential-1password</a>: stores in 1Password password manager.</li>
     <li><a href="https://github.com/Frederick888/git-credential-keepassxc">git-credential-keepassxc</a>: stores in KeePassXC password manager.</li>
   </ul>
 


### PR DESCRIPTION
## Changes

Add a new repo for the 1Password helper.

## Context

The old one is no longer available.
