### PR TITLE
.github/workflows: purge Cloudflare cache on deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,3 +21,8 @@ jobs:
       - name: deploy to GitHub Pages
         id: deploy
         uses: ./.github/actions/deploy-to-github-pages
+      - name: Purge Cloudflare cache
+        uses: jakejarvis/cloudflare-purge-action@v0.3.0
+        env:
+          CLOUDFLARE_ZONE: ${{ secrets.CLOUDFLARE_ZONE }}
+          CLOUDFLARE_TOKEN: ${{ secrets.CLOUDFLARE_TOKEN }}


### PR DESCRIPTION
We use Cloudflare in front of the git-scm.com website in order to cache traffic that would otherwise be going directly to GitHub Pages. However, this cache needs to be purged whenever the actual site is updated, otherwise clients will have to wait out Cloudflare's and their own browser's cache TTL until they see the new content.

Usually this is just fine: for high priority deployments where the new content should be reflected immediately, someone can manually purge the cache by logging into Cloudflare and clicking on the "Purge everything" button.

But sometimes folks aren't around to log into Cloudflare, don't have permissions to, etc. Let's remove the need to have anyone log into Cloudflare and instead purge the cache on deployment so that the site is more up-to-date more quickly upon deployment.

(Note that this only purges the cache for git-scm.com, not git-scm.org. The former receives the vast majority of traffic, and when purging manually I almost always skipped git-scm.org without complaints. Let's avoid having two API keys and instead let git-scm.org lag slightly behind git-scm.com after a deployment).

To generate the API key, I logged into Cloudflare and created an API token[1] that has permissions limited to "Zone.Cache Purge" for all zones in the Git project's Cloudflare account. The token is stored as a repository secret[2].

[1]: https://developers.cloudflare.com/fundamentals/api/get-started/create-token/
[2]: https://docs.github.com/en/actions/security-for-github-actions/security-guides/using-secrets-in-github-actions

##

/cc @pedrorijo91 @dscho 