### PR TITLE
mark Aurees as  "no longer under active development"

### DIFF
--- a/resources/guis.yml
+++ b/resources/guis.yml
@@ -123,7 +123,7 @@ guis:
   license: GNU GPL
   trend_name: Git giggle
   order: 27
-- name: Aurees
+- name: Aurees (no longer under active development)
   url: https://aurees.com/
   image_tag: guis/aurees@2x.png
   platforms:


### PR DESCRIPTION
## Changes

Updated the entry for Auress in /resources/guis.yml 

-

## Context

As described in https://github.com/git/git-scm.com/issues/1848 the application is no longer maintained.
