### PR TITLE
lib/searchable.rb: do not use minimum_number_should_match

### DIFF
--- a/lib/searchable.rb
+++ b/lib/searchable.rb
@@ -19,7 +19,7 @@ module Searchable
         "query" => {
           "bool" => {
             "should" => [],
-            "minimum_number_should_match" => 1
+            "minimum_should_match" => 1
           },
         },
         "highlight" => {


### PR DESCRIPTION
Modern ElasticSearch versions do not support minimum_number_should_match as a part of their search term, and instead prefer minimum_should_match.

Update our query construction to match so that we hopefully start getting some results back.
