### PR TITLE
update-download-data: accommodate for Git for Windows' four-part version format

### DIFF
--- a/hugo.yml
+++ b/hugo.yml
@@ -43,22 +43,22 @@ params:
     filename: git-2.33.0-intel-universal-mavericks.dmg
   windows_installer:
     portable32:
-      filename: PortableGit-2.47.0-32-bit.7z.exe
-      release_date: '2024-10-08'
-      version: 2.47.0
-      url: https://github.com/git-for-windows/git/releases/download/v2.47.0.windows.1/PortableGit-2.47.0-32-bit.7z.exe
+      filename: PortableGit-2.47.0.2-32-bit.7z.exe
+      release_date: '2024-10-22'
+      version: 2.47.0(2)
+      url: https://github.com/git-for-windows/git/releases/download/v2.47.0.windows.2/PortableGit-2.47.0.2-32-bit.7z.exe
     portable64:
-      filename: PortableGit-2.47.0-64-bit.7z.exe
-      release_date: '2024-10-08'
-      version: 2.47.0
-      url: https://github.com/git-for-windows/git/releases/download/v2.47.0.windows.1/PortableGit-2.47.0-64-bit.7z.exe
+      filename: PortableGit-2.47.0.2-64-bit.7z.exe
+      release_date: '2024-10-22'
+      version: 2.47.0(2)
+      url: https://github.com/git-for-windows/git/releases/download/v2.47.0.windows.2/PortableGit-2.47.0.2-64-bit.7z.exe
     installer32:
-      filename: Git-2.47.0-32-bit.exe
-      release_date: '2024-10-08'
-      version: 2.47.0
-      url: https://github.com/git-for-windows/git/releases/download/v2.47.0.windows.1/Git-2.47.0-32-bit.exe
+      filename: Git-2.47.0.2-32-bit.exe
+      release_date: '2024-10-22'
+      version: 2.47.0(2)
+      url: https://github.com/git-for-windows/git/releases/download/v2.47.0.windows.2/Git-2.47.0.2-32-bit.exe
     installer64:
-      filename: Git-2.47.0-64-bit.exe
-      release_date: '2024-10-08'
-      version: 2.47.0
-      url: https://github.com/git-for-windows/git/releases/download/v2.47.0.windows.1/Git-2.47.0-64-bit.exe
+      filename: Git-2.47.0.2-64-bit.exe
+      release_date: '2024-10-22'
+      version: 2.47.0(2)
+      url: https://github.com/git-for-windows/git/releases/download/v2.47.0.windows.2/Git-2.47.0.2-64-bit.exe

--- a/script/update-download-data.rb
+++ b/script/update-download-data.rb
@@ -35,8 +35,10 @@ class DownloadData
         bitness  = match[3]
 
         # Git for windows sometimes creates extra releases all based off of the same upstream Git version
-        # so we want to crop versions like 2.16.1.4 to just 2.16.1
+        # so we first want to crop versions like 2.16.1.4 to just 2.16.1
         version = match[2].slice(/^\d+\.\d+\.\d+/)
+        # Now, as per Git for Windows' custom, append the fourth part in parens, e.g. 2.16.1(4)
+        version += "(#{match[2].slice(version.length + 1)})" if match[2][version.length] == "."
 
         if version
           config["windows_installer"] = {} if config["windows_installer"].nil?
@@ -119,8 +121,8 @@ class DownloadData
     end
 
     def version_compare(a, b)
-      a = a.nil? ? [] : a.gsub(/^v/, "").split(/\./)
-      b = b.nil? ? [] : b.gsub(/^v/, "").split(/\./)
+      a = a.nil? ? [] : a.gsub(/^v/, "").split(/[.()]/)
+      b = b.nil? ? [] : b.gsub(/^v/, "").split(/[.()]/)
       while true
         a0 = a.shift
         b0 = b.shift


### PR DESCRIPTION
## Changes

Accommodate for Git for Windows' "intermediate" versions in the script that wants to update the download data.

## Context

Git for Windows' versions are usually based on upstream Git versions, and hence uses the same version string.

Every once in a while, an extra, intermediate version is required, in which case Git for Windows appends an extra number in parentheses, starting with 2 (implying that regular Git for Windows versions are implicitly "(1)"), at least where parentheses can be used (otherwise it appends it separated by a dot).

It was noticed that the current v2.47.0(2) was _not_ picked up by git-scm.com, and that users kept downloading v2.47.0.