### PR TITLE
Fix formatting in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This site is built with [Hugo](https://gohugo.io/) and served via GitHub Pages.
 $ scalar clone https://github.com/git/git-scm.com
 $ cd git-scm.com/src
 $ git sparse-checkout set layouts content static assets hugo.yml data script
+```
 
 If your Git installation comes without `scalar`, you can create a sparse, partial clone manually, like this:
 
@@ -24,6 +25,7 @@ $ cd git-scm.com
 $ git sparse-checkout set layouts content static assets hugo.yml data script
 $ git reset --hard
 ```
+
 > [!NOTE]
 > If you _already_ have a full clone and wish to accelerate development by focusing only on a small subset of the pages, you may want to run the `git sparse-checkout set [...]` command mentioned above.
 


### PR DESCRIPTION
## Changes

- Fix the first code block by adding a missing <code>```</code>.

## Context

The first code block in the README is currently broken.
