### PR TITLE
deploy(playwright): work around externally-enforced HTTPS

### DIFF
--- a/.github/actions/deploy-to-github-pages/action.yml
+++ b/.github/actions/deploy-to-github-pages/action.yml
@@ -194,7 +194,10 @@ runs:
       shell: bash
       env:
         PLAYWRIGHT_TEST_URL: ${{ steps.pages.outputs.base_url }}
-      run: npx playwright test --project=chrome
+      run: |
+        # avoid test failures when HTTPS is enforced half-way through
+        PLAYWRIGHT_TEST_URL="$(echo "$PLAYWRIGHT_TEST_URL" | sed 's/^http:/https:/')" &&
+        npx playwright test --project=chrome
     - uses: actions/upload-artifact@v4
       if: always()
       with:


### PR DESCRIPTION
## Changes

Runs the Playwright tests using the https:// URL, always, even if http:// would be possible.

## Context

It is possible to enforce HTTPS on GitHub Pages, via https://docs.github.com/en/pages/getting-started-with-github-pages/securing-your-github-pages-site-with-https#enforcing-https-for-your-github-pages-site

Without this flag enabled, it is still possible to access the site via http:// URLs, otherwise such URLs will automatically redirect to https:// URLs.

However, it is also possible to enforce HTTPS e.g. by using a custom domain and putting Cloudflare in front of GitHub Pages.

The Playwright tests, which are designed to catch undesired redirects that may, say, drop the `/git-scm.com/` part of the URLs in forks by mistake, are currently not expecting this.

Since GitHub Pages supports HTTPS in all cases, and there are no options anywhere to enforce HTTP instead of HTTPS, let's just test with the https:// URL even if no enforcement was configured.

This supersedes #1898.