### PR TITLE
Upload playwright results in PR builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,3 +83,8 @@ jobs:
       env:
         PLAYWRIGHT_TEST_URL: http://localhost:5000/
       run: npx playwright test --project=chrome
+    - uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: playwright-report
+        path: playwright-report/

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -22,7 +22,11 @@ module.exports = defineConfig({
   workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   /* Uses 'github' for GitHub Actions CI to generate annotations, otherwise 'html' */
-  reporter: process.env.CI && process.env.PLAYWRIGHT_TEST_URL === 'http://localhost:5000/' ? 'github' : 'html',
+  reporter: [
+    [ 'html' ],
+    ...(process.env.CI && process.env.PLAYWRIGHT_TEST_URL === 'http://localhost:5000/'
+      ? [ [ 'github' ] ] : [])
+  ],
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */


### PR DESCRIPTION
## Changes

For ease of debugging test failures in the Playwright tests, let's upload the results also in PR builds (we already publish them as build artifacts in the `playwright` workflow as well as when deploying the site).

## Context

When I was working on https://github.com/git/git-scm.com/pull/1878, I was puzzled about some test failures in the Playwright tests. When I found out, it was quite obvious that I had forgotten to update the test accordingly, but I had to recreate the test failure locally because the test results had not been made available as a build artifact.