### PR TITLE
Fix sidebar button on iPhones

### DIFF
--- a/assets/sass/sidebar.scss
+++ b/assets/sass/sidebar.scss
@@ -47,7 +47,7 @@ aside.sidebar.active {
     background-color: $black-3 !important;
     display: block;
     position: fixed;
-    padding: 2rem 0.4rem;
+    padding: 2rem 0rem;
     z-index: 1;
     border: none;
     left: 0;

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -1,5 +1,5 @@
 {{ $section := .Scratch.Get "section" }}
-<button class="sidebar-btn"></button>
+<div tabindex="1" class="sidebar-btn"></div>
 <aside class="sidebar" id="sidebar">
   <nav>
     <ul>

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "This is the Git home page.",
   "license": "MIT",
   "devDependencies": {
-    "@playwright/test": "^1.47.0",
+    "@playwright/test": "^1.47.2",
     "@types/node": "^22.5.4"
   }
 }

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -57,6 +57,13 @@ module.exports = defineConfig({
       name: 'chrome',
       use: { ...devices['Desktop Chrome'], channel: 'chrome' },
     },
+    {
+      name: 'iPhone',
+      use: {
+        ...devices['iPhone 11'],
+      },
+    },
+
 
     /* Test against mobile viewports. */
     // {

--- a/tests/git-scm.spec.js
+++ b/tests/git-scm.spec.js
@@ -265,3 +265,19 @@ test('404', async ({ page }) => {
   // the usual navbar is shown
   await expect(page.getByRole('link', { name: 'Community' })).toBeVisible()
 })
+
+test('sidebar', async ({ page }) => {
+  await page.goto(`${url}community`);
+
+  test.skip(!await page.evaluate(() => matchMedia('(max-width: 940px)').matches),
+    'not a small screen');
+
+  const sidebarButton = page.locator('.sidebar-btn');
+  await expect(sidebarButton).toBeVisible();
+  await sidebarButton.click();
+
+  const about = page.getByRole('link', { name: 'About', exact: true });
+  await expect(about).toBeVisible();
+  await about.click();
+  await expect(page.getByRole('heading', { name: 'About - Branching and Merging' })).toBeVisible();
+});


### PR DESCRIPTION
## Changes

This makes the sidebar button work when browsing on iPhones.

## Context

On small screens, the navigation sidebar is hidden by default, and instead a button is displayed on the left side:

![image](https://github.com/user-attachments/assets/2ddfdb1e-cae2-41d7-b4bb-d5ab281f6093)

The idea is that the navigation sidebar is displayed when tapping that button. However, as @To1ne pointed out to me at GitMerge, tapping this sidebar button on iPhones does not do anything.

The reason is that Safari does not give focus to `<button>`s, and the sidebar button is a `<button>`.

With this PR, the button is a `<div>` with a tab index, and therefore can receive focus on iPhones. The result will now look like this:

![image](https://github.com/user-attachments/assets/d4bee739-fac3-4860-96ba-ba2d5c92cde5)

For good measure, I added a Playwright test; This test is not run in CI by default (to avoid the cost of downloading Webkit in every CI/PR build), but can at least be run manually.