### PR TITLE
Fix: Fix missing comma in website sidebar translations

### DIFF
--- a/layouts/partials/translations.html
+++ b/layouts/partials/translations.html
@@ -17,7 +17,7 @@ This book is available in
     <tr><td><a href="{{ partial "translated-chapter.html" (dict "ctx" . "lang" "ru") }}">Русский</a>,</td></tr>
     <tr><td><a href="{{ partial "translated-chapter.html" (dict "ctx" . "lang" "sl") }}">Slovenščina</a>,</td></tr>
     <tr><td><a href="{{ partial "translated-chapter.html" (dict "ctx" . "lang" "tl") }}">Tagalog</a>,</td></tr>
-    <tr><td><a href="{{ partial "translated-chapter.html" (dict "ctx" . "lang" "uk") }}">Українська</a></td></tr>
+    <tr><td><a href="{{ partial "translated-chapter.html" (dict "ctx" . "lang" "uk") }}">Українська</a>,</td></tr>
     <tr><td><a href="{{ partial "translated-chapter.html" (dict "ctx" . "lang" "zh") }}">简体中文</a>,</td></tr>
   </table>
 </p>


### PR DESCRIPTION
Fixed the missing comma after the Ukrainian translation in the book translations section of the website sidebar, aligning it with the formatting used in other language sections.

## Changes

<!-- List the changes this PR makes. -->

- fix missing comma in `layouts/partials/translations.html`

## Context

<!-- Explain why you're making these changes. -->
The missing comma caused an inconsistency in the sidebar translations list.  
This fix ensures uniform formatting across all language sections.

![Unmodified](https://github.com/user-attachments/assets/6c57e6aa-cd8f-41b2-90d9-9cbe4a0986b8)