### PR TITLE
fix: Use --block option for Kate editor in translations

### DIFF
--- a/external/book/content/book/az/v2/Appendix-C:-Git-Əmrləri-Quraşdırma-və-Konfiqurasiya.html
+++ b/external/book/content/book/az/v2/Appendix-C:-Git-Əmrləri-Quraşdırma-və-Konfiqurasiya.html
@@ -99,7 +99,7 @@ Bu əmrin oxuduğu və yazacağı bir neçə sənəd var, beləcə dəyərləri 
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Kate (Linux)</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>git config --global core.editor "kate"</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>git config --global core.editor "kate --block"</code></p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">nano</p></td>

--- a/external/book/content/book/be/v2/Дадатак-C:-Git-Commands-Setup-and-Config.html
+++ b/external/book/content/book/be/v2/Дадатак-C:-Git-Commands-Setup-and-Config.html
@@ -98,7 +98,7 @@ There are several files this command will read from and write to so you can set 
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Kate (Linux)</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>git config --global core.editor "kate"</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>git config --global core.editor "kate --block"</code></p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">nano</p></td>

--- a/external/book/content/book/bg/v2/Приложение-C:-Git-команди-Настройки-и-конфигурация.html
+++ b/external/book/content/book/bg/v2/Приложение-C:-Git-команди-Настройки-и-конфигурация.html
@@ -95,7 +95,7 @@ url: "/book/bg/v2/Приложение-C:-Git-команди-Настройки-
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Kate (Linux)</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>git config --global core.editor "kate"</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>git config --global core.editor "kate --block"</code></p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">nano</p></td>

--- a/external/book/content/book/de/v2/Anhang-C:-Git-Kommandos-Setup-und-Konfiguration.html
+++ b/external/book/content/book/de/v2/Anhang-C:-Git-Kommandos-Setup-und-Konfiguration.html
@@ -98,7 +98,7 @@ Bei diesem Befehl werden mehrere Dateien gelesen und beschrieben, so dass Sie We
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Kate (Linux)</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>git config --global core.editor "kate"</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>git config --global core.editor "kate --block"</code></p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">nano</p></td>

--- a/external/book/content/book/fa/v2/پیوست-C:-Git-Commands-Setup-and-Config.html
+++ b/external/book/content/book/fa/v2/پیوست-C:-Git-Commands-Setup-and-Config.html
@@ -95,7 +95,7 @@ There are several files this command will read from and write to so you can set 
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Kate (Linux)</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>git config --global core.editor "kate"</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>git config --global core.editor "kate --block"</code></p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">nano</p></td>

--- a/external/book/content/book/fr/v2/Commandes-Git-Installation-et-configuration.html
+++ b/external/book/content/book/fr/v2/Commandes-Git-Installation-et-configuration.html
@@ -98,7 +98,7 @@ Il y a plusieurs fichiers que cette commande lira et dans lesquels elle écrira 
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Kate (Linux)</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>git config --global core.editor "kate"</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>git config --global core.editor "kate --block"</code></p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">nano</p></td>

--- a/external/book/content/book/ms/v2/Appendix-C:-Git-Commands-Setup-and-Config.html
+++ b/external/book/content/book/ms/v2/Appendix-C:-Git-Commands-Setup-and-Config.html
@@ -95,7 +95,7 @@ There are several files this command will read from and write to so you can set 
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Kate (Linux)</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>git config --global core.editor "kate"</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>git config --global core.editor "kate --block"</code></p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">nano</p></td>

--- a/external/book/content/book/ru/v2/Приложение-C:-Команды-Git-Настройка-и-конфигурация.html
+++ b/external/book/content/book/ru/v2/Приложение-C:-Команды-Git-Настройка-и-конфигурация.html
@@ -99,7 +99,7 @@ aliases:
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Kate (Linux)</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>git config --global core.editor "kate"</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>git config --global core.editor "kate --block"</code></p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">nano</p></td>

--- a/external/book/content/book/tr/v2/Ek-bölüm-C:-Git-Komutları-Kurulum-ve-Yapılandırma-Komutları.html
+++ b/external/book/content/book/tr/v2/Ek-bölüm-C:-Git-Komutları-Kurulum-ve-Yapılandırma-Komutları.html
@@ -94,7 +94,7 @@ Bu komutun okuyacağı ve yazacağı birkaç dosya vardır, böylece değerleri 
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Kate (Linux)</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>git config --global core.editor "kate"</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>git config --global core.editor "kate --block"</code></p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">nano</p></td>


### PR DESCRIPTION
This fixes the kate command, needs to use "kate -b".
