### PR TITLE
Do open tickets about broken links

### DIFF
--- a/.github/actions/deploy-to-github-pages/action.yml
+++ b/.github/actions/deploy-to-github-pages/action.yml
@@ -138,6 +138,9 @@ runs:
         echo "remap-dotdot=$(echo "$base_url" |
           sed -n 's|^\(https\?:\/\/.*\)\(/git-scm\.com\)$|--remap '\''^(\1.*) file://../$1'\''|p')" \
           >>$GITHUB_OUTPUT
+        # When running in forks, do treat https://git-scm.com links as if they were relative
+        test https://git-scm.com = "$base_url" ||
+        echo "remap-git-scm=--remap '^https?://git-scm.com(.*) file://$PWD/public\$1'" >>$GITHUB_OUTPUT
 
     - name: check for downgrades to unencrypted HTTP
       if: startsWith(env.base_url, 'https://')
@@ -163,6 +166,7 @@ runs:
           --base '${{ env.base_url }}'
           --remap '${{ steps.remap.outputs.result }}'
           ${{ steps.remap.outputs.remap-dotdot }}
+          ${{ steps.remap.outputs.remap-git-scm }}
           --exclude file:///path/to/repo.git/
           --exclude file:///caminho/para/o/reposit%C3%B3rio.git/
           --exclude file:///ruta/a/repositorio.git/

--- a/.github/actions/deploy-to-github-pages/action.yml
+++ b/.github/actions/deploy-to-github-pages/action.yml
@@ -176,8 +176,7 @@ runs:
         fail: false
         failIfEmpty: false # needed because its default overrides `fail = false`
 
-    - name: ${{ env.lychee_exit_code != '0' && 'open or update' || 'maybe close' }} link checker issue
-      if: env.lychee_exit_code != ''
+    - name: ${{ steps.lychee.outputs.exit_code != '0' && 'open or update' || 'maybe close' }} link checker issue
       uses: actions/github-script@v7
       with:
         github-token: ${{ inputs.github-token }}
@@ -211,13 +210,13 @@ runs:
           })()
 
           if (issues.data.items.length === 0) {
-            if (process.env.lychee_exit_code !== '0') {
+            if ('${{ steps.lychee.outputs.exit_code }}' !== '0') {
               await github.rest.issues.create({ ...req, title: 'Link Checker Report', body, labels: ['linkchecker'] })
             }
           } else {
             req.issue_number = issues.data.items[0].number
             await github.rest.issues.createComment({ ...req, body })
-            if (process.env.lychee_exit_code === '0') {
+            if ('${{ steps.lychee.outputs.exit_code }}' === '0') {
               await github.rest.issues.update({ ...req, state: 'closed' })
             }
           }

--- a/.github/actions/deploy-to-github-pages/action.yml
+++ b/.github/actions/deploy-to-github-pages/action.yml
@@ -131,12 +131,12 @@ runs:
       shell: bash
       run: |
         echo "result=$(echo "$base_url" |
-          sed 's|^\(.*\)\(/git-scm\.com\)$|(\1)?\2(.*)|') file://$PWD/public\$2" \
+          sed 's|^\(.*\)\(/git-scm\.com\)$|^(\1)?\2(.*)|') file://$PWD/public\$2" \
           >>$GITHUB_OUTPUT
         # When running in forks, do detect when links try to break out of the
         # `/git-scm.com/` subdirectory
         echo "remap-dotdot=$(echo "$base_url" |
-          sed -n 's|^\(https\?:\/\/.*\)\(/git-scm\.com\)$|--remap '\''(\1.*) file://../$1'\''|p')" \
+          sed -n 's|^\(https\?:\/\/.*\)\(/git-scm\.com\)$|--remap '\''^(\1.*) file://../$1'\''|p')" \
           >>$GITHUB_OUTPUT
 
     - name: check for downgrades to unencrypted HTTP

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,13 @@ jobs:
         curl -Lo /tmp/hugo.deb https://github.com/gohugoio/hugo/releases/download/v$HUGO_VERSION/hugo_extended_${HUGO_VERSION}_linux-amd64.deb &&
         sudo dpkg -i /tmp/hugo.deb
 
+    - name: work around a broken link
+      # See https://github.com/jnavila/git-manpages-l10n/pull/131;
+      # A space is missing in "https://git-scm.com/docs上查看"
+      run: |
+        sed -i 's,\(href="\(https://git-scm.com/docs\)\)\(上查看\)"\([^>]*>\)\2\3\(</a>\),\1"\4\1\5 \3,p' \
+          external/docs/content/docs/git/zh_HANS-CN.html
+
     - name: run Hugo to build the pages
       run: hugo
 
@@ -64,6 +71,7 @@ jobs:
       with:
         args: >-
           --offline
+          --remap '^https?://git-scm.com(.*) file://'"$PWD"'/public$1'
           --fallback-extensions html
           --exclude file:///path/to/repo.git/
           --exclude file:///caminho/para/o/reposit%C3%B3rio.git/


### PR DESCRIPTION
## Changes

- This fixes the issue where the `deploy` workflow code wants to open a ticket in case of any broken link, but due to a bug would fail to do so.
- This PR also increases the coverage so that links that point back to this site through "https://git-scm.com/..." links are also checked in PR builds and deployments in forks for broken links (previously, only relative links, or absolute links to the fork's GitHub Pages would have been checked, but there are plenty of links in "/book/" and in "/docs/" that were thusly missed).

## Context

I was quite surprised that the most recent deployment worked but all of a sudden complained about a broken link. This was uncovered by #1953, because we now asked lychee to verify "https://git-scm.com/" links _as part of the `deploy` workflow_ (but not in forks, and neither in the `ci` workflow that powers PR builds where this issue would ideally have been caught). Even more surprising was the fact that this broken link was not reported in a new GitHub issue, even if that was intended.

So here is some code that will hopefully prevent similar surprises in the future.