### PR TITLE
ci(link-check): mark outdated link check comments as such

### DIFF
--- a/.github/actions/deploy-to-github-pages/action.yml
+++ b/.github/actions/deploy-to-github-pages/action.yml
@@ -222,6 +222,45 @@ runs:
             await github.rest.issues.createComment({ ...req, body })
             if ('${{ steps.lychee.outputs.exit_code }}' === '0') {
               await github.rest.issues.update({ ...req, state: 'closed' })
+            } else {
+              // minimize outdated comments, if any
+              const query = `query ($owner: String!, $repo: String!, $issue_number: Int!) {
+                repository(owner: $owner, name: $repo) {
+                  issue(number: $issue_number) {
+                    comments(first: 100) {
+                      nodes {
+                        id
+                        isMinimized
+                        minimizedReason
+                        body
+                        author {
+                          login
+                        }
+                      }
+                    }
+                  }
+                }
+              }`
+              const commentIds = (await github.graphql(query, req)).repository.issue.comments.nodes
+              commentIds.pop() // leave the just-created comment alone
+              const markOutdatedCommentMutation = `mutation ($id: ID!, $classifier: ReportedContentClassifiers!) {
+                minimizeComment(input: { subjectId: $id, classifier: $classifier }) {
+                  clientMutationId
+                  minimizedComment {
+                    isMinimized
+                    minimizedReason
+                    viewerCanMinimize
+                  }
+                }
+              }`
+              for (const outdatedComment of commentIds.filter(
+                comment => comment.author.login === 'github-actions' && comment.isMinimized === false
+              )) {
+                await github.graphql(markOutdatedCommentMutation, {
+                  id: outdatedComment.id,
+                  classifier: 'OUTDATED',
+                })
+              }
             }
           }
 


### PR DESCRIPTION
## Changes

<!-- List the changes this PR makes. -->

- Let the link checker, which adds new comments to existing link check issues if there still is an open one, hide its own now-outdated comments from previous runs.

## Context

In particular with long-running issues where links are broken for weeks (and over the course of dozens of git-scm.com deployments), while it is nice that the link checker adds the most recent "verdict", the previous ones are no longer _that_ interesting. Let's hide them.

This is the case for example in #1962.

I verified that this patch works over in my fork where [this workflow run](https://github.com/dscho/git-scm.com/actions/runs/13698695589) added [this issue comment](https://github.com/dscho/git-scm.com/issues/18#issuecomment-2703724245) and marked all previous ones as outdated, as desired.