### PR TITLE
Fix book redirects

### DIFF
--- a/external/book/content/book/az/v2/_index.html
+++ b/external/book/content/book/az/v2/_index.html
@@ -13,4 +13,5 @@ page_title: Git - Book
 url: "/book/az/v2.html"
 aliases:
 - "/book/az/v2/index.html"
+- "/book/az/index.html"
 ---

--- a/external/book/content/book/be/v2/_index.html
+++ b/external/book/content/book/be/v2/_index.html
@@ -13,4 +13,5 @@ page_title: Git - Book
 url: "/book/be/v2.html"
 aliases:
 - "/book/be/v2/index.html"
+- "/book/be/index.html"
 ---

--- a/external/book/content/book/bg/v2/_index.html
+++ b/external/book/content/book/bg/v2/_index.html
@@ -13,4 +13,5 @@ page_title: Git - Book
 url: "/book/bg/v2.html"
 aliases:
 - "/book/bg/v2/index.html"
+- "/book/bg/index.html"
 ---

--- a/external/book/content/book/cs/v2/_index.html
+++ b/external/book/content/book/cs/v2/_index.html
@@ -13,4 +13,5 @@ page_title: Git - Book
 url: "/book/cs/v2.html"
 aliases:
 - "/book/cs/v2/index.html"
+- "/book/cs/index.html"
 ---

--- a/external/book/content/book/de/v2/_index.html
+++ b/external/book/content/book/de/v2/_index.html
@@ -13,4 +13,5 @@ page_title: Git - Book
 url: "/book/de/v2.html"
 aliases:
 - "/book/de/v2/index.html"
+- "/book/de/index.html"
 ---

--- a/external/book/content/book/en/v2/_index.html
+++ b/external/book/content/book/en/v2/_index.html
@@ -16,4 +16,6 @@ page_title: Git - Book
 url: "/book/en/v2.html"
 aliases:
 - "/book/en/v2/index.html"
+- "/book/en/index.html"
+- "/book/index.html"
 ---

--- a/external/book/content/book/es/v2/_index.html
+++ b/external/book/content/book/es/v2/_index.html
@@ -13,4 +13,5 @@ page_title: Git - Book
 url: "/book/es/v2.html"
 aliases:
 - "/book/es/v2/index.html"
+- "/book/es/index.html"
 ---

--- a/external/book/content/book/fa/v2/_index.html
+++ b/external/book/content/book/fa/v2/_index.html
@@ -13,4 +13,5 @@ page_title: Git - Book
 url: "/book/fa/v2.html"
 aliases:
 - "/book/fa/v2/index.html"
+- "/book/fa/index.html"
 ---

--- a/external/book/content/book/fr/v2/_index.html
+++ b/external/book/content/book/fr/v2/_index.html
@@ -13,4 +13,5 @@ page_title: Git - Book
 url: "/book/fr/v2.html"
 aliases:
 - "/book/fr/v2/index.html"
+- "/book/fr/index.html"
 ---

--- a/external/book/content/book/gr/v2/_index.html
+++ b/external/book/content/book/gr/v2/_index.html
@@ -13,4 +13,5 @@ page_title: Git - Book
 url: "/book/gr/v2.html"
 aliases:
 - "/book/gr/v2/index.html"
+- "/book/gr/index.html"
 ---

--- a/external/book/content/book/id/v2/_index.html
+++ b/external/book/content/book/id/v2/_index.html
@@ -13,4 +13,5 @@ page_title: Git - Book
 url: "/book/id/v2.html"
 aliases:
 - "/book/id/v2/index.html"
+- "/book/id/index.html"
 ---

--- a/external/book/content/book/it/v2/_index.html
+++ b/external/book/content/book/it/v2/_index.html
@@ -13,4 +13,5 @@ page_title: Git - Book
 url: "/book/it/v2.html"
 aliases:
 - "/book/it/v2/index.html"
+- "/book/it/index.html"
 ---

--- a/external/book/content/book/ja/v2/_index.html
+++ b/external/book/content/book/ja/v2/_index.html
@@ -13,4 +13,5 @@ page_title: Git - Book
 url: "/book/ja/v2.html"
 aliases:
 - "/book/ja/v2/index.html"
+- "/book/ja/index.html"
 ---

--- a/external/book/content/book/ko/v2/_index.html
+++ b/external/book/content/book/ko/v2/_index.html
@@ -13,4 +13,5 @@ page_title: Git - Book
 url: "/book/ko/v2.html"
 aliases:
 - "/book/ko/v2/index.html"
+- "/book/ko/index.html"
 ---

--- a/external/book/content/book/mk/v2/_index.html
+++ b/external/book/content/book/mk/v2/_index.html
@@ -13,4 +13,5 @@ page_title: Git - Book
 url: "/book/mk/v2.html"
 aliases:
 - "/book/mk/v2/index.html"
+- "/book/mk/index.html"
 ---

--- a/external/book/content/book/ms/v2/_index.html
+++ b/external/book/content/book/ms/v2/_index.html
@@ -13,4 +13,5 @@ page_title: Git - Book
 url: "/book/ms/v2.html"
 aliases:
 - "/book/ms/v2/index.html"
+- "/book/ms/index.html"
 ---

--- a/external/book/content/book/nl/v2/_index.html
+++ b/external/book/content/book/nl/v2/_index.html
@@ -13,4 +13,5 @@ page_title: Git - Book
 url: "/book/nl/v2.html"
 aliases:
 - "/book/nl/v2/index.html"
+- "/book/nl/index.html"
 ---

--- a/external/book/content/book/pl/v2/_index.html
+++ b/external/book/content/book/pl/v2/_index.html
@@ -13,4 +13,5 @@ page_title: Git - Book
 url: "/book/pl/v2.html"
 aliases:
 - "/book/pl/v2/index.html"
+- "/book/pl/index.html"
 ---

--- a/external/book/content/book/pt-br/v2/_index.html
+++ b/external/book/content/book/pt-br/v2/_index.html
@@ -13,4 +13,5 @@ page_title: Git - Book
 url: "/book/pt-br/v2.html"
 aliases:
 - "/book/pt-br/v2/index.html"
+- "/book/pt-br/index.html"
 ---

--- a/external/book/content/book/pt-pt/v2/_index.html
+++ b/external/book/content/book/pt-pt/v2/_index.html
@@ -13,4 +13,5 @@ page_title: Git - Book
 url: "/book/pt-pt/v2.html"
 aliases:
 - "/book/pt-pt/v2/index.html"
+- "/book/pt-pt/index.html"
 ---

--- a/external/book/content/book/ru/v2/_index.html
+++ b/external/book/content/book/ru/v2/_index.html
@@ -13,4 +13,5 @@ page_title: Git - Book
 url: "/book/ru/v2.html"
 aliases:
 - "/book/ru/v2/index.html"
+- "/book/ru/index.html"
 ---

--- a/external/book/content/book/sl/v2/_index.html
+++ b/external/book/content/book/sl/v2/_index.html
@@ -13,4 +13,5 @@ page_title: Git - Book
 url: "/book/sl/v2.html"
 aliases:
 - "/book/sl/v2/index.html"
+- "/book/sl/index.html"
 ---

--- a/external/book/content/book/sr/v2/_index.html
+++ b/external/book/content/book/sr/v2/_index.html
@@ -13,4 +13,5 @@ page_title: Git - Book
 url: "/book/sr/v2.html"
 aliases:
 - "/book/sr/v2/index.html"
+- "/book/sr/index.html"
 ---

--- a/external/book/content/book/sv/v2/_index.html
+++ b/external/book/content/book/sv/v2/_index.html
@@ -13,4 +13,5 @@ page_title: Git - Book
 url: "/book/sv/v2.html"
 aliases:
 - "/book/sv/v2/index.html"
+- "/book/sv/index.html"
 ---

--- a/external/book/content/book/tl/v2/_index.html
+++ b/external/book/content/book/tl/v2/_index.html
@@ -13,4 +13,5 @@ page_title: Git - Book
 url: "/book/tl/v2.html"
 aliases:
 - "/book/tl/v2/index.html"
+- "/book/tl/index.html"
 ---

--- a/external/book/content/book/tr/v2/_index.html
+++ b/external/book/content/book/tr/v2/_index.html
@@ -13,4 +13,5 @@ page_title: Git - Book
 url: "/book/tr/v2.html"
 aliases:
 - "/book/tr/v2/index.html"
+- "/book/tr/index.html"
 ---

--- a/external/book/content/book/uk/v2/_index.html
+++ b/external/book/content/book/uk/v2/_index.html
@@ -13,4 +13,5 @@ page_title: Git - Book
 url: "/book/uk/v2.html"
 aliases:
 - "/book/uk/v2/index.html"
+- "/book/uk/index.html"
 ---

--- a/external/book/content/book/uz/v2/_index.html
+++ b/external/book/content/book/uz/v2/_index.html
@@ -13,4 +13,5 @@ page_title: Git - Book
 url: "/book/uz/v2.html"
 aliases:
 - "/book/uz/v2/index.html"
+- "/book/uz/index.html"
 ---

--- a/external/book/content/book/zh-tw/v2/_index.html
+++ b/external/book/content/book/zh-tw/v2/_index.html
@@ -13,4 +13,5 @@ page_title: Git - Book
 url: "/book/zh-tw/v2.html"
 aliases:
 - "/book/zh-tw/v2/index.html"
+- "/book/zh-tw/index.html"
 ---

--- a/external/book/content/book/zh/v2/_index.html
+++ b/external/book/content/book/zh/v2/_index.html
@@ -13,4 +13,5 @@ page_title: Git - Book
 url: "/book/zh/v2.html"
 aliases:
 - "/book/zh/v2/index.html"
+- "/book/zh/index.html"
 ---

--- a/script/book.rb
+++ b/script/book.rb
@@ -130,7 +130,11 @@ class Book
     front_matter = self.front_matter
     front_matter["page_title"] = "Git - Book"
     front_matter["url"] = "/book/#{@language_code}/v#{@edition}.html"
-    front_matter["aliases"] = [ "/book/#{@language_code}/v#{@edition}/index.html" ]
+    front_matter["aliases"] = [
+      "/book/#{@language_code}/v#{@edition}/index.html",
+      "/book/#{@language_code}/index.html"
+    ]
+    front_matter["aliases"].push("/book/index.html") if @language_code == "en"
     front_matter["book"]["front_page"] = true
     front_matter["book"]["repository_url"] = "https://github.com/#{@@all_books[@language_code]}"
     front_matter["book"]["sha"] = self.sha

--- a/script/serve-public.js
+++ b/script/serve-public.js
@@ -25,7 +25,14 @@ const mimeTypes = {
 
 const handler = (request, response) => {
     const pathname = decodeURIComponent(url.parse(request.url).pathname);
-    let filename = path.join(basePath, pathname === "/" ? "index.html" : pathname);
+    let filename = path.join(
+        basePath,
+        pathname === "/"
+        ? "index.html"
+        : pathname.endsWith("/")
+          ? `${pathname}index.html`
+          : pathname
+    );
 
     let stats = fs.statSync(filename, { throwIfNoEntry: false });
     if (!stats?.isFile() && !filename.match(/\.[A-Za-z0-9]{1,11}$/)) {

--- a/tests/git-scm.spec.js
+++ b/tests/git-scm.spec.js
@@ -199,7 +199,11 @@ test('manual pages', async ({ page }) => {
 })
 
 test('book', async ({ page }) => {
+  await page.goto(`${url}book/`)
+  await expect(page).toHaveURL(`${url}book/en/v2`)
+
   await page.goto(`${url}book`)
+  await expect(page).toHaveURL(`${url}book/en/v2`)
 
   // Navigate to the first section
   await page.getByRole('link', { name: 'Getting Started' }).click()


### PR DESCRIPTION
## Changes

This makes the following URLs redirect to the respective book front pages:

- https://git-scm.com/book/ (note the trailing slash)
- https://git-scm.com/book/en/
- https://git-scm.com/book/az/
- (and the same for all the other languages, too)

## Context

By mistake, I typed in one of those URLs and was surprised to be redirected to the 404 page. Easy fix.