### PR TITLE
Add missing <br> for Ubuntu PPA instructions

### DIFF
--- a/content/downloads/linux.html
+++ b/content/downloads/linux.html
@@ -17,7 +17,7 @@ aliases:
   <p>For the latest stable version for your release of Debian/Ubuntu</p>
   <code># apt-get install git</code>
   <p>For Ubuntu, this PPA provides the latest stable upstream Git version</p>
-  <code># add-apt-repository ppa:git-core/ppa</code>
+  <code># add-apt-repository ppa:git-core/ppa</code><br>
   <code># apt update; apt install git</code>
 
   <h3>Fedora</h3>


### PR DESCRIPTION
## Changes

- The instructions for adding the PPA in Ubuntu were missing a newline. This change fixes that.

## Context

This is what [the "Download for Linux and Unix" page](https://git-scm.com/downloads/linux) currently looks like:

![image](https://github.com/user-attachments/assets/b35dfe60-ea56-406f-8c56-ce8ee205db82)

I don't know how to render a test site to verify that my fix works, so if you can help me with that it would be great. While this is a dead-simple change, it's never fun to make changes blindly.