### PR TITLE
Add html code tags for ko&en

### DIFF
--- a/external/book/content/book/en/v2/Git-Internals-The-Refspec.html
+++ b/external/book/content/book/en/v2/Git-Internals-The-Refspec.html
@@ -38,8 +38,8 @@ Suppose you were following along with the last couple sections and had created a
 </div>
 </div>
 <div class="paragraph">
-<p>The format of the refspec is, first, an optional <code>`, followed by `&lt;src&gt;:&lt;dst&gt;`, where `&lt;src&gt;` is the pattern for references on the remote side and `&lt;dst&gt;` is where those references will be tracked locally.
-The `</code> tells Git to update the reference even if it isn’t a fast-forward.</p>
+<p>The format of the refspec is, first, an optional <code>`</code>, followed by <code>&lt;src&gt;:&lt;dst&gt;</code>, where <code>&lt;src&gt;</code> is the pattern for references on the remote side and <code>&lt;dst&gt;</code> is where those references will be tracked locally.
+The <code>`</code> tells Git to update the reference even if it isn’t a fast-forward.</p>
 </div>
 <div class="paragraph">
 <p>In the default case that is automatically written by a <code>git remote add origin</code> command, Git fetches all the references under <code>refs/heads/</code> on the server and writes them to <code>refs/remotes/origin/</code> locally.

--- a/external/book/content/book/ko/v2/Git의-내부-Refspec.html
+++ b/external/book/content/book/ko/v2/Git의-내부-Refspec.html
@@ -39,7 +39,7 @@ url: "/book/ko/v2/Git의-내부-Refspec.html"
 </div>
 </div>
 <div class="paragraph">
-<p>Refspec 형식은 <code>` 와 `&lt;src&gt;:&lt;dest&gt;` 로 돼 있다. `</code> 는 생략 가능하고, <code>&lt;src&gt;</code> 는 리모트 저장소의 Refs 패턴이고 <code>&lt;dst&gt;</code> 는 매핑되는 로컬 저장소의 Refs 패턴이다.
+<p>Refspec 형식은 <code>`</code> 와 <code>&lt;src&gt;:&lt;dest&gt;</code> 로 돼 있다. <code>`</code> 는 생략 가능하고, <code>&lt;src&gt;</code> 는 리모트 저장소의 Refs 패턴이고 <code>&lt;dst&gt;</code> 는 매핑되는 로컬 저장소의 Refs 패턴이다.
 <code>+</code> 는 Fast-forward가 아닌 업데이트를 허용하는 것이다.</p>
 </div>
 <div class="paragraph">


### PR DESCRIPTION
## Changes

<!-- List the changes this PR makes. -->

Fix the broken html code tags for Korean and English in book about refspec.

| Language | Before | After |
|----------|----------|----------|
| English  | ![image](https://github.com/user-attachments/assets/10b7ed8f-5b2f-4051-8ae3-4ce7ebed5e7f)  | ![image](https://github.com/user-attachments/assets/4c6d54d2-dcc2-4fd0-842f-b0a7f9499d95)   |
| Korean   | ![image](https://github.com/user-attachments/assets/ec28add3-b30e-402b-9aa0-3c841c7267ac)  | ![image](https://github.com/user-attachments/assets/5c9a9c66-2189-4a44-8463-304819054208)  |

## Context

<!-- Explain why you're making these changes. -->

I was reading the section about refspec and realize that it's `<code></code>` tag was little bit broken in English
and also found the same issue in Korean books. I think it will be more comfortable to read after the changes in both languages. 😄 

