### PR TITLE
Update pricing info on Fork GUI

### DIFF
--- a/data/guis/fork.yml
+++ b/data/guis/fork.yml
@@ -6,7 +6,7 @@ platforms:
   - "Windows"
   - "Mac"
 # No details on the evaluation limits or terms
-price: "$49.99 (Free evaluation)"
+price: "$59.99 (Free evaluation)"
 license: "Proprietary"
 trend_name: "Fork Git client"
 order: 12


### PR DESCRIPTION
https://git-fork.com/buy

## Changes

- Changes the Fork GUI list price from $49.99 to $59.99 to reflect the current price on the website.

## Context

I was just looking to download a GUI and noticed that the pricing appears to be incorrect for the Fork GUI.
