### PR TITLE
Upgrade lychee

### DIFF
--- a/.github/actions/deploy-to-github-pages/action.yml
+++ b/.github/actions/deploy-to-github-pages/action.yml
@@ -144,6 +144,7 @@ runs:
         failIfEmpty: false # needed because its default overrides `fail = false`
 
     - name: ${{ env.lychee_exit_code != '0' && 'maybe close' || 'open or update' }} link checker issue
+      if: env.lychee_exit_code != ''
       uses: actions/github-script@v7
       with:
         github-token: ${{ inputs.github-token }}

--- a/.github/actions/deploy-to-github-pages/action.yml
+++ b/.github/actions/deploy-to-github-pages/action.yml
@@ -143,7 +143,7 @@ runs:
         fail: false
         failIfEmpty: false # needed because its default overrides `fail = false`
 
-    - name: ${{ env.lychee_exit_code != '0' && 'maybe close' || 'open or update' }} link checker issue
+    - name: ${{ env.lychee_exit_code != '0' && 'open or update' || 'maybe close' }} link checker issue
       if: env.lychee_exit_code != ''
       uses: actions/github-script@v7
       with:

--- a/.github/actions/deploy-to-github-pages/action.yml
+++ b/.github/actions/deploy-to-github-pages/action.yml
@@ -198,6 +198,7 @@ runs:
       run: sudo sh -c 'echo "185.199.108.153 git-scm.com" >>/etc/hosts'
     - name: Run Playwright tests
       shell: bash
+      id: playwright
       env:
         PLAYWRIGHT_TEST_URL: ${{ steps.pages.outputs.base_url }}
       run: |
@@ -206,9 +207,10 @@ runs:
         https://*|http://git-scm.com) ;; # okay, leave as-is
         http://*) PLAYWRIGHT_TEST_URL="https://${PLAYWRIGHT_TEST_URL#http://}";;
         esac &&
+        echo "result=$PLAYWRIGHT_TEST_URL" >>$GITHUB_OUTPUT &&
         npx playwright test --project=chrome
     - uses: actions/upload-artifact@v4
-      if: always()
+      if: always() && steps.playwright.outputs.result != ''
       with:
         name: playwright-report
         path: playwright-report/

--- a/.github/actions/deploy-to-github-pages/action.yml
+++ b/.github/actions/deploy-to-github-pages/action.yml
@@ -122,9 +122,8 @@ runs:
 
     - name: check for broken links
       id: lychee
-      uses: lycheeverse/lychee-action@d4128702eae98bbc5ecf74df0165a8156c80920a # until an official version is out that includes https://github.com/lycheeverse/lychee/pull/1422
+      uses: lycheeverse/lychee-action@v2
       with:
-        lycheeVersion: nightly # until an official version includes https://github.com/lycheeverse/lychee/pull/1422
         args: >-
           --offline
           --fallback-extensions html

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,11 +79,14 @@ jobs:
     - name: Install @playwright/test
       run: npm install @playwright/test
     - name: Run Playwright tests
+      id: playwright
       env:
         PLAYWRIGHT_TEST_URL: http://localhost:5000/
-      run: npx playwright test --project=chrome
+      run: |
+        echo "result=$PLAYWRIGHT_TEST_URL" >>$GITHUB_OUTPUT &&
+        npx playwright test --project=chrome
     - uses: actions/upload-artifact@v4
-      if: always()
+      if: always() && steps.playwright.outputs.result != ''
       with:
         name: playwright-report
         path: playwright-report/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,9 +60,8 @@ jobs:
 
     - name: check for broken links
       id: lychee
-      uses: lycheeverse/lychee-action@d4128702eae98bbc5ecf74df0165a8156c80920a # until an official version is out that includes https://github.com/lycheeverse/lychee/pull/1422
+      uses: lycheeverse/lychee-action@v2
       with:
-        lycheeVersion: nightly # until an official version includes https://github.com/lycheeverse/lychee/pull/1422
         args: >-
           --offline
           --fallback-extensions html


### PR DESCRIPTION
## Changes

This upgrades from a nightly version of lychee, the link checker, to the latest version.

## Context

To make use of lychee, we needed to first contribute a change where it can imitate the logic of GitHub Pages where URLs do not need to contain the `.html` extension but will still resolve to the correct page.

For a long time, this feature was only available in the nightly version of lychee. As of 3 days ago, there is now a stable release of lychee that includes this feature. As of yesterday, the lychee project provides  a version of the corresponding GitHub Action that uses that lychee version by default. So let's upgrade.

While at it, touch up the logic around the lychee steps some.