### PR TITLE
Add OpenIndiana download

### DIFF
--- a/content/downloads/linux.html
+++ b/content/downloads/linux.html
@@ -45,7 +45,7 @@ aliases:
   <h3>Solaris 9/10/11 (<a href="https://www.opencsw.org">OpenCSW</a>)</h3>
   <code># pkgutil -i git</code>
 
-  <h3>Solaris 11 Express</h3>
+  <h3>Solaris 11 Express, OpenIndiana</h3>
   <code># pkg install developer/versioning/git</code>
 
   <h3>OpenBSD</h3>


### PR DESCRIPTION
## Changes

Add OpenIndiana to the download page.

## Context

<!-- Explain why you're making these changes. -->
The install steps for OpenIndiana are missing.  Since they are same as for Solaris 11 (Express), then it is easy to add OpenIndiana there too.