### PR TITLE
ci: skip the scheduled workflows in forked repositories

### DIFF
--- a/.github/workflows/update-book.yml
+++ b/.github/workflows/update-book.yml
@@ -13,6 +13,7 @@ on:
 
 jobs:
   check-for-updates:
+    if: github.event.repository.fork == false || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/update-download-data.yml
+++ b/.github/workflows/update-download-data.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   update-download-data:
+    if: github.event.repository.fork == false || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
       contents: write # to push changes (if any)

--- a/.github/workflows/update-git-version-and-manual-pages.yml
+++ b/.github/workflows/update-git-version-and-manual-pages.yml
@@ -13,6 +13,7 @@ on:
 
 jobs:
   update-git-version-and-manual-pages:
+    if: github.event.repository.fork == false || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
       contents: write # to push changes (if any)

--- a/.github/workflows/update-translated-manual-pages.yml
+++ b/.github/workflows/update-translated-manual-pages.yml
@@ -13,6 +13,7 @@ on:
 
 jobs:
   check-for-updates:
+    if: github.event.repository.fork == false || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
The idea of the scheduled workflows that were added in #1804 is to keep the actual https://git-scm.com/ site up to date. Doing this in fork repositories makes little sense, so let's skip them in forks.