### PR TITLE
Sync with `main`, in preparation for deleting it

### DIFF
--- a/data/guis/fork.yml
+++ b/data/guis/fork.yml
@@ -6,7 +6,7 @@ platforms:
   - "Windows"
   - "Mac"
 # No details on the evaluation limits or terms
-price: "$49.99 (Free evaluation)"
+price: "$59.99 (Free evaluation)"
 license: "Proprietary"
 trend_name: "Fork Git client"
 order: 12


### PR DESCRIPTION
## Changes

This includes the commit history of `main` so that it can be deleted.

## Context

By mistake, I merged #1918 without realizing that it targeted `main`.

In trying to fix that, I cherry-picked 071a0923723525822666262a59b738e72d4f3b01 onto `gh-pages`, but that did not result in a fast-forward'able commit history, of course.

I want to delete the `main` branch so that such a mistake simply cannot happen anymore.