### PR TITLE
css: disable ligatures in monospace fonts

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -39,6 +39,7 @@ pre {
   color: $orange;
   display: block;
   font-family: $fixed-width-font-family;
+  font-variant-ligatures: none;
   line-height: 18px;
   margin-bottom: 1em;
   overflow: auto;

--- a/app/assets/stylesheets/man-pages.scss
+++ b/app/assets/stylesheets/man-pages.scss
@@ -6,6 +6,7 @@
   p {
     em {
       font-family: $fixed-width-font-family !important;
+      font-variant-ligatures: none;
       font-style: normal;
       font-weight: bold;
       color: $fixed-width-font-color;
@@ -28,6 +29,7 @@
       display: block;
       padding: 2px;
       font-family: $fixed-width-font-family !important;
+      font-variant-ligatures: none;
       background-color: #eee0b5;
     }
     margin-bottom: 15px;
@@ -35,6 +37,7 @@
 
   dt.hdlist1 {
     font-family: $fixed-width-font-family !important;
+    font-variant-ligatures: none;
   }
 
   // Man pages
@@ -44,6 +47,7 @@
       margin-bottom: 1em;
       font-family: $fixed-width-font-family !important;
       line-height: $fixed-width-line-height;
+      font-variant-ligatures: none;
       color: $fixed-width-font-color;
       word-wrap: break-word;       /* Internet Explorer 5.5+ */
       white-space: pre;

--- a/app/assets/stylesheets/typography.scss
+++ b/app/assets/stylesheets/typography.scss
@@ -258,6 +258,7 @@ code {
   overflow: auto;
   font-family: $fixed-width-font-family;
   line-height: $fixed-width-line-height;
+  font-variant-ligatures: none;
   color: $orange;
   background-color: #fff;
   border: solid 1px #efeee6;
@@ -364,6 +365,7 @@ div.more {
 
 .fixed {
   font-family: $fixed-width-font-family;
+  font-variant-ligatures: none;
 }
 
 .text-center {


### PR DESCRIPTION
A fix for the readability issue reported in #1817. The commit message basically repeats the bug report.

I am fairly familiar with CSS, but I don't know how exactly `.scss` works, similar to how I didn't know Ruby in #838 (still don't). However, the things required for this PR were relatively intuitive and I did get the fix working locally simply by guessing. Here are comparisons to the screenshots from the bug report:

| what                                                                                                                             | before/after screenshots                                                                                                                         |
|----------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------|
| "mentions of `reflog` in monospace"                                                                                              | ![image](https://github.com/git/git-scm.com/assets/624072/04a5225c-8644-4041-92aa-73c95b72752d "mentions of reflog in config keys and commands") |
| "[mention of `git config`](https://git-scm.com/docs/git-config#Documentation/git-config.txt---typelttypegt)"                     | ![image](https://github.com/git/git-scm.com/assets/624072/a15fe698-fce3-43d0-b842-ad45c84706d2 "mention of git config")                          |
| "[mention of `color.diff.new`](https://git-scm.com/docs/git-config#Documentation/git-config.txt---get-colorltnamegtltdefaultgt)" | ![image](https://github.com/git/git-scm.com/assets/624072/28f40381-f40c-4d89-8962-7a8af83c50d3 "mention of color.diff.new")                      |