### PR TITLE
Gemfile: update to latest elasticsearch

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem 'net-pop', require: false
 gem 'net-smtp', require: false
 
 gem "asciidoctor", "~> 2.0.0"
-gem "elasticsearch", "2.0.2"
+gem "elasticsearch", "8.15.0"
 gem "iso8601"
 gem "octokit"
 gem "puma"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,13 +91,13 @@ GEM
     dotenv-rails (2.7.6)
       dotenv (= 2.7.6)
       railties (>= 3.2)
-    elasticsearch (2.0.2)
-      elasticsearch-api (= 2.0.2)
-      elasticsearch-transport (= 2.0.2)
-    elasticsearch-api (2.0.2)
+    elastic-transport (8.3.5)
+      faraday (< 3)
       multi_json
-    elasticsearch-transport (2.0.2)
-      faraday
+    elasticsearch (8.15.0)
+      elastic-transport (~> 8.3)
+      elasticsearch-api (= 8.15.0)
+    elasticsearch-api (8.15.0)
       multi_json
     erubi (1.12.0)
     execjs (2.8.1)
@@ -107,25 +107,29 @@ GEM
     factory_bot_rails (6.2.0)
       factory_bot (~> 6.2.0)
       railties (>= 5.0.0)
-    faraday (1.8.0)
+    faraday (1.10.3)
       faraday-em_http (~> 1.0)
       faraday-em_synchrony (~> 1.0)
       faraday-excon (~> 1.1)
-      faraday-httpclient (~> 1.0.1)
+      faraday-httpclient (~> 1.0)
+      faraday-multipart (~> 1.0)
       faraday-net_http (~> 1.0)
-      faraday-net_http_persistent (~> 1.1)
+      faraday-net_http_persistent (~> 1.0)
       faraday-patron (~> 1.0)
       faraday-rack (~> 1.0)
-      multipart-post (>= 1.2, < 3)
+      faraday-retry (~> 1.0)
       ruby2_keywords (>= 0.0.4)
     faraday-em_http (1.0.0)
     faraday-em_synchrony (1.0.0)
     faraday-excon (1.1.0)
     faraday-httpclient (1.0.1)
-    faraday-net_http (1.0.1)
+    faraday-multipart (1.0.4)
+      multipart-post (~> 2)
+    faraday-net_http (1.0.2)
     faraday-net_http_persistent (1.2.0)
     faraday-patron (1.0.0)
     faraday-rack (1.0.0)
+    faraday-retry (1.0.3)
     ffi (1.15.4)
     foreman (0.87.2)
     globalid (1.2.1)
@@ -152,7 +156,7 @@ GEM
     mini_portile2 (2.8.6)
     minitest (5.22.3)
     multi_json (1.15.0)
-    multipart-post (2.1.1)
+    multipart-post (2.4.1)
     net-imap (0.3.1)
       net-protocol
     net-pop (0.1.2)
@@ -351,7 +355,7 @@ DEPENDENCIES
   database_cleaner
   diffy
   dotenv-rails
-  elasticsearch (= 2.0.2)
+  elasticsearch (= 8.15.0)
   fabrication
   factory_bot_rails
   foreman


### PR DESCRIPTION
I ran the following after modifying the Gemfile to point at a more modern version of the elasticsearch Gem.

```
$ rbenv local 3.1.3
$ bundle update
```