### PR TITLE
Fix link to “add GUI” section

### DIFF
--- a/content/downloads/guis/_index.html
+++ b/content/downloads/guis/_index.html
@@ -15,7 +15,7 @@ aliases:
     Git comes with built-in GUI tools for committing (<a href="{{< relurl "docs/git-gui" >}}">git-gui</a>) and browsing (<a href="{{< relurl "docs/gitk" >}}">gitk</a>), but there are several third-party tools for users looking for platform-specific experience.
   </p>
   <p>
-    <small>If you want to add another GUI tool to this list, just <a href="https://github.com/git/git-scm.com/blob/main/README.md#adding-a-new-gui">follow the instructions</a>.</small>
+    <small>If you want to add another GUI tool to this list, just <a href="https://github.com/git/git-scm.com/tree/gh-pages?tab=readme-ov-file#adding-a-new-gui">follow the instructions</a>.</small>
   </p>
 
   <p>


### PR DESCRIPTION
## Changes

<!-- List the changes this PR makes. -->

- Fix link to “add GUI” section on https://git-scm.com/downloads/guis

## Context

<!-- Explain why you're making these changes. -->
The old link was 404.