### PR TITLE
Fix link to the site's license

### DIFF
--- a/content/site/_index.html
+++ b/content/site/_index.html
@@ -24,7 +24,7 @@ aliases:
     repository at GitHub. That includes all pages except the book and
     manpages, along with the general design of the site. This content
     is available under the
-    <a href="https://github.com/git/git-scm.com/blob/main/MIT-LICENSE.txt">MIT license</a>.
+    <a href="https://github.com/git/git-scm.com/tree/gh-pages?tab=MIT-1-ov-file#readme">MIT license</a>.
     Bug reports and suggestions may be made in that repository.
 
     <li>Content from the ProGit book is imported from the


### PR DESCRIPTION
## Changes

- Fixes the stale link to the site's license

## Context

- Inspired by #1945 
