### PR TITLE
Fix three typos in content/site/_index.html

### DIFF
--- a/content/site/_index.html
+++ b/content/site/_index.html
@@ -9,12 +9,12 @@ aliases:
   <h1>About git-scm.com</h1>
 
   This site is open source and maintained by members of the Git
-  community.  We welcome patches, suggestions, and corrections.
+  community. We welcome patches, suggestions, and corrections.
 
   <h2>Open Source</h2>
 
   The content on this site is pulled from multiple sources. It is
-  available under various licenses, and bugs reports should be directed
+  available under various licenses, and bug reports should be directed
   to the appropriate repositories:
 
   <ul>
@@ -81,6 +81,6 @@ aliases:
   </ul>
 
   For a detailed view of the site's network layout, see our
-  <a href="https://github.com/git/git-scm.com/blob/main/ARCHITECTURE.md">architecture document</a>.
+  <a href="https://github.com/git/git-scm.com/blob/gh-pages/ARCHITECTURE.md">architecture document</a>.
 
 </div>


### PR DESCRIPTION
## Changes

- Changes a double-space to a single space: consistency with the rest of the page.
- "and bugs reports" -> "and bug reports": the original is grammatically incorrect.
- Updates a link so that the architectural link works: otherwise it is more difficult to reach the correct page.

## Context

See above.