### PR TITLE
Adjust the schedule of the `update-git-version-and-manual-pages` workflow

### DIFF
--- a/.github/workflows/update-git-version-and-manual-pages.yml
+++ b/.github/workflows/update-git-version-and-manual-pages.yml
@@ -9,7 +9,7 @@ on:
         default: false
   schedule:
     # check daily for updates
-    - cron: '37 17 * * *'
+    - cron: '37 19 * * *'
 
 jobs:
   update-git-version-and-manual-pages:


### PR DESCRIPTION
## Changes

- Moves back by two hours the scheduled time when the "Synchronize with new Git version (if any)" workflow is started, to accommodate better for the times when Git versions seem to be released nowadays.

## Context

Currently, the `update-git-version-and-manual-pages` workflow is scheduled to run at 17:37:00 UTC every day. Let's adjust this, based on the recent `push` times:

| Date | Commit message of the tip commit |
| - | - |
| 2025-03-10T16:46:00.000Z | Git 2.49-rc2 |
| 2025-03-04T17:11:00.000Z | Git 2.49-rc1 |
| 2025-02-26T18:02:00.000Z | Git 2.49-rc0 |
| 2025-01-14T17:58:00.000Z | Sync with Git 2.48.1 |
| 2025-01-10T18:10:00.000Z | Git 2.48 |
| 2025-01-06T18:45:00.000Z | Git 2.48-rc2 |
| 2024-12-30T17:10:00.000Z | Git 2.48-rc1 |
| 2024-12-16T17:42:00.000Z | Git 2.48-rc0 |
| 2024-11-25T05:57:00.000Z | Sync with Git 2.47.1 |
| 2024-10-07T15:04:00.000Z | Git 2.47 |
| 2024-10-02T16:49:00.000Z | Git 2.47-rc1 |
| 2024-09-26T16:38:00.000Z | Git 2.47-rc0 |
| 2024-09-14T16:13:00.000Z | Sync with Git 2.46.1 |
| 2024-07-29T16:58:00.000Z | Git 2.46 |
| 2024-07-24T17:01:00.000Z | Git 2.46-rc2 |
| 2024-07-18T16:54:00.000Z | Git 2.46-rc1 |
| 2024-07-12T16:51:00.000Z | Git 2.46-rc0 |
| 2024-05-31T17:21:00.000Z | Sync with Git 2.45.2 |
| 2024-05-14T16:57:00.000Z | Sync with Git 2.45.1 |
| 2024-04-29T16:59:00.000Z | Git 2.45 |
| 2024-04-24T16:53:00.000Z | Git 2.45-rc1 |
| 2024-04-19T16:51:00.000Z | Git 2.45-rc0 |
| 2024-02-23T17:01:00.000Z | Git 2.44 |
| 2024-02-20T17:02:00.000Z | Git 2.44-rc2 |
| 2024-02-14T16:59:00.000Z | Git 2.44-rc1 |
| 2024-02-09T17:05:00.000Z | Git 2.44-rc0 |
| 2023-11-20T17:00:00.000Z | Git 2.43 |
| 2023-11-14T17:11:00.000Z | Git 2.43-rc2 |
| 2023-11-08T17:06:00.000Z | Git 2.43-rc1 |
| 2023-11-02T17:01:00.000Z | Git 2.43-rc0 |
| 2023-08-21T17:33:00.000Z | Git 2.42 |
| 2023-08-15T20:06:00.000Z | Git 2.42-rc2 |
| 2023-08-10T16:09:00.000Z | Git 2.42-rc1 |
| 2023-08-04T19:05:00.000Z | Git 2.42-rc0 |
| ... | ... |
