### PR TITLE
.github/workflows: don't clear Cloudflare cache unless configured

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,6 +22,9 @@ jobs:
         id: deploy
         uses: ./.github/actions/deploy-to-github-pages
       - name: Purge Cloudflare cache
+        env:
+          CLOUDFLARE_TOKEN: ${{ secrets.CLOUDFLARE_TOKEN }}
+        if: env.CLOUDFLARE_TOKEN != ''
         uses: jakejarvis/cloudflare-purge-action@v0.3.0
         env:
           CLOUDFLARE_ZONE: ${{ secrets.CLOUDFLARE_ZONE }}


### PR DESCRIPTION
The recent change in 0d22411a4 (.github/workflows: purge Cloudflare cache on deployment, 2024-10-01) will cause deployment workflows run in forks of git/git-scm.com to fail, since they will likely not have a Cloudflare token configured in their repository secrets.

Let's make use of a suggestion from Johannes[1] and only run this step when the repository is configured with a Cloudflare token.

Note that we can't directly write:

    if: ${{ secrets.CLOUDFLARE_TOKEN != '' }}

, because repository secrets cannot be used in job step-level conditionals[2]. Instead, the GitHub Actions documentation recommends setting the secret as an environment variable, and then using the presence (or absence) of that environment variable's contents as a proxy to determine whether or not the secret is set.

All together, this should un-break deployment workflows in forks of git/git-scm.com for repositories that have not set up a Cloudflare token.

[1]: https://github.com/git/git-scm.com/pull/1893#pullrequestreview-2343346677
[2]: https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#example-using-secrets

Suggested-by: Johannes Schindelin <Johannes.Schindelin@gmx.de>

##

/cc @dscho 