### PR TITLE
small-and-fast: make bar-graph table responsive

### DIFF
--- a/assets/sass/about.scss
+++ b/assets/sass/about.scss
@@ -1,3 +1,14 @@
+.bar-chart-grid {
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+}
+
+@media (max-width: 760px) {
+  .bar-chart-grid {
+    grid-template-columns: repeat(auto-fill, minmax(115px, 1fr));
+  }
+}
+
 .bar-chart {
   display: inline-grid;
 

--- a/assets/sass/about.scss
+++ b/assets/sass/about.scss
@@ -1,0 +1,60 @@
+.bar-chart {
+  display: inline-grid;
+
+  /* Got the idea of using <dl>, <dt>, and <dd> from:
+   * https://css-tricks.com/making-charts-with-css/ */
+  dt {
+    grid-column: 1 / 4;
+    text-align: center;
+  }
+
+  dd {
+    padding: 5px;
+    margin: 0;
+    text-align: center;
+    display: flex;
+    flex-direction: column;
+  }
+
+  dd + dd {
+    border-left: 1px solid #ccc;
+  }
+
+  progress {
+  /* Reset the default appearance */
+  -webkit-appearance: none;
+     -moz-appearance: none;
+          appearance: none;
+
+    writing-mode: vertical-lr;
+
+    width: 2em;
+    height: 5em;
+    background: none;
+    border: none;
+    position: relative;
+  }
+
+  progress::-webkit-progress-bar {
+    background: none;
+  }
+
+  progress::-webkit-progress-value {
+    /* Chrome (and derivatives) are stubborn to attach the bar to the top */
+    bottom: 0;
+    position: absolute;
+  }
+
+  progress.git::-moz-progress-bar {
+    background-color: #E09FA0;
+  }
+  progress.git::-webkit-progress-value {
+    background-color: #E09FA0;
+  }
+  progress.svn::-moz-progress-bar {
+    background-color: #E05F49;
+  }
+  progress.svn::-webkit-progress-value {
+    background-color: #E05F49;
+  }
+}

--- a/assets/sass/application.scss
+++ b/assets/sass/application.scss
@@ -26,6 +26,7 @@ $baseurl: "{{ .Site.BaseURL }}{{ if (and (ne .Site.BaseURL "/") (ne .Site.BaseUR
 @import 'book';
 @import 'book2';
 @import 'lists';
+@import 'about';
 
 code {
   display: inline;
@@ -48,65 +49,4 @@ pre {
 
 .d-flex{
   display: flex;
-}
-
-.bar-chart {
-  display: inline-grid;
-
-  /* Got the idea of using <dl>, <dt>, and <dd> from:
-   * https://css-tricks.com/making-charts-with-css/ */
-  dt {
-    grid-column: 1 / 4;
-    text-align: center;
-  }
-
-  dd {
-    padding: 5px;
-    margin: 0;
-    text-align: center;
-    display: flex;
-    flex-direction: column;
-  }
-
-  dd + dd {
-    border-left: 1px solid #ccc;
-  }
-
-  progress {
-  /* Reset the default appearance */
-  -webkit-appearance: none;
-     -moz-appearance: none;
-          appearance: none;
-
-    writing-mode: vertical-lr;
-
-    width: 2em;
-    height: 5em;
-    background: none;
-    border: none;
-    position: relative;
-  }
-
-  progress::-webkit-progress-bar {
-    background: none;
-  }
-
-  progress::-webkit-progress-value {
-    /* Chrome (and derivatives) are stubborn to attach the bar to the top */
-    bottom: 0;
-    position: absolute;
-  }
-
-  progress.git::-moz-progress-bar {
-    background-color: #E09FA0;
-  }
-  progress.git::-webkit-progress-value {
-    background-color: #E09FA0;
-  }
-  progress.svn::-moz-progress-bar {
-    background-color: #E05F49;
-  }
-  progress.svn::-webkit-progress-value {
-    background-color: #E05F49;
-  }
 }

--- a/content/about/small-and-fast.html
+++ b/content/about/small-and-fast.html
@@ -27,173 +27,167 @@ aliases:
       to CVS or Perforce. <em>Smaller is faster.</em>
     </p>
 
-    <table width="100%">
-      <tbody>
-        <tr>
-          <td>
-            <dl class="bar-chart">
-              <dt>Commit A</dt>
-              <dd>
-                <progress value="0.649" max="3" class="git"></progress>
-                <span>git</span>
-              </dd>
-              <dd>
-                <progress value="2.6" max="3" class="svn"></progress>
-                <span>svn</span>
-              </dd>
-            </dl>
-          </td>
-          <td>
-            <dl class="bar-chart">
-              <dt>Commit B</dt>
-              <dd>
-                <progress value="1.53" max="25" class="git"></progress>
-                <span>git</span>
-              </dd>
-              <dd>
-                <progress value="24.7" max="25" class="svn"></progress>
-                <span>svn</span>
-              </dd>
-            </dl>
-          </td>
-          <td>
-            <dl class="bar-chart">
-              <dt>Diff Curr</dt>
-              <dd>
-                <progress value="0.257" max="1.2" class="git"></progress>
-                <span>git</span>
-              </dd>
-              <dd>
-                <progress value="1.09" max="1.2" class="svn"></progress>
-                <span>svn</span>
-              </dd>
-            </dl>
-          </td>
-          <td>
-            <dl class="bar-chart">
-              <dt>Diff Rec</dt>
-              <dd>
-                <progress value="0.248" max="4" class="git"></progress>
-                <span>git</span>
-              </dd>
-              <dd>
-                <progress value="3.99" max="4" class="svn"></progress>
-                <span>svn</span>
-              </dd>
-            </dl>
-          </td>
-          <td>
-            <dl class="bar-chart">
-              <dt>Diff Tags</dt>
-              <dd>
-                <progress value="1.17" max="85" class="git"></progress>
-                <span>git</span>
-              </dd>
-              <dd>
-                <progress value="83.57" max="85" class="svn"></progress>
-                <span>svn</span>
-              </dd>
-            </dl>
-          </td>
-          <td>
-            <dl class="bar-chart">
-              <dt>Clone</dt>
-              <dd>
-                <progress value="21.0" max="110" class="git"></progress>
-                <span>git*</span>
-              </dd>
-              <dd>
-                <progress value="107.5" max="110" class="git"></progress>
-                <span>git</span>
-              </dd>
-              <dd>
-                <progress value="14.0" max="110" class="svn"></progress>
-              </dd>
-            </dl>
-          </td>
-        </tr>
-        <tr>
-          <td>
-            <dl class="bar-chart">
-              <dt>Log (50)</dt>
-              <dd>
-                <progress value="0.012" max="0.4" class="git"></progress>
-                <span>git</span>
-              </dd>
-              <dd>
-                <progress value="0.381" max="0.4" class="svn"></progress>
-                <span>svn</span>
-              </dd>
-            </dl>
-          </td>
-          <td>
-            <dl class="bar-chart">
-              <dt>Log (All)</dt>
-              <dd>
-                <progress value="0.519" max="170" class="git"></progress>
-                <span>git</span>
-              </dd>
-              <dd>
-                <progress value="169.197" max="170" class="svn"></progress>
-                <span>svn</span>
-              </dd>
-            </dl>
-          </td>
-          <td>
-            <dl class="bar-chart">
-              <dt>Log (File)</dt>
-              <dd>
-                <progress value="0.601" max="83" class="git"></progress>
-                <span>git</span>
-              </dd>
-              <dd>
-                <progress value="82.843" max="83" class="svn"></progress>
-                <span>svn</span>
-              </dd>
-            </dl>
-          </td>
-          <td>
-            <dl class="bar-chart">
-              <dt>Update</dt>
-              <dd>
-                <progress value="0.896" max="2.9" class="git"></progress>
-                <span>git</span>
-              </dd>
-              <dd>
-                <progress value="2.816" max="2.9" class="svn"></progress>
-                <span>svn</span>
-              </dd>
-            </dl>
-          </td>
-          <td>
-            <dl class="bar-chart">
-              <dt>Blame</dt>
-              <dd>
-                <progress value="1.91" max="3.1" class="git"></progress>
-                <span>git</span>
-              </dd>
-              <dd>
-                <progress value="3.04" max="3.1" class="svn"></progress>
-                <span>svn</span>
-              </dd>
-            </dl>
-          </td>
-          <td>
-            <dl class="bar-chart">
-              <dt>Size</dt>
-              <dd>
-                <progress value="181" max="182" class="git"></progress>
-                <span>git</span>
-              </dd>
-              <dd>
-                <progress value="132" max="182" class="svn"></progress>
-                <span>svn</span>
-              </dd>
-            </dl>
-          </td>
-        </tr>
-      </tbody>
-    </table>
+    <div class="bar-chart-grid">
+      <div>
+        <dl class="bar-chart">
+          <dt>Commit A</dt>
+          <dd>
+            <progress value="0.649" max="3" class="git"></progress>
+            <span>git</span>
+          </dd>
+          <dd>
+            <progress value="2.6" max="3" class="svn"></progress>
+            <span>svn</span>
+          </dd>
+        </dl>
+      </div>
+      <div>
+        <dl class="bar-chart">
+          <dt>Commit B</dt>
+          <dd>
+            <progress value="1.53" max="25" class="git"></progress>
+            <span>git</span>
+          </dd>
+          <dd>
+            <progress value="24.7" max="25" class="svn"></progress>
+            <span>svn</span>
+          </dd>
+        </dl>
+      </div>
+      <div>
+        <dl class="bar-chart">
+          <dt>Diff Curr</dt>
+          <dd>
+            <progress value="0.257" max="1.2" class="git"></progress>
+            <span>git</span>
+          </dd>
+          <dd>
+            <progress value="1.09" max="1.2" class="svn"></progress>
+            <span>svn</span>
+          </dd>
+        </dl>
+      </div>
+      <div>
+        <dl class="bar-chart">
+          <dt>Diff Rec</dt>
+          <dd>
+            <progress value="0.248" max="4" class="git"></progress>
+            <span>git</span>
+          </dd>
+          <dd>
+            <progress value="3.99" max="4" class="svn"></progress>
+            <span>svn</span>
+          </dd>
+        </dl>
+      </div>
+      <div>
+        <dl class="bar-chart">
+          <dt>Diff Tags</dt>
+          <dd>
+            <progress value="1.17" max="85" class="git"></progress>
+            <span>git</span>
+          </dd>
+          <dd>
+            <progress value="83.57" max="85" class="svn"></progress>
+            <span>svn</span>
+          </dd>
+        </dl>
+      </div>
+      <div>
+        <dl class="bar-chart">
+          <dt>Clone</dt>
+          <dd>
+            <progress value="21.0" max="110" class="git"></progress>
+            <span>git*</span>
+          </dd>
+          <dd>
+            <progress value="107.5" max="110" class="git"></progress>
+            <span>git</span>
+          </dd>
+          <dd>
+            <progress value="14.0" max="110" class="svn"></progress>
+          </dd>
+        </dl>
+      </div>
+      <div>
+        <dl class="bar-chart">
+          <dt>Log (50)</dt>
+          <dd>
+            <progress value="0.012" max="0.4" class="git"></progress>
+            <span>git</span>
+          </dd>
+          <dd>
+            <progress value="0.381" max="0.4" class="svn"></progress>
+            <span>svn</span>
+          </dd>
+        </dl>
+      </div>
+      <div>
+        <dl class="bar-chart">
+          <dt>Log (All)</dt>
+          <dd>
+            <progress value="0.519" max="170" class="git"></progress>
+            <span>git</span>
+          </dd>
+          <dd>
+            <progress value="169.197" max="170" class="svn"></progress>
+            <span>svn</span>
+          </dd>
+        </dl>
+      </div>
+      <div>
+        <dl class="bar-chart">
+          <dt>Log (File)</dt>
+          <dd>
+            <progress value="0.601" max="83" class="git"></progress>
+            <span>git</span>
+          </dd>
+          <dd>
+            <progress value="82.843" max="83" class="svn"></progress>
+            <span>svn</span>
+          </dd>
+        </dl>
+      </div>
+      <div>
+        <dl class="bar-chart">
+          <dt>Update</dt>
+          <dd>
+            <progress value="0.896" max="2.9" class="git"></progress>
+            <span>git</span>
+          </dd>
+          <dd>
+            <progress value="2.816" max="2.9" class="svn"></progress>
+            <span>svn</span>
+          </dd>
+        </dl>
+      </div>
+      <div>
+        <dl class="bar-chart">
+          <dt>Blame</dt>
+          <dd>
+            <progress value="1.91" max="3.1" class="git"></progress>
+            <span>git</span>
+          </dd>
+          <dd>
+            <progress value="3.04" max="3.1" class="svn"></progress>
+            <span>svn</span>
+          </dd>
+        </dl>
+      </div>
+      <div>
+        <dl class="bar-chart">
+          <dt>Size</dt>
+          <dd>
+            <progress value="181" max="182" class="git"></progress>
+            <span>git</span>
+          </dd>
+          <dd>
+            <progress value="132" max="182" class="svn"></progress>
+            <span>svn</span>
+          </dd>
+        </dl>
+      </div>
+    </div>
 
     <p>
       For testing, large AWS instances were set up in the same availability zone.

--- a/tests/git-scm.spec.js
+++ b/tests/git-scm.spec.js
@@ -1,4 +1,4 @@
-const { test, expect, selectors } = require('@playwright/test')
+const { test, expect, selectors, devices } = require('@playwright/test')
 
 const url = process.env.PLAYWRIGHT_TEST_URL
   ? process.env.PLAYWRIGHT_TEST_URL.replace(/[^/]$/, '$&/')
@@ -287,4 +287,16 @@ test('sidebar', async ({ page }) => {
   await expect(about).toBeVisible();
   await about.click();
   await expect(page.getByRole('heading', { name: 'About - Branching and Merging' })).toBeVisible();
+});
+
+test('small-and-fast', async ({ page }) => {
+  await page.setViewportSize(devices['iPhone X'].viewport);
+
+  await page.goto(`${url}about/small-and-fast`);
+
+  // Scroll to text right below the graphs
+  await page.getByText('For testing, large AWS instances').scrollIntoViewIfNeeded();
+
+  const lastGraph = page.locator('.bar-chart').last();
+  await expect(lastGraph).toBeInViewport();
 });


### PR DESCRIPTION
The bar charts are shown in a table. This doesn't work well when viewed
on mobile, because the screen is a lot narrower than the content.

Use CSS grid to responsively show bar charts on a single line depending
on the available horizontal space.

### Screenshots

Screen width: 1200px

![Screen Shot 2024-10-16 at 16 13 18](https://github.com/user-attachments/assets/89d23d9f-1a9d-470e-952f-c5d7b0881a1f)

---

Screen width: 939px (just below 940px breakproint where sidebar is hidden)

![Screen Shot 2024-10-16 at 16 17 15](https://github.com/user-attachments/assets/536a13bc-96e5-43f8-84af-e3af47b1caa5)

---

Screen width: 877px

![Screen Shot 2024-10-16 at 16 17 48](https://github.com/user-attachments/assets/3f6ade8e-5ef3-4216-80ea-84456e4f4dc9)

---

Screen width: 876px

![Screen Shot 2024-10-16 at 16 18 32](https://github.com/user-attachments/assets/604682e5-5a29-4b31-8d35-d20284ed5c60)

--- 

Screen width: 762px

![Screen Shot 2024-10-16 at 16 19 04](https://github.com/user-attachments/assets/35e77494-63c2-4a33-8e9f-1076b4d1f4e6)

---

Screen width: 761px

![Screen Shot 2024-10-16 at 16 20 02](https://github.com/user-attachments/assets/71a65418-4c05-4fb6-a180-bd5da24142ca)


---

Screen width: 647px

![Screen Shot 2024-10-16 at 16 20 49](https://github.com/user-attachments/assets/41e43d8b-007c-4d30-8596-9684972462a4)

--- 

Screen width: 600px

![Screen Shot 2024-10-16 at 16 21 27](https://github.com/user-attachments/assets/ca89d5ec-968f-4bdd-87c9-1a76040cb5b2)

---

Screen width: 375px (iPhone 13mini according to web inspector)

![Screen Shot 2024-10-16 at 16 22 02](https://github.com/user-attachments/assets/8607413b-764d-449b-92ad-a331e6146b1d)




