### PR TITLE
logos: Jason Long seems to have moved to Bluesky

### DIFF
--- a/content/downloads/logos/_index.html
+++ b/content/downloads/logos/_index.html
@@ -99,7 +99,7 @@ aliases:
   <div id="logo-license">
     <p>
       <img src="{{< relurl "images/creative-commons.png" >}}" />
-      Git Logo by <a href="https://twitter.com/jasonlong">Jason Long</a> is licensed under the <a href="https://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 Unported License</a>.
+      Git Logo by <a href="https://bsky.app/profile/jasonlong.me">Jason Long</a> is licensed under the <a href="https://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 Unported License</a>.
     </p>
     <p>
       This license lets others distribute, remix, tweak, and build upon your work, even commercially, as long as they credit you for the original creation. This is the most accommodating of the CC licenses offered. Recommended for maximum dissemination and use of licensed materials.


### PR DESCRIPTION
Link to Jason Long's Bluesky profile because he seemed to have moved of of ~~Twitter~~X.

