### PR TITLE
tests/git-scm.spec.js: loosen book redirect assertions

### DIFF
--- a/tests/git-scm.spec.js
+++ b/tests/git-scm.spec.js
@@ -200,10 +200,10 @@ test('manual pages', async ({ page }) => {
 
 test('book', async ({ page }) => {
   await page.goto(`${url}book/`)
-  await expect(page).toHaveURL(`${url}book/en/v2`)
+  await expect(page).toHaveURL(/book\/en\/v2/)
 
   await page.goto(`${url}book`)
-  await expect(page).toHaveURL(`${url}book/en/v2`)
+  await expect(page).toHaveURL(/book\/en\/v2/)
 
   // the repository URL is correct
   await expect(page.getByRole('link', { name: 'hosted on GitHub' }))


### PR DESCRIPTION
In 8781699e9 (tests: verify that the book URL redirects work, 2024-09-26), there were a couple of assertions that were added to the Playwright test suite that look like the following:

    await page.goto(`${url}book/`)
    await expect(page).toHaveURL(`${url}book/en/v2`)

Or, in other words, expecting that going to the `/book` path relative to the site's base URL would result in a redirect to `/book/env/v2`.

But this test breaks when the hosted site is configured to redirect HTTP requests to HTTPS ones, like in this\[1\] example.

Loosen this assertion to just assert on the path component of the URL in an identical fashion to other similar assertions in this test. Note that a 'git grep toHaveURL' on the pre-image of this patch yields all but two assertions which only look at the path component. The two that don't are the ones which we modify here.

This should allow us to successfully run the Playwright tests in forks whose deployment configuration is similar to the above.

\[1\]: https://github.com/ttaylorr/git-scm.com/actions/runs/11185173194/artifacts/2017238933

##

/cc @dscho 