### PR TITLE
Fixes gpg.format default value

### DIFF
--- a/external/docs/content/docs/gitformat-signature.html
+++ b/external/docs/content/docs/gitformat-signature.html
@@ -46,7 +46,7 @@ which differ depending on signature type (as selected by <code>gpg.format</code>
 </div>
 <div class="dlist">
 <dl>
-<dt class="hdlist1" id="Documentation/gitformat-signature.txt-codegpgcodePGP"> <a class="anchor" href="#Documentation/gitformat-signature.txt-codegpgcodePGP"></a><code>gpg</code> (PGP) </dt>
+<dt class="hdlist1" id="Documentation/gitformat-signature.txt-codegpgcodePGP"> <a class="anchor" href="#Documentation/gitformat-signature.txt-codegpgcodePGP"></a><code>opengpg</code> (PGP) </dt>
 <dd>
 <p><code>-----BEGIN PGP SIGNATURE-----</code> and <code>-----END PGP SIGNATURE-----</code>.
 Or, if gpg is told to produce RFC1991 signatures,


### PR DESCRIPTION
## Changes

Update the `gpg.format` value reference to `opengpg` instead of `gpg`.

## Context

The `gitformat-signature` docs page refers to a `gpg` value that does not work as expected. Using the value `opengpg` instead, as documented under https://git-scm.com/docs/git-config `gpg.format` section fixes it.