### PR TITLE
.github/actions/deploy-to-github-pages: use Cloudflare API directly

### DIFF
--- a/.github/actions/deploy-to-github-pages/action.yml
+++ b/.github/actions/deploy-to-github-pages/action.yml
@@ -14,6 +14,12 @@ inputs:
     description: The GitHub token used to create an authenticated client
     default: ${{ github.token }}
     required: true
+  cloudflare-token:
+    description: The Cloudflare API token used to purge Cloudflare caches.
+    required: false
+  cloudflare-zone:
+    description: The Cloudflare zone to purge.
+    required: false
 outputs:
   url:
     description: The URL to which the site was deployed
@@ -86,6 +92,19 @@ runs:
     - name: deploy
       id: deploy
       uses: actions/deploy-pages@v4
+
+    - name: Purge Cloudflare cache
+      id: cloudflare
+      shell: bash
+      env:
+        CLOUDFLARE_ZONE: ${{ inputs.cloudflare-zone }}
+        CLOUDFLARE_TOKEN: ${{ inputs.cloudflare-token }}
+      if: env.CLOUDFLARE_TOKEN != ''
+      run: |
+        curl "https://api.cloudflare.com/client/v4/zones/$CLOUDFLARE_ZONE/purge_cache" \
+          -H "Authorization: Bearer $CLOUDFLARE_TOKEN" \
+          -H "Content-Type: application/json" \
+          -d '{ "purge_everything": true }'
 
     - name: construct `--remap` option for lychee
       id: remap

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,9 +21,6 @@ jobs:
       - name: deploy to GitHub Pages
         id: deploy
         uses: ./.github/actions/deploy-to-github-pages
-      - name: Purge Cloudflare cache
-        env:
-          CLOUDFLARE_ZONE: ${{ secrets.CLOUDFLARE_ZONE }}
-          CLOUDFLARE_TOKEN: ${{ secrets.CLOUDFLARE_TOKEN }}
-        if: env.CLOUDFLARE_TOKEN != ''
-        uses: jakejarvis/cloudflare-purge-action@v0.3.0
+        with:
+          cloudflare-token: ${{ secrets.CLOUDFLARE_TOKEN }}
+          cloudflare-zone: ${{ secrets.CLOUDFLARE_ZONE }}

--- a/.github/workflows/update-book.yml
+++ b/.github/workflows/update-book.yml
@@ -133,3 +133,6 @@ jobs:
       - name: deploy to GitHub Pages
         id: deploy
         uses: ./.github/actions/deploy-to-github-pages
+        with:
+          cloudflare-token: ${{ secrets.CLOUDFLARE_TOKEN }}
+          cloudflare-zone: ${{ secrets.CLOUDFLARE_ZONE }}

--- a/.github/workflows/update-download-data.yml
+++ b/.github/workflows/update-download-data.yml
@@ -70,3 +70,6 @@ jobs:
         if: steps.commit.outputs.result != ''
         id: deploy
         uses: ./.github/actions/deploy-to-github-pages
+        with:
+          cloudflare-token: ${{ secrets.CLOUDFLARE_TOKEN }}
+          cloudflare-zone: ${{ secrets.CLOUDFLARE_ZONE }}

--- a/.github/workflows/update-git-version-and-manual-pages.yml
+++ b/.github/workflows/update-git-version-and-manual-pages.yml
@@ -103,3 +103,6 @@ jobs:
         if: steps.commit.outputs.result != '' || steps.manual-pages.outputs.result != ''
         id: deploy
         uses: ./.github/actions/deploy-to-github-pages
+        with:
+          cloudflare-token: ${{ secrets.CLOUDFLARE_TOKEN }}
+          cloudflare-zone: ${{ secrets.CLOUDFLARE_ZONE }}

--- a/.github/workflows/update-translated-manual-pages.yml
+++ b/.github/workflows/update-translated-manual-pages.yml
@@ -89,3 +89,6 @@ jobs:
         if: steps.manual-pages.outputs.result != ''
         id: deploy
         uses: ./.github/actions/deploy-to-github-pages
+        with:
+          cloudflare-token: ${{ secrets.CLOUDFLARE_TOKEN }}
+          cloudflare-zone: ${{ secrets.CLOUDFLARE_ZONE }}


### PR DESCRIPTION
As pointed out in \[1\], using the cloudflare-purge-action incurs a ~31 second penalty at the start of the "deploy" action, where time is spent building a Docker container to run the action.

This is unnecessary, since Cloudflare has a straightforward REST API that we can use cURL to communicate with directly, without the extra start-up cost.

Let's do that instead, and move this to run in the deploy-to-github-pages action, which is run from multiple entry points, all of which will want to purge the Cloudflare caches upon deployment.

\[1\]: https://github.com/git/git-scm.com/pull/1893#issuecomment-2392975994

##

/cc @dscho 