### PR TITLE
Prevent concurrent deployments

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,9 @@ on:
 
 jobs:
   deploy:
+    concurrency:
+      group: "pages"
+      cancel-in-progress: false
     runs-on: ubuntu-latest
     permissions:
       pages: write # to deploy to GitHub Pages

--- a/.github/workflows/update-book.yml
+++ b/.github/workflows/update-book.yml
@@ -104,6 +104,9 @@ jobs:
           name: bundle-${{ matrix.language.lang }}
           path: ${{ matrix.language.lang }}.bundle
   push-updates:
+    concurrency:
+      group: "pages"
+      cancel-in-progress: false
     needs: [check-for-updates, update-book]
     if: needs.check-for-updates.outputs.matrix != '[""]'
     permissions:

--- a/.github/workflows/update-download-data.yml
+++ b/.github/workflows/update-download-data.yml
@@ -8,6 +8,9 @@ on:
 
 jobs:
   update-download-data:
+    concurrency:
+      group: "pages"
+      cancel-in-progress: false
     if: github.event.repository.fork == false || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/update-git-version-and-manual-pages.yml
+++ b/.github/workflows/update-git-version-and-manual-pages.yml
@@ -13,6 +13,9 @@ on:
 
 jobs:
   update-git-version-and-manual-pages:
+    concurrency:
+      group: "pages"
+      cancel-in-progress: false
     if: github.event.repository.fork == false || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/update-translated-manual-pages.yml
+++ b/.github/workflows/update-translated-manual-pages.yml
@@ -13,6 +13,9 @@ on:
 
 jobs:
   check-for-updates:
+    concurrency:
+      group: "pages"
+      cancel-in-progress: false
     if: github.event.repository.fork == false || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Changes

Let's avoid having multiple deployment runs stumble over each other's toes.

## Context

GitHub Pages' sites are singletons and therefore we should use the recommended pattern to prevent multiple deployments to run at the same time; Instead, we want to queue them all up.

Otherwise the same might happen as in [this deployment](https://github.com/git/git-scm.com/actions/runs/11055176144), which was triggered by merging a PR while the previous deployment (triggered by merging another PR) was still running:

> ⨂ **deploy**
> &nbsp;&nbsp;&nbsp;HttpError: Deployment request failed for ca3b63f4c72cf73db893bebaa1e546501971ea8a due to in progress deployment. Please cancel 5b1041af975c9689b55feb14f40d5b2c1cd37ae9 first or wait for it to complete.
> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;at /home/runner/work/_actions/actions/deploy-pages/v4/node_modules/@octokit/request/dist-node/index.js:124:1
> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;at processTicksAndRejections (node:internal/process/task_queues:95:5)
> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;at createPagesDeployment (/home/runner/work/_actions/actions/deploy-pages/v4/src/internal/api-client.js:125:1)
> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;at Deployment.create (/home/runner/work/_actions/actions/deploy-pages/v4/src/internal/deployment.js:74:1)
> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;at main (/home/runner/work/_actions/actions/deploy-pages/v4/src/index.js:30:1)</div>
>
> ⨂ **deploy**
> &nbsp;&nbsp;&nbsp;Error: Failed to create deployment (status: 400) with build version ca3b63f4c72cf73db893bebaa1e546501971ea8a. Request ID 2460:3B264E:2D28F10:5686FAF:66F57B0B Responded with: Deployment request failed for ca3b63f4c72cf73db893bebaa1e546501971ea8a due to in progress deployment. Please cancel 5b1041af975c9689b55feb14f40d5b2c1cd37ae9 first or wait for it to complete.