### PR TITLE
community: stop mentioning Git for Windows' Google Group

### DIFF
--- a/content/community/_index.html
+++ b/content/community/_index.html
@@ -27,7 +27,7 @@ aliases:
   </p>
 
   <p>
-    Windows-specific questions can also be sent to the <a href="https://groups.google.com/forum/?fromgroups#!forum/git-for-windows">Git for Windows mailing list</a> (if in doubt whether your question is Windows-specific, just use the general Git mailing list). Please submit Windows-specific bugs to <a href="https://github.com/git-for-windows/git/issues">Git for Windows' bug tracker</a>.
+    Windows-specific questions can also be asked at <a href="https://github.com/git-for-windows/git/discussions/">Git for Windows' discussions</a> (if in doubt whether your question is Windows-specific, or if you prefer mailing lists or want to avoid GitHub, just use the general <a href="mailto:git@vger.kernel.org">Git mailing list</a>). Please submit Windows-specific bugs to <a href="https://github.com/git-for-windows/git/issues">Git for Windows' bug tracker</a>.
   </p>
 
   <p>


### PR DESCRIPTION
## Changes

- Replaces the link to Git for Windows' Google Group.

## Context

As per https://github.com/git-for-windows/git/discussions/5473, Git for Windows' Google Group was shut down.