### PR TITLE
Gemfile: :arrow_down: gem 'elasticsearch'

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem 'net-pop', require: false
 gem 'net-smtp', require: false
 
 gem "asciidoctor", "~> 2.0.0"
-gem "elasticsearch", "8.15.0"
+gem "elasticsearch", "7.13"
 gem "iso8601"
 gem "octokit"
 gem "puma"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,13 +91,13 @@ GEM
     dotenv-rails (2.7.6)
       dotenv (= 2.7.6)
       railties (>= 3.2)
-    elastic-transport (8.3.5)
-      faraday (< 3)
+    elasticsearch (7.13.0)
+      elasticsearch-api (= 7.13.0)
+      elasticsearch-transport (= 7.13.0)
+    elasticsearch-api (7.13.0)
       multi_json
-    elasticsearch (8.15.0)
-      elastic-transport (~> 8.3)
-      elasticsearch-api (= 8.15.0)
-    elasticsearch-api (8.15.0)
+    elasticsearch-transport (7.13.0)
+      faraday (~> 1)
       multi_json
     erubi (1.12.0)
     execjs (2.8.1)
@@ -355,7 +355,7 @@ DEPENDENCIES
   database_cleaner
   diffy
   dotenv-rails
-  elasticsearch (= 8.15.0)
+  elasticsearch (= 7.13)
   fabrication
   factory_bot_rails
   foreman


### PR DESCRIPTION
Newer versions of the elasticsearch Gem do not communicate with Bonsai as they are not an official Elastic product, and instead raise the following error:

    /app/vendor/bundle/ruby/3.1.0/gems/elasticsearch-8.15.0/lib/elasticsearch.rb:103:in `verify_elasticsearch': The client noticed that the server is not Elasticsearch and we do not support this unknown product. (Elasticsearch::UnsupportedProductError)

Downgrade to the highest supported version per this[1] guide from Bonsai.

[1]: https://bonsai.io/docs/ruby-on-rails
