### PR TITLE
Fix: url with filters in gui client

### DIFF
--- a/assets/js/application.js
+++ b/assets/js/application.js
@@ -475,7 +475,7 @@ var Downloads = {
       if (window.history && window.history.pushState) {
         var url = os === ''
           ? `${baseURLPrefix}downloads/guis`
-          : `${baseURLPrefix}download/guis?os=${os}`;
+          : `${baseURLPrefix}downloads/guis?os=${os}`;
         try {
           history.pushState(null, $(this).html(), url);
         } catch (e) {

--- a/content/downloads/guis/_index.html
+++ b/content/downloads/guis/_index.html
@@ -5,6 +5,8 @@ title: "Git - GUI Clients"
 url: /downloads/guis.html
 aliases:
 - /downloads/guis/index.html
+- /download/guis/index.html
+- /download/guis.html
 ---
 
 <div id="main">

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -13,7 +13,7 @@
   <meta name="robots" content="noindex">
  </head>
  <body>
-  <script>window.location.replace(document.querySelector("link[rel='canonical']").href + window.location.hash)</script>
+  <script>window.location.replace(document.querySelector("link[rel='canonical']").href + window.location.search + window.location.hash)</script>
   <h1>Redirecting&hellip;</h1>
   <a href="{{ $redirect_to }}">Click here if you are not redirected.</a>
  </body>

--- a/layouts/alias.html
+++ b/layouts/alias.html
@@ -8,7 +8,7 @@
   <meta name="robots" content="noindex">
  </head>
  <body>
-  <script>window.location.replace(document.querySelector("link[rel='canonical']").href + window.location.hash)</script>
+  <script>window.location.replace(document.querySelector("link[rel='canonical']").href + window.location.search + window.location.hash)</script>
   <h1>Redirecting&hellip;</h1>
   <a href="{{ $redirect_to }}">Click here if you are not redirected.</a>
  </body>


### PR DESCRIPTION
Fix the url when the filters are selected, to one that exists

## Changes

<!-- List the changes this PR makes. -->

- Change the url to a correct one for when the filters are applied in https://git-scm.com/downloads/guis

## Context

<!-- Explain why you're making these changes. -->
Fix #1886