### PR TITLE
app.json: :arrow_up: stack to heroku-24

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,4 +1,5 @@
 {
+  "stack": "heroku-24",
   "scripts": {
   },
   "env": {


### PR DESCRIPTION
Heroku has deprecated the heroku-20 stack, which runs git-scm.com \[1\]. Upgrade the stack to the more modern heroku-24 to keep the site's builds from failing after February 1, 2025.

\[1\]: https://help.heroku.com/NPN275RK/heroku-20-end-of-life-faq

##

/cc @pedrorijo91 