### PR TITLE
Fix deployment

### DIFF
--- a/.github/actions/deploy-to-github-pages/action.yml
+++ b/.github/actions/deploy-to-github-pages/action.yml
@@ -141,7 +141,10 @@ runs:
       # A simple `grep` should work without any false positives,
       # unless git-scm.com mentions the base URL of one of its forks,
       # which is unlikely.
-      run: '! grep -FInr "http:${base_url#https:}" public'
+      #
+      # To catch bugs early, let's always look for non-HTTPS links
+      # to git-scm.com.
+      run: '! grep -FInre "http://git-scm.com" -e "http:${base_url#https:}" public'
 
     - name: check for broken links
       id: lychee

--- a/.github/actions/deploy-to-github-pages/action.yml
+++ b/.github/actions/deploy-to-github-pages/action.yml
@@ -74,6 +74,13 @@ runs:
       shell: bash
       run: hugo config && hugo --baseURL "${{ env.base_url }}/"
 
+    - name: enforce HTTPS in links to git-scm.com from external sources (book, docs, ...)
+      if: startsWith(env.base_url, 'https://')
+      shell: bash
+      run: |
+        find public/book public/docs -name \*.html -print0 |
+        xargs -0r sed -i 's,http://git-scm\.com,https://git-scm.com,g'
+
     - name: run Pagefind ${{ env.PAGEFIND_VERSION }} to build the search index
       shell: bash
       run: npx -y pagefind@${{ env.PAGEFIND_VERSION }} --site public


### PR DESCRIPTION
## Changes

- Fixes the deployment problems that happen after I merged #1953.

## Context

#1953 tried to ensure that no links to `http://git-scm.com/` were part of the deployment (note the missing "s" in "http").

Unfortunately, there are plenty of such links to go around, most of them in translations of the ProGit book (out of our control) and the remaining ones in the `gitweb.conf` manual pages related to Git versions prior to v2.13.0 (specifically, before commit git/git@e52a53df38af37cc32d641bfdeaa43ceb8277eef).

This caused the `deploy` workflow run to [fail](https://github.com/git/git-scm.com/actions/runs/13539600621/job/37837557415#step:3:135167).

I've added a work-around in this here PR by manually forcing `http://`-only links _specifically_ to git-scm.com in the `book/` and `docs/` pages to `https://` ones.

To make sure that this kind of problem is caught in PRs before merging, I've also extended the check to catch `http://git-scm.com` links also when deploying to a fork. To verify that this works as intended, I deployed to my fork with these changes, which [was successful](https://github.com/dscho/git-scm.com/actions/runs/13543000419), and then I deployed with the fix reverted (for testing), which [failed as expected](https://github.com/dscho/git-scm.com/actions/runs/13543099878/job/37848402337#step:3:135174).

/cc @b9a1