### PR TITLE
Avoid some unnecessary redirects

### DIFF
--- a/.github/actions/deploy-to-github-pages/action.yml
+++ b/.github/actions/deploy-to-github-pages/action.yml
@@ -20,6 +20,10 @@ inputs:
   cloudflare-zone:
     description: The Cloudflare zone to purge.
     required: false
+  external-https:
+    description: Whether HTTPS is set up externally, e.g. on Cloudflare instead of GitHub.
+    default: false
+    required: false
 outputs:
   url:
     description: The URL to which the site was deployed
@@ -41,6 +45,15 @@ runs:
       id: pages
       uses: actions/configure-pages@v5
 
+    - name: set base URL
+      shell: bash
+      run: |
+        base_url="${{ steps.pages.outputs.base_url }}"
+        if [ "${{ inputs.external-https }}" = true ] ; then
+          base_url="$(echo "$base_url" | sed 's/^http:/https:/')"
+        fi
+        echo "base_url=$base_url" >>"$GITHUB_ENV"
+
     - name: configure Hugo and Pagefind version
       shell: bash
       run: |
@@ -59,7 +72,7 @@ runs:
       env:
         HUGO_RELATIVEURLS: false
       shell: bash
-      run: hugo config && hugo --baseURL "${{ steps.pages.outputs.base_url }}/"
+      run: hugo config && hugo --baseURL "${{ env.base_url }}/"
 
     - name: run Pagefind ${{ env.PAGEFIND_VERSION }} to build the search index
       shell: bash
@@ -110,7 +123,6 @@ runs:
       id: remap
       shell: bash
       run: |
-        base_url='${{ steps.pages.outputs.base_url }}'
         echo "result=$(echo "$base_url" |
           sed 's|^\(.*\)\(/git-scm\.com\)$|(\1)?\2(.*)|') file://$PWD/public\$2" \
           >>$GITHUB_OUTPUT
@@ -120,6 +132,17 @@ runs:
           sed -n 's|^\(https\?:\/\/.*\)\(/git-scm\.com\)$|--remap '\''(\1.*) file://../$1'\''|p')" \
           >>$GITHUB_OUTPUT
 
+    - name: check for downgrades to unencrypted HTTP
+      if: startsWith(env.base_url, 'https://')
+      shell: bash
+      # The `--require-https` option of lychee could come in handy,
+      # but it also complains about `http://` links to other sites,
+      # and (more importantly) doesn't work in offline mode.
+      # A simple `grep` should work without any false positives,
+      # unless git-scm.com mentions the base URL of one of its forks,
+      # which is unlikely.
+      run: '! grep -FInr "http:${base_url#https:}" public'
+
     - name: check for broken links
       id: lychee
       uses: lycheeverse/lychee-action@v2
@@ -127,7 +150,7 @@ runs:
         args: >-
           --offline
           --fallback-extensions html
-          --base '${{ steps.pages.outputs.base_url }}'
+          --base '${{ env.base_url }}'
           --remap '${{ steps.remap.outputs.result }}'
           ${{ steps.remap.outputs.remap-dotdot }}
           --exclude file:///path/to/repo.git/
@@ -192,23 +215,21 @@ runs:
     - name: Install @playwright/test
       shell: bash
       run: npm install @playwright/test
-    - name: Edit /etc/hosts to map git-scm.com to GitHub
+    - name: Edit /etc/hosts to map the deployed domain to GitHub
       shell: bash
-      # This side-steps the Cloudflare caches
-      run: sudo sh -c 'echo "185.199.108.153 git-scm.com" >>/etc/hosts'
+      # This side-steps any caches that might be configured on the domain,
+      # and works even when the real server is not reachable from GitHub.
+      run: |
+        host="$(echo "$base_url" | sed -E 's|^https?://([^:/]+).*|\1|')"
+        sudo sh -c "echo '185.199.108.153 $host' >>/etc/hosts"
     - name: Run Playwright tests
       shell: bash
       id: playwright
       env:
-        PLAYWRIGHT_TEST_URL: ${{ steps.pages.outputs.base_url }}
-      run: |
+        PLAYWRIGHT_TEST_URL: ${{ env.base_url }}
         # avoid test failures when HTTPS is enforced half-way through
-        case "$PLAYWRIGHT_TEST_URL" in
-        https://*|http://git-scm.com) ;; # okay, leave as-is
-        http://*) PLAYWRIGHT_TEST_URL="https://${PLAYWRIGHT_TEST_URL#http://}";;
-        esac &&
-        echo "result=$PLAYWRIGHT_TEST_URL" >>$GITHUB_OUTPUT &&
-        npx playwright test --project=chrome
+        PLAYWRIGHT_EXTERNAL_HTTPS: ${{ inputs.external-https }}
+      run: npx playwright test --project=chrome
     - uses: actions/upload-artifact@v4
       if: always() && steps.playwright.outputs.result != ''
       with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,3 +27,4 @@ jobs:
         with:
           cloudflare-token: ${{ secrets.CLOUDFLARE_TOKEN }}
           cloudflare-zone: ${{ secrets.CLOUDFLARE_ZONE }}
+          external-https: ${{ vars.EXTERNAL_HTTPS }}

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -34,6 +34,16 @@ With this change, the site can be tested in the fork by pushing to the
 `gh-pages` branch (which will trigger the `deploy.yml` workflow) and then
 navigating to https://git-scm.<user>.github.io/.
 
+If the site will be deployed to a custom domain that supports HTTPS,
+but the "[Enforce HTTPS]" option cannot be enabled in the GitHub Pages settings
+(this can happen if the domain points to a third-party gateway),
+the [GitHub Actions variable] `EXTERNAL_HTTPS` should be set to `true`,
+so that the site can be built with a proper HTTPS base URL.
+The official `git-scm.com` domain is an example of such a setup.
+
+[Enforce HTTPS]: https://docs.github.com/en/pages/getting-started-with-github-pages/securing-your-github-pages-site-with-https#enforcing-https-for-your-github-pages-site
+[GitHub Actions variable]: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables#defining-configuration-variables-for-multiple-workflows
+
 ## Non-static parts
 
 While the site consists mostly of static content, there are a couple of

--- a/assets/js/application.js
+++ b/assets/js/application.js
@@ -56,27 +56,27 @@ var DownloadBox = {
     var os = window.session.browser.os; // Mac, Win, Linux
     if(os == "Mac") {
       $(".monitor").addClass("mac");
-      $("#download-link").text("Download for Mac").attr("href", `${baseURLPrefix}download/mac`);
+      $("#download-link").text("Download for Mac").attr("href", `${baseURLPrefix}downloads/mac`);
       $("#gui-link").removeClass('mac').addClass('gui');
-      $("#gui-link").text("Mac GUIs").attr("href", `${baseURLPrefix}download/gui/mac`);
+      $("#gui-link").text("Mac GUIs").attr("href", `${baseURLPrefix}downloads/guis?os=mac`);
       $("#gui-os-filter").attr('data-os', 'mac');
       $("#gui-os-filter").text("Only show GUIs for my OS (Mac)")
     } else if (os == "Windows") {
       $(".monitor").addClass("windows");
-      $("#download-link").text("Download for Windows").attr("href", `${baseURLPrefix}download/win`);
+      $("#download-link").text("Download for Windows").attr("href", `${baseURLPrefix}downloads/win`);
       $("#gui-link").removeClass('mac').addClass('gui');
-      $("#gui-link").text("Windows GUIs").attr("href", `${baseURLPrefix}download/gui/windows`);
+      $("#gui-link").text("Windows GUIs").attr("href", `${baseURLPrefix}downloads/guis?os=windows`);
       $("#alt-link").removeClass("windows").addClass("mac");
-      $("#alt-link").text("Mac Build").attr("href", `${baseURLPrefix}download/mac`);
+      $("#alt-link").text("Mac Build").attr("href", `${baseURLPrefix}downloads/mac`);
       $("#gui-os-filter").attr('data-os', 'windows');
       $("#gui-os-filter").text("Only show GUIs for my OS (Windows)")
     } else if (os == "Linux") {
       $(".monitor").addClass("linux");
-      $("#download-link").text("Download for Linux").attr("href", `${baseURLPrefix}download/linux`);
+      $("#download-link").text("Download for Linux").attr("href", `${baseURLPrefix}downloads/linux`);
       $("#gui-link").removeClass('mac').addClass('gui');
-      $("#gui-link").text("Linux GUIs").attr("href", `${baseURLPrefix}download/gui/linux`);
+      $("#gui-link").text("Linux GUIs").attr("href", `${baseURLPrefix}downloads/guis?os=linux`);
       $("#alt-link").removeClass("windows").addClass("mac");
-      $("#alt-link").text("Mac Build").attr("href", `${baseURLPrefix}download/mac`);
+      $("#alt-link").text("Mac Build").attr("href", `${baseURLPrefix}downloads/mac`);
       $("#gui-os-filter").attr('data-os', 'linux');
       $("#gui-os-filter").text("Only show GUIs for my OS (Linux)")
     } else {

--- a/content/downloads/_index.html
+++ b/content/downloads/_index.html
@@ -14,15 +14,15 @@ aliases:
         <table class="binaries">
           <tr>
             <td>
-              <a href="{{< relurl "download/mac" >}}" class="icon mac">macOS</a>
+              <a href="{{< relurl "downloads/mac" >}}" class="icon mac">macOS</a>
             </td>
             <td>
-              <a href="{{< relurl "download/win" >}}" class="icon windows">Windows</a>
+              <a href="{{< relurl "downloads/win" >}}" class="icon windows">Windows</a>
             </td>
           </tr>
           <tr>
             <td>
-              <a href="{{< relurl "download/linux" >}}" class="icon linux">Linux/Unix</a>
+              <a href="{{< relurl "downloads/linux" >}}" class="icon linux">Linux/Unix</a>
             </td>
           </tr>
         </table>

--- a/layouts/partials/site-root.html
+++ b/layouts/partials/site-root.html
@@ -50,7 +50,7 @@
         <td nowrap="true"><a href="https://www.kernel.org/pub/software/scm/git/" class="icon older-releases">Tarballs</a></td>
       </tr>
       <tr>
-        <td nowrap="true"><a href="{{ relURL "download/win" }}" class="icon windows" id="alt-link">Windows Build</a></td>
+        <td nowrap="true"><a href="{{ relURL "downloads/win" }}" class="icon windows" id="alt-link">Windows Build</a></td>
         <td nowrap="true"><a href="https://github.com/git/git" class="icon source">Source Code</a></td>
       </tr>
     </table>

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -34,6 +34,10 @@ module.exports = defineConfig({
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
+
+    /* Ignore ERR_CERT_COMMON_NAME_INVALID when tesing against GitHub's server,
+    if the real certificate is hosted by a third party (e.g. Cloudflare). */
+    ignoreHTTPSErrors: process.env.PLAYWRIGHT_EXTERNAL_HTTPS === 'true',
   },
 
   /* Configure projects for major browsers */

--- a/tests/git-scm.spec.js
+++ b/tests/git-scm.spec.js
@@ -59,7 +59,7 @@ test.describe('Windows', () => {
     await expect(page.getByRole('link', { name: 'Graphical UIs' })).toBeHidden()
     const windowsGUIs = page.getByRole('link', { name: 'Windows GUIs' })
     await expect(windowsGUIs).toBeVisible()
-    await expect(windowsGUIs).toHaveAttribute('href', /\/download\/gui\/windows$/)
+    await expect(windowsGUIs).toHaveAttribute('href', /\/downloads\/guis\?os=windows$/)
 
     // navigate to Windows GUIs
     await windowsGUIs.click()


### PR DESCRIPTION
## Changes

* A new GitHub Actions variable `EXTERNAL_HTTPS` will need to be (manually) set to `true` on this repository, either in the environment scope or in the repository scope. Forks of this repository may do the same based on instructions in `ARCHITECTURE.md`.
* The `--baseURL` option of Hugo for the official `git-scm.com` site will be changed from `http://git-scm.com/` to `https://git-scm.com/` (with only a different scheme).
* Playwright tests will be run directly against GitHub Pages (as opposed to gateways like Cloudflare) for any domain, not just for `git-scm.com`.
* Playwright tests will be run with HTTP or HTTPS depending solely on the base URL scheme, which means `git-scm.com` will be tested with HTTPS, while other domains may be tested with HTTP if they don’t support HTTPS. This differs from the current strategy of using HTTP for `git-scm.com` and HTTPS for others.
* A new test will be run during each deployment to ensure that downgrades to unencrypted HTTP never happen, as long as the base URL is HTTPS.
* Hyperlinks to download pages will be updated to reflect current path structure.

## Context

Currently, clicking the most prominent download button on [`https://git-scm.com/`](https://git-scm.com/) causes three navigations:

1. `https://git-scm.com/download/win`, the hyperlink destination (assuming a Windows system), which is an alias to…
2. `http://git-scm.com/downloads/win`, with an `http` scheme, resulting in a `301 Moved Permanently` to…
3. `https://git-scm.com/downloads/win`, which is the canonical URL.

This PR avoids both types of redundant redirects above (HTTPS to HTTP and `download` to `downloads`) so the button (and some other links mentioned in the commit message) opens the canonical URL directly. Tests are also updated to accomondate for this change.

In addition, this PR might serve as a better fix for #1898, which was supposed to be solved by #1899, by always running Playwright tests with HTTPS. However, that fix requires serveral conditions to work:

1. Since only `git-scm.com` was resolved to the GitHub Pages server in `/etc/hosts`, other domains might be tested against a third‐party gateway, which needs to be able to speak HTTPS.
2. The tested server must have a valid TLS certificate for the domain.
3. The test cases would expect `https://git-scm.example/book` to redirect to `https://git-scm.example/book/en/v2`, but this redirection depends on the base URL, so at least one of the following must be true:
   a. The base URL already has an `https` scheme.
   b. The tested server enforces HTTPS, so the final URL always says `https` even if the base URL doesn’t.

The official domain (`git-scm.com`) didn’t meet condition 2, thus d4f88c1a6c5178d78a860de28e805b27b1249269. The fork domain in #1898 (`ttaylorr.com`), however, met all of 1, 2 and 3b, so it *was* fixed, but the issue remains for other domains.

Conveniently, this PR lifts all the requirements above (respectively) by:

1. Always run Playwright tests against a server that supports HTTPS (i.e. GitHub Pages), not just for the `git-scm.com` domain.
2. Tell Playwright to ignore HTTPS errors, if (and only if) the certificate might be invalid (i.e. when `EXTERNAL_HTTPS=true`).
3. Set the base URL scheme selectively so there is no more bouncing around between HTTP and HTTPS.

In fact, the last change alone is sufficient to fix #1898, while the first two are kept for the original purpose of bypassing caches. This also removes the need to special‐case `git-scm.com` in the workflow, thereby simplifying the deployment logic.