### PR TITLE
playwright(book): let the tests pass on small screens

### DIFF
--- a/tests/git-scm.spec.js
+++ b/tests/git-scm.spec.js
@@ -228,6 +228,12 @@ test('book', async ({ page }) => {
   await expect(chaptersDropdown.locator('.active')).toHaveCount(1)
 
   // Navigate to the French translation
+  if (await page.evaluate(() => matchMedia('(max-width: 940px)').matches)) {
+    // On small screens, the links to the translated versions of the ProGit book
+    // are hidden by default, and have to be "un-hidden" by clicking on the
+    // sidebar button first.
+    await page.locator('.sidebar-btn').click();
+  }
   await page.getByRole('link', { name: 'Français' }).click()
   await expect(page).toHaveURL(/book\/fr/)
   await expect(page.getByRole('link', { name: 'Démarrage rapide' })).toBeVisible()


### PR DESCRIPTION
## Changes

This let's manual `npx playwright test` invocations pass again.

## Context

When attempting to verify that #1891's deployment indeed fixed the iPhone issues, I noticed that the Playwright tests were failing in a totally unexpected location: The assumptions in the `book` tests do not hold true for smaller screens. Easy fix.

Note: This was not caught by the CI runs because they only test with Chrome (to avoid hefty downloads of the Firefox, Chromium and Webkit browsers, only Chrome is tested because it comes pre-installed on GitHub's hosted Actions runners).