### PR TITLE
Keep sidebar open when clicking inside it

### DIFF
--- a/assets/sass/sidebar.scss
+++ b/assets/sass/sidebar.scss
@@ -52,9 +52,9 @@ aside.sidebar.active {
     border: none;
     left: 0;
     width: 1.6rem;
-    &:focus + .sidebar {
-      @include responsive-sidebar-ui;
-    }
+  }
+  .sidebar-btn:focus + .sidebar, .sidebar:focus-within {
+    @include responsive-sidebar-ui;
   }
   aside{
     &.sidebar {


### PR DESCRIPTION
## Changes

This fixes https://github.com/git/git-scm.com/issues/1916

## Context

When the screen is small (or the Zoom factor set high), the navigation menu is not shown anymore by default. Instead, there is a sidebar button on the left side, and clicking it will open the "sidebar menu".

However, clicking a link in that menu makes the menu disappear, and the link is not actually followed. (For some reason, this works on mobile devices, but not on the Desktop.)

By playing a little CSS trick, we can keep the sidebar menu open, though, when a link inside it is clicked, which this here PR does.