### PR TITLE
search: hide empty categories by default

### DIFF
--- a/assets/js/application.js
+++ b/assets/js/application.js
@@ -362,6 +362,7 @@ var Search = {
 
     const ui = new PagefindUI({
       element: "#search-div",
+      showEmptyFilters: false,
       showSubResults: true,
       showImages: false,
       language,


### PR DESCRIPTION
The search page (https://git-scm.com/search/results?search=something) is now backed by Pagefind, which allows specifying a "category", i.e. whether to show only results from the book or the reference, etc.

By default, the Pagefind UI [shows all categories](https://pagefind.app/docs/ui/#show-empty-filters), even if there are no matches for the current search term(s) in a given category.

During the demonstration of the Pagefind-based search at the Git Contributors Summit during [GitMerge '24](https://git-merge.com/), @peff mentioned the desire to hide empty categories, in particular the blog. This here PR makes it so.

| Before | After |
| - | - |
| ![including empty categories](https://github.com/user-attachments/assets/cf3b755b-eb06-4006-b721-e3bd958f69ea) | ![hiding empty categories](https://github.com/user-attachments/assets/d2bc8909-c5e1-4024-aa7d-6603842dd634) |

