### PR TITLE
search: add shortcuts to focus

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -102,6 +102,7 @@ var Search = {
     Search.observeFocus();
     Search.observeTextEntry();
     Search.observeResultsClicks();
+    Search.installKeyboardShortcuts();
   },
 
   observeFocus: function() {
@@ -146,6 +147,15 @@ var Search = {
   observeResultsClicks: function() {
     $('#search-results').mousedown(function(e) {
       e.preventDefault();
+    });
+  },
+
+  installKeyboardShortcuts: function() {
+    $(document).keydown(function(e) {
+      if (e.target.tagName.toUpperCase() !== 'INPUT' && ['s', 'S', '/'].includes(e.key)) {
+        e.preventDefault();
+        $('form#search input').focus();
+      }
     });
   },
 

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -8,7 +8,7 @@
     document.getElementById('tagline').innerHTML = '--' + tagline;
   </script>
   <form id="search" action="/search/results">
-    <input id="search-text" name="search" placeholder="Search entire site..." autocomplete="off" type="text" />
+    <input id="search-text" name="search" placeholder="Type / to search entire site…" autocomplete="off" type="text" />
   </form>
   <div id="search-results"></div>
 


### PR DESCRIPTION
This cribs from Racket's documentation site [1], where pressing "s" will
focus the search bar. This is a modified version of [2], which I choose
to receive and use under the MIT license [3], [4], which is compatible
with MIT-LICENSE.txt.

Add a note to the search bar's placeholder: there's a probably a better
way to steer users into this, but "/" is common thanks to Vim and many
websites; "s" is natural (at least to me, having used Racket's docs so
long).

The jQuery features may be using deprecated handlers [5], but the site
appears to be on 12-year old jQuery [6]. Modifications to the jQuery
code from Racket work better on Firefox and allow other document
elements to intercept the event.

[1]: https://docs.racket-lang.org/
[2]: https://github.com/racket/scribble/blob/02ecb223c8e0e4dda3c00739338c96dcd1d5bac6/scribble-lib/scribble/scribble-common.js#L145C2-L152C13
[3]: https://github.com/racket/scribble/blob/02ecb223c8e0e4dda3c00739338c96dcd1d5bac6/LICENSE.txt
[4]: https://github.com/racket/racket/blob/240aa086c548440e0b11641c40cf79e393a560a4/racket/src/LICENSE-MIT.txt
[5]: https://api.jquery.com/keyup-shorthand/
[6]: https://blog.jquery.com/2012/03/21/jquery-1-7-2-released/

---

I haven't yet managed to setup a local version to test this; feedback from testers welcome.