### PR TITLE
Fix typo in bash credentials helper example

### DIFF
--- a/external/book/content/book/en/v2/Git-Tools-Credential-Storage.html
+++ b/external/book/content/book/en/v2/Git-Tools-Credential-Storage.html
@@ -170,7 +170,7 @@ There are several forms it can take:</p>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Runs <code>/absolute/path/foo -xyz</code></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>!f() { echo "password=s3cre7"; }; f</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>! if() { echo "password=s3cre7"; };</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Code after <code>!</code> evaluated in shell</p></td>
 </tr>
 </tbody>


### PR DESCRIPTION
## Changes

There is a code example, that is not an executable example:

<img width="456" alt="image" src="https://github.com/user-attachments/assets/fbc37211-d2a9-489d-9c17-e3a8d352ffd0" />

After the change it should look like this 

<img width="467" alt="image" src="https://github.com/user-attachments/assets/40e03541-a1ac-4ce9-a9c2-4db042a3caba" />

-

## Context

I am looking to implement a custom git credentials helper and did not find a good example. I am not sure though, whether the example shouldn't even be

```shell
! if("$1" == 'get') { echo "password=s3cre7"; };
```
