### PR TITLE
Update now git-credential-cache is available on Windows

### DIFF
--- a/content/doc/credential-helpers.html
+++ b/content/doc/credential-helpers.html
@@ -15,7 +15,7 @@ aliases:
 
   <ul>
     <li><a href="https://git-scm.com/docs/git-credential-store">git-credential-store</a>: saves credentials in plaintext.</li>
-    <li><a href="https://git-scm.com/docs/git-credential-cache">git-credential-cache</a>: holds credentials temporarily in process memory. <a href="https://github.com/git-for-windows/git/issues/3892">Not available on Windows</a>. (Note that since credentials are lost when the cache expires or system restarts, this is inconvenient to store long-lived personal access tokens.)</li>
+    <li><a href="https://git-scm.com/docs/git-credential-cache">git-credential-cache</a>: holds credentials temporarily in process memory. (Note that since credentials are lost when the cache expires or system restarts, this is inconvenient to store long-lived personal access tokens.)</li>
   </ul>
 
   <h2>Platform specific storage</h2>


### PR DESCRIPTION
git-credential-cache is available on Windows since v2.45.0.windows.1 https://github.com/git-for-windows/git/commit/2406bf5fc5fbaa042e05fc0001ba72beb888d60f
