### PR TITLE
Upgrade the Hugo version

### DIFF
--- a/hugo.yml
+++ b/hugo.yml
@@ -31,7 +31,7 @@ module:
   - source: external/docs/content
     target: content
 params:
-  hugo_version: 0.134.3
+  hugo_version: 0.139.4
   pagefind_version: 1.1.1
   latest_version: 2.47.1
   latest_relnote_url: https://raw.github.com/git/git/master/Documentation/RelNotes/2.47.1.txt


### PR DESCRIPTION
## Changes

- Upgrades the Hugo version we use to the latest one

## Context

Not that we don't trust our Markdown files, but just to avoid having to deal with any reports about using "an unsafe Hugo version"... see https://github.com/gohugoio/hugo/security/advisories/GHSA-c2xf-9v2r-r2rx for more details.