### PR TITLE
script/update-docs: use ISO-8601 dates for history

### DIFF
--- a/external/docs/data/docs.yml
+++ b/external/docs/data/docs.yml
@@ -4,1012 +4,1012 @@ versions:
     commit_sha: 6d7babea1d02a11eb4b4d6dd66e35b569d201fbe
     tree_sha: bc6ce29d1ec757d9d036532531a1046db4da0d96
     committed: 2014-12-17 19:30:46.000000000 +00:00
-    date: 12/17/14
+    date: '2014-12-17'
   2.1.4:
     commit_sha: 06fa2b7c2b65eedca6f31d62ae59e6f551db5495
     tree_sha: 815fc42c27ab577ea1b9e5c3eb0bce6e990c8790
     committed: 2014-12-17 19:44:59.000000000 +00:00
-    date: 12/17/14
+    date: '2014-12-17'
   2.2.3:
     commit_sha: 213030c8af8ad9f9060cc264395817adb4ede44e
     tree_sha: bf87a99cac9a2124260ff13ba9bd26fdb0c51327
     committed: 2015-09-04 17:26:23.000000000 +00:00
-    date: '09/04/15'
+    date: '2015-09-04'
   2.3.10:
     commit_sha: 1a3206d6abe95652dec384a1dee36d10f34f9f15
     tree_sha: 3fd19c10cd668b7e8d10a2ba3acf3ee42d5078ab
     committed: 2015-09-28 22:26:52.000000000 +00:00
-    date: '09/28/15'
+    date: '2015-09-28'
   2.4.12:
     commit_sha: 0a493fee385e530baa898a4ba4c0a64fd02ed0d6
     tree_sha: dd3225fdc5c7baccb32e4330e99f29199bb144cb
     committed: 2017-05-05 03:43:16.000000000 +00:00
-    date: 05/05/17
+    date: '2017-05-05'
   2.5.6:
     commit_sha: aaeee53fab72a6f96d17d2b3f4da4d6e29e92cc0
     tree_sha: adada97e9d6e84f9b3ad82bcc1bca6eb0dbc3a7b
     committed: 2017-05-05 03:50:38.000000000 +00:00
-    date: 05/05/17
+    date: '2017-05-05'
   2.6.7:
     commit_sha: 997f3c0214a4b19c69ba0102e426d41501ca8cef
     tree_sha: 076f9699f91e78514fa616e66febcc1c16e9d430
     committed: 2017-05-05 03:56:19.000000000 +00:00
-    date: 05/05/17
+    date: '2017-05-05'
   2.7.6:
     commit_sha: 7299fdaceb63ab08c360fa89c6b1b9601f60ca40
     tree_sha: c858f25264da2d8bbc78f3258c4ecac3f9901c4e
     committed: 2017-07-30 21:45:13.000000000 +00:00
-    date: 07/30/17
+    date: '2017-07-30'
   2.8.6:
     commit_sha: c9b60935183fba425fbd739ea6db3a97807cc48d
     tree_sha: 2382989e15a2a4f69a3757840e03a5b0443c0e9b
     committed: 2017-07-30 21:49:08.000000000 +00:00
-    date: 07/30/17
+    date: '2017-07-30'
   2.9.5:
     commit_sha: dcba104ffdcf2f27bc5058d8321e7a6c2fe8f27e
     tree_sha: 7b7719d955ed206004a5abdf4293f62336c4f345
     committed: 2017-07-30 21:53:25.000000000 +00:00
-    date: 07/30/17
+    date: '2017-07-30'
   2.10.5:
     commit_sha: 47e5ff3c281667f060ab33eeb7271a232d78a846
     tree_sha: ec80e9a9756cf7046cc3640a9e5acb575f80d77e
     committed: 2017-09-22 05:42:22.000000000 +00:00
-    date: '09/22/17'
+    date: '2017-09-22'
   2.11.4:
     commit_sha: f4cbb61dbc985e56fd6e739d0f9a85144df01c44
     tree_sha: 4fab548625094915655bf95e0978400d82bedc30
     committed: 2017-09-22 05:44:45.000000000 +00:00
-    date: '09/22/17'
+    date: '2017-09-22'
   2.12.5:
     commit_sha: c69c7b915ad59c3e74df57d50417e94a47edba53
     tree_sha: bd2422eee9e0d10902ccc4cb63aa2756ba4eaf90
     committed: 2017-09-22 05:47:41.000000000 +00:00
-    date: '09/22/17'
+    date: '2017-09-22'
   2.13.7:
     commit_sha: 5806c395177efc7fc08883e793b1a410e6d8e143
     tree_sha: 1066054d066d005da9761ced28d899fd7edd29ac
     committed: 2018-05-22 04:50:36.000000000 +00:00
-    date: 05/22/18
+    date: '2018-05-22'
   2.14.6:
     commit_sha: a0c139318735ff35fd3a33fc6e9bfa4d9b2e7770
     tree_sha: 84597f006e85bd3cbb613d7676f653856135696b
     committed: 2019-12-06 15:26:15.000000000 +00:00
-    date: 12/06/19
+    date: '2019-12-06'
   2.15.4:
     commit_sha: 368f2b213f2235a848739c924d6b75a2fc659ac0
     tree_sha: '0014851bdc71780993faa39e54897e6b1f8e25ce'
     committed: 2019-12-06 15:26:58.000000000 +00:00
-    date: 12/06/19
+    date: '2019-12-06'
   2.16.6:
     commit_sha: 9548a3d859b71ff15e959a7109f876933890753d
     tree_sha: 6faed3f101817b547362021b89187e75b4586d25
     committed: 2019-12-06 15:27:20.000000000 +00:00
-    date: 12/06/19
+    date: '2019-12-06'
   2.17.0:
     commit_sha: e8f2650052f3ff646023725e388ea1112b020e79
     tree_sha: 6a54cb7c68d97e863a28478d728c58a1e47f0b4f
     committed: 2018-04-02 17:13:35.000000000 +00:00
-    date: 04/02/18
+    date: '2018-04-02'
   2.17.1:
     commit_sha: 5b62a68cad663be4cd19fd59d053c57d88811c80
     tree_sha: ccbd5bc7c0d981e19c6355ce6bd81e1e7630eab9
     committed: 2018-05-22 05:28:26.000000000 +00:00
-    date: 05/22/18
+    date: '2018-05-22'
   2.17.2:
     commit_sha: 7f8020239f3b8ebc28299a97ba7db23d74e65447
     tree_sha: 92ffd949aca7918772fd2b35e2a845d68ea04f3e
     committed: 2018-09-27 18:44:07.000000000 +00:00
-    date: '09/27/18'
+    date: '2018-09-27'
   2.17.3:
     commit_sha: 17900eb8cee391a1fe73c9c6f32870c841b28b15
     tree_sha: 5accbda5882edc16e2387012e06545cf4c2ae901
     committed: 2019-12-06 15:27:38.000000000 +00:00
-    date: 12/06/19
+    date: '2019-12-06'
   2.17.4:
     commit_sha: 482f0c984cd289eaff6f781ab11ff26ac23c6003
     tree_sha: 5e958ae4191ade220c544b7c4528a92db829bf89
     committed: 2020-03-17 20:25:33.000000000 +00:00
-    date: 03/17/20
+    date: '2020-03-17'
   2.17.5:
     commit_sha: 6be77858ee1b7d62992f165357d067b0a34311a1
     tree_sha: 2db77b363da50260dc261cea0ec57df7121d6efe
     committed: 2020-04-19 23:10:58.000000000 +00:00
-    date: 04/19/20
+    date: '2020-04-19'
   2.17.6:
     commit_sha: a945d34ddc47f88a49e68d0d1e98552e2239c78b
     tree_sha: 5f88897f5a84c7b5ef2c811fb9454be95935d827
     committed: 2021-02-12 14:47:02.000000000 +00:00
-    date: 02/12/21
+    date: '2021-02-12'
   2.18.0:
     commit_sha: 994353f6efaef01719ab5704b67fcbea02d04e59
     tree_sha: 691408489fb0028188472ddca75fc930c58c5f11
     committed: 2018-06-21 17:00:06.000000000 +00:00
-    date: 06/21/18
+    date: '2018-06-21'
   2.18.1:
     commit_sha: d37ff315436cf953d41648fab73b23b228d1b2e4
     tree_sha: d3ae3dd90f782fb8615b525d08f649358a263459
     committed: 2018-09-27 18:48:19.000000000 +00:00
-    date: '09/27/18'
+    date: '2018-09-27'
   2.18.2:
     commit_sha: b53a704006bf72f52f9c6e1186201742a49789fe
     tree_sha: 03ac4fe3a7460f64e56c6fd878c1a823ddd2e0be
     committed: 2019-12-06 15:29:17.000000000 +00:00
-    date: 12/06/19
+    date: '2019-12-06'
   2.18.3:
     commit_sha: 8f8fa4a5cdbbd8e475bbc40e1923ab469693128e
     tree_sha: 284b77f6aa29e9ef10881da0400fe7527c017699
     committed: 2020-03-17 20:34:12.000000000 +00:00
-    date: 03/17/20
+    date: '2020-03-17'
   2.18.4:
     commit_sha: 1a1713a738a2228ac9d90b7d1847a1941d1ab054
     tree_sha: 568cffa77566b7b50fed2a7db52f89cf26016ef2
     committed: 2020-04-19 23:24:14.000000000 +00:00
-    date: 04/19/20
+    date: '2020-04-19'
   2.18.5:
     commit_sha: 9e8b89c6a8017c15081c1ea25d9e1e76ff9b03b1
     tree_sha: 19c98c5249b73a9a196175d3505227f1b3a9e4bd
     committed: 2021-02-12 14:47:43.000000000 +00:00
-    date: 02/12/21
+    date: '2021-02-12'
   2.19.0:
     commit_sha: '09963943a84ac6fbf20067743f7f20507253aa33'
     tree_sha: f7ce55dd7d1f1681e34c6061c18b29b45c14ff94
     committed: 2018-09-10 17:41:56.000000000 +00:00
-    date: '09/10/18'
+    date: '2018-09-10'
   2.19.1:
     commit_sha: 0d3c37ddaccbb48809fdd3810ebb3f2bc961973c
     tree_sha: 6fc060e90345ae83a8ef94ff0bf78da93e7148a8
     committed: 2018-09-27 18:52:33.000000000 +00:00
-    date: '09/27/18'
+    date: '2018-09-27'
   2.19.2:
     commit_sha: e0a939751a2738d0dd0aa09814cdfb57994b23ad
     tree_sha: 8b09a2c7062a7af90b93b25f0b370bf2ef462b25
     committed: 2018-11-21 14:22:12.000000000 +00:00
-    date: 11/21/18
+    date: '2018-11-21'
   2.19.3:
     commit_sha: 3bd0dbcc0436df810cafdef68088d3e4657b7137
     tree_sha: 887d6398d2f5eedef4a0983d409bac7e456774fa
     committed: 2019-12-06 15:30:40.000000000 +00:00
-    date: 12/06/19
+    date: '2019-12-06'
   2.19.4:
     commit_sha: 1e0fe0193b51e60c6294f33e09eea8e9615f2c64
     tree_sha: e0386b6988b0aaeb6a6ce43cd5a4a5eb6c4e6776
     committed: 2020-03-17 20:43:08.000000000 +00:00
-    date: 03/17/20
+    date: '2020-03-17'
   2.19.5:
     commit_sha: 69a930174b4d2f372fe4f251cc7b83878d9f2f74
     tree_sha: d82790a92ce10a52c1492d58c271099cac389244
     committed: 2020-04-19 23:26:41.000000000 +00:00
-    date: 04/19/20
+    date: '2020-04-19'
   2.19.6:
     commit_sha: 51d8efc293d2a82516727d95e1aa5cd6123e79b1
     tree_sha: 3c209946dea01b95cbac4a339c4275a36ab5e6b1
     committed: 2021-02-12 14:47:48.000000000 +00:00
-    date: 02/12/21
+    date: '2021-02-12'
   2.20.0:
     commit_sha: 90141c859541f8daa08bdb0621c64cbd7dadbd8c
     tree_sha: c790c47fe551d5ed812cfefdac243eb972c1fde3
     committed: 2018-12-09 04:16:21.000000000 +00:00
-    date: 12/09/18
+    date: '2018-12-09'
   2.20.1:
     commit_sha: 7a95a1cd084cb665c5c2586a415e42df0213af74
     tree_sha: f7a4925fb621cdef69d7dec49159c13cfc6aa789
     committed: 2018-12-15 03:31:34.000000000 +00:00
-    date: 12/15/18
+    date: '2018-12-15'
   2.20.2:
     commit_sha: 85d91b75a8bbb1796ae6585c0dfccf8de215d583
     tree_sha: 8cb10fa6e02a094dd7ea429f50a92174940ded6e
     committed: 2019-12-06 15:30:51.000000000 +00:00
-    date: 12/06/19
+    date: '2019-12-06'
   2.20.3:
     commit_sha: df449eca603312f8331de82a74fba8a0ce3ae194
     tree_sha: 6629073a7aff831ff6361ec99e68a528bad7ac51
     committed: 2020-03-17 20:46:10.000000000 +00:00
-    date: 03/17/20
+    date: '2020-03-17'
   2.20.4:
     commit_sha: 16c573854a23903f29c3e478fcd0fcc28723ee31
     tree_sha: efd3a79e0f5bac17b6526ea00e396d4bdcf62c26
     committed: 2020-04-19 23:28:57.000000000 +00:00
-    date: 04/19/20
+    date: '2020-04-19'
   2.20.5:
     commit_sha: 7df1be854bdd4332abb5e042a336190e5e05b611
     tree_sha: c94f49bd2bf0dbec8f1c531f9b152bac4d9310ce
     committed: 2021-02-12 14:49:17.000000000 +00:00
-    date: 02/12/21
+    date: '2021-02-12'
   2.21.0:
     commit_sha: 2bb64867dc05d9a8432488ddc1d22a194cee4d31
     tree_sha: 236c1f1d2403c388ae0f4baf03a923977838e888
     committed: 2019-02-24 15:55:19.000000000 +00:00
-    date: 02/24/19
+    date: '2019-02-24'
   2.21.1:
     commit_sha: c933d82efee4e660dc6ffa02f7f9c02638f0e679
     tree_sha: 159d2c1a75aef38315f472ed21ace813a66eb8ec
     committed: 2019-12-06 15:31:15.000000000 +00:00
-    date: 12/06/19
+    date: '2019-12-06'
   2.21.2:
     commit_sha: 02164beebd5292478f585ca84f0129b17b6318f1
     tree_sha: 167bed69fc0573efbaa3523342c17a4114c4f9f2
     committed: 2020-03-17 21:16:08.000000000 +00:00
-    date: 03/17/20
+    date: '2020-03-17'
   2.21.3:
     commit_sha: 5aa0ca270d6cab720c5e8d30897afe3e23a43a09
     tree_sha: c7bf92c51265916390430f79f5233e33be25b4ed
     committed: 2020-04-19 23:30:08.000000000 +00:00
-    date: 04/19/20
+    date: '2020-04-19'
   2.21.4:
     commit_sha: 80a258ca16ecdf94978804d491c76f2770b6f7d6
     tree_sha: 42b7593a2f4e5af9c0cf54484e322103dc517b2c
     committed: 2021-02-12 14:49:36.000000000 +00:00
-    date: 02/12/21
+    date: '2021-02-12'
   2.22.0:
     commit_sha: 286461941b7b6546185cf6d89fefc7223364fa26
     tree_sha: 6ad0201503e26458cfab159e162eda53315a0046
     committed: 2019-06-07 16:39:21.000000000 +00:00
-    date: 06/07/19
+    date: '2019-06-07'
   2.22.1:
     commit_sha: 4ed0275fa14a3c75f071c03d4ea4a7ce1dbcc20b
     tree_sha: b6802e0f0cef590d0ec955cf4d3bcb558eabf9af
     committed: 2019-08-11 22:07:51.000000000 +00:00
-    date: '08/11/19'
+    date: '2019-08-11'
   2.22.2:
     commit_sha: adcfadd78504765fd78cc64bee4ccc2dcb90ab5f
     tree_sha: 7f3e8773e25ab8c93a0b2d7295c2c801e2260264
     committed: 2019-12-06 15:31:24.000000000 +00:00
-    date: 12/06/19
+    date: '2019-12-06'
   2.22.3:
     commit_sha: 4c52d526ec9befe47613df9503ac5fecd5c890e2
     tree_sha: bf5209473cfa39921c3eb069d236db9eb9f20a47
     committed: 2020-03-17 21:24:55.000000000 +00:00
-    date: 03/17/20
+    date: '2020-03-17'
   2.22.4:
     commit_sha: 545ccb193a0276723a60374d5823b1c956013853
     tree_sha: 49e1802baf85a3b95796f457739d51f242c41f3d
     committed: 2020-04-19 23:30:19.000000000 +00:00
-    date: 04/19/20
+    date: '2020-04-19'
   2.22.5:
     commit_sha: 52deb6867f9ad26e1821c7929b76410edfb3f06c
     tree_sha: e886dc6d736cb3acb18810f79a06e1731d868326
     committed: 2021-02-12 14:49:41.000000000 +00:00
-    date: 02/12/21
+    date: '2021-02-12'
   2.23.0:
     commit_sha: cb715685942260375e1eb8153b0768a376e4ece7
     tree_sha: e3accb9beed5c4c1b5a05c99db71ab2841f0ed04
     committed: 2019-08-16 17:28:23.000000000 +00:00
-    date: '08/16/19'
+    date: '2019-08-16'
   2.23.1:
     commit_sha: d1fe8575943a77b8f7000208ae22cbe55b072b59
     tree_sha: 89c6a6feba2f627d14aa1c05d408a4215c14a3d1
     committed: 2019-12-06 15:31:32.000000000 +00:00
-    date: 12/06/19
+    date: '2019-12-06'
   2.23.2:
     commit_sha: 1f3bcc763e517b9d44204e0ee8eb6163134e2903
     tree_sha: d90361c2acb4dcea4bc68f0725748fe1c49cd97c
     committed: 2020-03-17 21:33:34.000000000 +00:00
-    date: 03/17/20
+    date: '2020-03-17'
   2.23.3:
     commit_sha: 1fc7edd089314d1f800008a4d8177f8b6e62f277
     tree_sha: 1c2cf45ae40c5e662d5f9277b63b78bb7ef9c420
     committed: 2020-04-19 23:30:27.000000000 +00:00
-    date: 04/19/20
+    date: '2020-04-19'
   2.23.4:
     commit_sha: 79e24491b1ebb8f4f09371c1e3db5505798c60c2
     tree_sha: ac43bc6c187d2afa8ac64f0cde09e0983af9851f
     committed: 2021-02-12 14:49:46.000000000 +00:00
-    date: 02/12/21
+    date: '2021-02-12'
   2.24.0:
     commit_sha: 1cc4bc0fcd93f816d514d77c29f2cc9ffdd8ae09
     tree_sha: 18066d0098c69ba7c8eea36e25ca614f419e3719
     committed: 2019-11-04 04:33:06.000000000 +00:00
-    date: 11/04/19
+    date: '2019-11-04'
   2.24.1:
     commit_sha: fd4fd83863680621b7db186ebbb5cd9a88f36e34
     tree_sha: 76e61a94ceaed4e4e7ed45ffd34aa92fb260fdf5
     committed: 2019-12-06 15:31:40.000000000 +00:00
-    date: 12/06/19
+    date: '2019-12-06'
   2.24.2:
     commit_sha: 7d2d44db1475f4d58bce86447c895bf8cc6e4ab6
     tree_sha: ffc75038e07070badec6d9add8861de6dbeba740
     committed: 2020-03-17 21:36:45.000000000 +00:00
-    date: 03/17/20
+    date: '2020-03-17'
   2.24.3:
     commit_sha: 233a527d0a7564a823c515c30a4cd1b34ea445e3
     tree_sha: 1dde4745773d761f1a4a677e1dcbf8149a27113b
     committed: 2020-04-19 23:30:34.000000000 +00:00
-    date: 04/19/20
+    date: '2020-04-19'
   2.24.4:
     commit_sha: dcc0b7d1de7c4e477751934bdce7fcd9037edc2b
     tree_sha: f61ddc69772960b562eb4261ef7a5e945fdd9303
     committed: 2021-02-12 14:49:50.000000000 +00:00
-    date: 02/12/21
+    date: '2021-02-12'
   2.25.0:
     commit_sha: 61e9521487999585dc2b8f27c2a65226fb531a07
     tree_sha: eacd13fab7e3d1385cf03bb8b1dc547dd30e3362
     committed: 2020-01-13 18:16:43.000000000 +00:00
-    date: 01/13/20
+    date: '2020-01-13'
   2.25.1:
     commit_sha: 46fef34b9aa6eaba5c20f4d80888f4f7655a84c9
     tree_sha: 692745bf5bc2e6bd2ec19a74014eedfc143f88f5
     committed: 2020-02-17 04:37:38.000000000 +00:00
-    date: 02/17/20
+    date: '2020-02-17'
   2.25.2:
     commit_sha: 635122cf142b7618ec3e0da9ea8f2b374eca4688
     tree_sha: '0502681eecb3060dd8627f6aaf48310c5bd11564'
     committed: 2020-03-17 22:06:37.000000000 +00:00
-    date: 03/17/20
+    date: '2020-03-17'
   2.25.3:
     commit_sha: ecee678d42cb488d3823645904f663b717a674e7
     tree_sha: cfb499c09dd5d0310006062e1e361c42d0045283
     committed: 2020-03-18 01:12:01.000000000 +00:00
-    date: 03/18/20
+    date: '2020-03-18'
   2.25.4:
     commit_sha: 73ad3e781f7cee3cc7bf8f61c3b3c707e1191adb
     tree_sha: 839c4f406bea1107beabd066440dbfa2e952b561
     committed: 2020-04-19 23:31:07.000000000 +00:00
-    date: 04/19/20
+    date: '2020-04-19'
   2.25.5:
     commit_sha: 3c922eadc15d9d29af996831242356a99a9891d3
     tree_sha: d607997026d5226345a2d6a805ba2256d15565ce
     committed: 2021-02-12 14:49:55.000000000 +00:00
-    date: 02/12/21
+    date: '2021-02-12'
   2.26.0:
     commit_sha: adf6396efeb4e8c12fb07174b4074c4031b2c460
     tree_sha: 97bd391b7e49c10af962121644bac85c0d23ead7
     committed: 2020-03-22 23:50:46.000000000 +00:00
-    date: 03/22/20
+    date: '2020-03-22'
   2.26.1:
     commit_sha: 12e22c1f1f6b5f32929f068cd131b97ee24d02a0
     tree_sha: aff75b1af189d2c3d2dffe6d5d3ba6f2f812ce08
     committed: 2020-03-25 20:07:47.000000000 +00:00
-    date: 03/25/20
+    date: '2020-03-25'
   2.26.2:
     commit_sha: ef7aa56f965a794d96fb0b1385f94634e7cea06f
     tree_sha: 4c7b9b1b1c22e457fbfa28ec64f33a0a469ebc02
     committed: 2020-04-19 23:32:24.000000000 +00:00
-    date: 04/19/20
+    date: '2020-04-19'
   2.26.3:
     commit_sha: dd3d9c5e45240dc79c0d74b30085dc5eebe8d5f6
     tree_sha: 30b3fe997467bd630915d174fab8c0acb8bfa690
     committed: 2021-02-12 14:50:00.000000000 +00:00
-    date: 02/12/21
+    date: '2021-02-12'
   2.27.0:
     commit_sha: a8b4596613e899cc4d09c3175bff045b94765396
     tree_sha: 2a721d0620e1836d19e09358d4b18680940a75a8
     committed: 2020-06-01 06:03:57.000000000 +00:00
-    date: 06/01/20
+    date: '2020-06-01'
   2.27.1:
     commit_sha: 3670d5b8f5904ba44af6264cb9969112bcaad396
     tree_sha: 28e67135204b33938d41d533ab1f8e8ba6800604
     committed: 2021-02-12 14:50:05.000000000 +00:00
-    date: 02/12/21
+    date: '2021-02-12'
   2.28.0:
     commit_sha: 4c8bcdda4d6e4757caf876ddc401b5392e874e21
     tree_sha: 8e02d73a5702ecfd3c570cd13127d84629ca2f8c
     committed: 2020-07-27 01:01:43.000000000 +00:00
-    date: 07/27/20
+    date: '2020-07-27'
   2.28.1:
     commit_sha: 60b893a13cd982da427336a808953a7c0d53c674
     tree_sha: 2903b5cb12e68c2d56d792eac4870a1bb98e493d
     committed: 2021-02-12 14:50:10.000000000 +00:00
-    date: 02/12/21
+    date: '2021-02-12'
   2.29.0:
     commit_sha: 0c6ff04c974f0aab239e9ba46307e1d1a4904d66
     tree_sha: ee5b5b41305cda618862beebc9c94859ae276e5a
     committed: 2020-10-19 16:58:42.000000000 +00:00
-    date: 10/19/20
+    date: '2020-10-19'
   2.29.1:
     commit_sha: 6c5034eca4973ae22eee0436e34f9f010895bea3
     tree_sha: 4a8f3738e5b4cd69b0c70fe245dfb03418bc1fe6
     committed: 2020-10-22 22:07:25.000000000 +00:00
-    date: 10/22/20
+    date: '2020-10-22'
   2.29.2:
     commit_sha: 1ec19b7757a1acb11332f06e8e812b505490afc6
     tree_sha: 75130889f941eceb57c6ceb95c6f28dfc83b609c
     committed: 2020-10-29 21:24:09.000000000 +00:00
-    date: 10/29/20
+    date: '2020-10-29'
   2.29.3:
     commit_sha: 14193fc92b3cdaad09c550474029c9a273bf8829
     tree_sha: 97912295bacabdfb32a0cf2eb0ffdee7b18e2760
     committed: 2021-02-12 14:50:15.000000000 +00:00
-    date: 02/12/21
+    date: '2021-02-12'
   2.30.0:
     commit_sha: 2d9685d47a7e516281aa093bf0cddc8aafa72448
     tree_sha: e6f5abb10362fdc4ab5411cc1f9eb008f6c68020
     committed: 2020-12-27 23:15:23.000000000 +00:00
-    date: 12/27/20
+    date: '2020-12-27'
   2.30.1:
     commit_sha: 36b80a59b799802fe776ed390870fe520d262f5c
     tree_sha: dd6a0eaf8ee41a274bfc150b93d66cbf6a6cc23a
     committed: 2021-02-08 22:05:55.000000000 +00:00
-    date: 02/08/21
+    date: '2021-02-08'
   2.30.2:
     commit_sha: 4340cdd2bdf420acc349f5cda141141230d5095a
     tree_sha: b4ca4da5256781384cbc09c0b38919cfae6dad34
     committed: 2021-02-12 14:51:13.000000000 +00:00
-    date: 02/12/21
+    date: '2021-02-12'
   2.30.3:
     commit_sha: 4b42588bf99dd6f8db0096f463f4132cb3358444
     tree_sha: 6bdac7fde1d2d3e7f08e58c3e711bf70100dfe26
     committed: 2022-03-23 23:22:17.000000000 +00:00
-    date: 03/23/22
+    date: '2022-03-23'
   2.30.4:
     commit_sha: 3bf735653d92fca9fe753de0344050235a60042c
     tree_sha: 3adf24b9f5331d9971e4641b3f456872535290f7
     committed: 2022-04-13 20:31:29.000000000 +00:00
-    date: 04/13/22
+    date: '2022-04-13'
   2.30.5:
     commit_sha: a75b578e5c81c7880cbc22a9e8b37e616b5b2e99
     tree_sha: 3f3cbf914b226d932a35ff50c74c2c59e7b0e9d0
     committed: 2022-06-23 10:31:05.000000000 +00:00
-    date: 06/23/22
+    date: '2022-06-23'
   2.30.6:
     commit_sha: 5f9f86a2dcdc83c9dca32625f085b94fee3fd31d
     tree_sha: ca2d68be95f02634cdb10b7b955792ffffb8043d
     committed: 2022-10-06 21:38:16.000000000 +00:00
-    date: 10/06/22
+    date: '2022-10-06'
   2.30.7:
     commit_sha: de638335fb5309e52df9cbb3fb51d27cd97557c1
     tree_sha: ab62bab4bb4b75ce3b822582e0832329baf4293d
     committed: 2022-12-13 11:56:43.000000000 +00:00
-    date: 12/13/22
+    date: '2022-12-13'
   2.30.8:
     commit_sha: d4de2bb368d0c0926fc3e7dae60e80721e732683
     tree_sha: 4dcd157c48e2f9329798b5e92e97b5c43c28c15f
     committed: 2023-02-06 08:14:45.000000000 +00:00
-    date: 02/06/23
+    date: '2023-02-06'
   2.30.9:
     commit_sha: b7bc991a0c34b63cc39c3db021ba73509ac767f1
     tree_sha: dcd6f94cd74712f6b38de3a85afb79839f9509f7
     committed: 2023-04-17 19:15:43.000000000 +00:00
-    date: 04/17/23
+    date: '2023-04-17'
   2.31.0:
     commit_sha: 3e90d4b58f3819cfd58ac61cb8668e83d3ea0563
     tree_sha: 1622f60d17b208487b1069935a5e72b08517d85a
     committed: 2021-03-15 18:51:51.000000000 +00:00
-    date: 03/15/21
+    date: '2021-03-15'
   2.31.1:
     commit_sha: 28afb7555c7013c02b5ee5dc0286546f1f8e2b8f
     tree_sha: a71b4c1d848822b1af790d158ba1f5c83427e10c
     committed: 2021-03-26 21:49:41.000000000 +00:00
-    date: 03/26/21
+    date: '2021-03-26'
   2.31.2:
     commit_sha: b798adfbbb57623b60e5d4469e6a6210163339f3
     tree_sha: 77025683264bea3e08e3b055a07b230fe244b9b2
     committed: 2022-03-23 23:24:29.000000000 +00:00
-    date: 03/23/22
+    date: '2022-03-23'
   2.31.3:
     commit_sha: 9372639dbe7d3302aff2709ce4e362072af59f17
     tree_sha: 8d387d1cc28d85ba1e2f21c56f9efa6537c84aed
     committed: 2022-04-13 22:21:08.000000000 +00:00
-    date: 04/13/22
+    date: '2022-04-13'
   2.31.4:
     commit_sha: 2c9159b1ed8dea0a7f3bec6c7a97b2161fd3d32a
     tree_sha: b6a454966aa1fdc49bef379bd3e9fd6a6f1e1d51
     committed: 2022-06-23 10:35:25.000000000 +00:00
-    date: 06/23/22
+    date: '2022-06-23'
   2.31.5:
     commit_sha: 4689c95a40e3783d7e78aa9cd8c3084a2b07e7c8
     tree_sha: 792766fa5cc60357bded6ac9fbd0bbe4319a4906
     committed: 2022-10-06 21:39:26.000000000 +00:00
-    date: 10/06/22
+    date: '2022-10-06'
   2.31.6:
     commit_sha: a76e723f5d6b28f404d07d83bbaa2c5b571e4b82
     tree_sha: a92adef507e1ae6d63b05e01fa99b3fa44d5171c
     committed: 2022-12-13 12:04:03.000000000 +00:00
-    date: 12/13/22
+    date: '2022-12-13'
   2.31.7:
     commit_sha: 1dd64c2d05c7eb9f03e7e3579ea5f9ec095d9923
     tree_sha: 7947f735aa883ad681d3cfb1d2f1fdfd80f6ab1f
     committed: 2023-02-06 08:24:07.000000000 +00:00
-    date: 02/06/23
+    date: '2023-02-06'
   2.31.8:
     commit_sha: d31472b33fb813279637dbbba82edc9c5da47305
     tree_sha: 10423bc2c46a887b2edc9f8d18584b747a1b9d1c
     committed: 2023-04-17 19:15:47.000000000 +00:00
-    date: 04/17/23
+    date: '2023-04-17'
   2.32.0:
     commit_sha: b7e68c41d92146de98ec5f433e1b123c4df2ac5a
     tree_sha: e357e9abc3cafd36e289e1952807e7688dc20240
     committed: 2021-06-06 06:40:01.000000000 +00:00
-    date: 06/06/21
+    date: '2021-06-06'
   2.32.1:
     commit_sha: e98226189cdd0ba52bac28fe46a615ce79982765
     tree_sha: 64c21b0c5f1312280fd517fed592d0f3cb7195fb
     committed: 2022-03-23 23:31:29.000000000 +00:00
-    date: 03/23/22
+    date: '2022-03-23'
   2.32.2:
     commit_sha: d910ee3641ca01294d980e1a91ef37081971ed06
     tree_sha: 111b132a085232ca4ff09105f539c9cac6bfaca1
     committed: 2022-04-13 22:21:26.000000000 +00:00
-    date: 04/13/22
+    date: '2022-04-13'
   2.32.3:
     commit_sha: 2e3207f11d883180c5862e1fec4b9af19e410f86
     tree_sha: e9f1ffe99c2c7888b818a7f5f2cdea8de05db4ce
     committed: 2022-06-23 10:35:32.000000000 +00:00
-    date: 06/23/22
+    date: '2022-06-23'
   2.32.4:
     commit_sha: 0d46d839a278a33759cc5c4d11889f195dfd1757
     tree_sha: 7e21ab51ef3e2b3532d5a7e8ed852d408b890971
     committed: 2022-10-06 21:41:15.000000000 +00:00
-    date: 10/06/22
+    date: '2022-10-06'
   2.32.5:
     commit_sha: fc887992d9159196ac48b95cb5afca3d788e62e2
     tree_sha: 4f1d9ddffbc57c9263a133b6dd2aadbfc44d8f78
     committed: 2022-12-13 12:10:27.000000000 +00:00
-    date: 12/13/22
+    date: '2022-12-13'
   2.32.6:
     commit_sha: 7c781ab4c859c91e8b4d174b1214abe6f8e373c4
     tree_sha: 510cf36376ab348a842216028072a44d1bf858a4
     committed: 2023-02-06 08:25:09.000000000 +00:00
-    date: 02/06/23
+    date: '2023-02-06'
   2.32.7:
     commit_sha: e8de0d254a1c0f0c13faf5ee91a17f22ecfeafd6
     tree_sha: a893c0456d8503d4b5f3949b64da6d7676fd5fc6
     committed: 2023-04-17 19:15:51.000000000 +00:00
-    date: 04/17/23
+    date: '2023-04-17'
   2.33.0:
     commit_sha: c06b72d02c588fefe7f77518a6d0f3f25414a41d
     tree_sha: 256afabcb270d602a0051923c999a0ac6f55e19d
     committed: 2021-08-16 19:15:44.000000000 +00:00
-    date: '08/16/21'
+    date: '2021-08-16'
   2.33.1:
     commit_sha: af0542251a92fade10e80ecee4bbae5aa852b75d
     tree_sha: 891cb6c9d9ba92f7c60b368a6896caa474e1e700
     committed: 2021-10-12 20:51:59.000000000 +00:00
-    date: 10/12/21
+    date: '2021-10-12'
   2.33.2:
     commit_sha: 927dd21d44528f5753bf1b1a5eb71e5c16683550
     tree_sha: 12380f4db514255bcbf9f47b9fbe582fb01310c8
     committed: 2022-03-23 23:31:32.000000000 +00:00
-    date: 03/23/22
+    date: '2022-03-23'
   2.33.3:
     commit_sha: 5e18c82bb9ac28d482413466150f08a7d49230e9
     tree_sha: d276b872a065585c0c85c1f4c2d0d544e46fd7ba
     committed: 2022-04-13 22:21:28.000000000 +00:00
-    date: 04/13/22
+    date: '2022-04-13'
   2.33.4:
     commit_sha: fe12aefafb5ac6220a315feef12a0f4c0bb0d040
     tree_sha: 0b213bb3245d66e4b4d650d0ea72ffc34a4bee0b
     committed: 2022-06-23 10:35:41.000000000 +00:00
-    date: 06/23/22
+    date: '2022-06-23'
   2.33.5:
     commit_sha: a159d3ebce34dc137e9ce482961793f2e8f5770a
     tree_sha: e60a50d86a8e67bd0fe83ebfa67ef7470f993b79
     committed: 2022-10-06 21:42:27.000000000 +00:00
-    date: 10/06/22
+    date: '2022-10-06'
   2.33.6:
     commit_sha: 83ed8cfb96b84d57e1a092ec9589f219b059efc6
     tree_sha: 7c2492329738ab879dea32041131ab1994da5e29
     committed: 2022-12-13 12:13:48.000000000 +00:00
-    date: 12/13/22
+    date: '2022-12-13'
   2.33.7:
     commit_sha: 4a00e713cf6fb59784d410bdd26a0a278685e56e
     tree_sha: 47a7ca60d8c1dee84370377bb3a9fa6278332ee9
     committed: 2023-02-06 08:25:58.000000000 +00:00
-    date: 02/06/23
+    date: '2023-02-06'
   2.33.8:
     commit_sha: 1daa995dd824ad02cb22315f81d0c8d2653c98f2
     tree_sha: 493d2e6639ce9050b63a8cb8acdeabd259aa5e7b
     committed: 2023-04-17 19:15:54.000000000 +00:00
-    date: 04/17/23
+    date: '2023-04-17'
   2.34.0:
     commit_sha: 8eb004e6b4cff162c921b53b67d95dc807208ff7
     tree_sha: 74152cd2109dbf866ae55c54ab495efad7f4a830
     committed: 2021-11-15 06:50:52.000000000 +00:00
-    date: 11/15/21
+    date: '2021-11-15'
   2.34.1:
     commit_sha: e0b44509711b2d9090f2dcf987f40c0bce248774
     tree_sha: 59717d8f5c3d55412d0f883f7f267a07893c834e
     committed: 2021-11-24 18:55:13.000000000 +00:00
-    date: 11/24/21
+    date: '2021-11-24'
   2.34.2:
     commit_sha: f22443884268ad56211ad5bffd275d7e72d5ca28
     tree_sha: 499066b83e7704cee40631b33e2f0c75724eb26e
     committed: 2022-03-23 23:31:36.000000000 +00:00
-    date: 03/23/22
+    date: '2022-03-23'
   2.34.3:
     commit_sha: a1171ecd147c9312ab4c7ded38dd13c1ced900a4
     tree_sha: f0dfa3cb9c28475d7d3bd80a2572d4e4751e3bf7
     committed: 2022-04-13 22:21:31.000000000 +00:00
-    date: 04/13/22
+    date: '2022-04-13'
   2.34.4:
     commit_sha: a829c08acb38ca5a3fdaa2f0ca3b5b1b87894763
     tree_sha: 4b6cb1053081db9bda27d3e01395a2e6259ec48b
     committed: 2022-06-23 10:35:49.000000000 +00:00
-    date: 06/23/22
+    date: '2022-06-23'
   2.34.5:
     commit_sha: c0d48c4325ca8bbdeb8ceee0a8c8d9ab864c11b0
     tree_sha: f6550f88edec4aa6eb7a28d1a2c3f2dcd324963f
     committed: 2022-10-06 21:43:08.000000000 +00:00
-    date: 10/06/22
+    date: '2022-10-06'
   2.34.6:
     commit_sha: ce273b21e2af09bc869f98df85177aad22d2a9d6
     tree_sha: 75ed8d7484cf5c7f72175f7b9461f87a07723526
     committed: 2022-12-13 12:15:39.000000000 +00:00
-    date: 12/13/22
+    date: '2022-12-13'
   2.34.7:
     commit_sha: c0cfcf10f35bdbca9cd631ba5782ba654c193cc1
     tree_sha: f15bc5c56ce47a80cbc6283cd568344888642760
     committed: 2023-02-06 08:29:17.000000000 +00:00
-    date: 02/06/23
+    date: '2023-02-06'
   2.34.8:
     commit_sha: 5bfdf1787270de99fd3dcce7ca65d32df1b18f51
     tree_sha: b3e20f85bf38a3db019fc971d236e6b0886f780e
     committed: 2023-04-17 19:15:57.000000000 +00:00
-    date: 04/17/23
+    date: '2023-04-17'
   2.35.0:
     commit_sha: 38fc0d036c2e0267736249eae49fb9df786fe87b
     tree_sha: 4bd8d505f4d6ebc97473eb786deed8407a357b32
     committed: 2022-01-24 17:25:25.000000000 +00:00
-    date: 01/24/22
+    date: '2022-01-24'
   2.35.1:
     commit_sha: 73807ff71e1acef4cfa35fe5cfb16d5878b6cd12
     tree_sha: da340c9d678702d801d37bcfef5bb559bfc76bc6
     committed: 2022-01-29 00:48:42.000000000 +00:00
-    date: 01/29/22
+    date: '2022-01-29'
   2.35.2:
     commit_sha: 6f2bb67f2b16cf525e66fb4379a33cf851acd0bc
     tree_sha: f31972382a0fb71fc3d9701c439bd35acd298428
     committed: 2022-03-23 23:31:43.000000000 +00:00
-    date: 03/23/22
+    date: '2022-03-23'
   2.35.3:
     commit_sha: 2dcfc3c7b3e36ce197c416921c23973a924a9a64
     tree_sha: 5ce8656672734b2dabab1a10747ce6674d139ac5
     committed: 2022-04-13 22:21:34.000000000 +00:00
-    date: 04/13/22
+    date: '2022-04-13'
   2.35.4:
     commit_sha: f10bdacba11da5ee08c3d78fb105706198170f13
     tree_sha: 94e61669ab0240bcae465ac297050bce5c6bcbd7
     committed: 2022-06-23 10:36:05.000000000 +00:00
-    date: 06/23/22
+    date: '2022-06-23'
   2.35.5:
     commit_sha: 5b78b58955428292e86ee9065969ad47a7fc3c07
     tree_sha: 5fa8b62849527dd4ba3a6b70fe7d0736f742c192
     committed: 2022-10-06 21:44:02.000000000 +00:00
-    date: 10/06/22
+    date: '2022-10-06'
   2.35.6:
     commit_sha: 92b348d486e1a04426208b09f54322875013a290
     tree_sha: 3e138b3e5e7c88cc9222c017d670936deb6874f7
     committed: 2022-12-13 12:17:26.000000000 +00:00
-    date: 12/13/22
+    date: '2022-12-13'
   2.35.7:
     commit_sha: 04cab0c6c9fa523b0cdf89d714fc937addb23936
     tree_sha: d39bf3864e33047c37a43ec8af914688716d8f71
     committed: 2023-02-06 08:29:45.000000000 +00:00
-    date: 02/06/23
+    date: '2023-02-06'
   2.35.8:
     commit_sha: 213de186f5caadc3722df2573263c967f8379b48
     tree_sha: 0bfeb3740a507bb35566b1e9ced7307020dda36c
     committed: 2023-04-17 19:16:00.000000000 +00:00
-    date: 04/17/23
+    date: '2023-04-17'
   2.36.0:
     commit_sha: 4ae3003ba571338cf247649b803f9718be42e537
     tree_sha: f184b2be71dda002aa77fd4e4e37a0d7399767b3
     committed: 2022-04-18 05:21:51.000000000 +00:00
-    date: 04/18/22
+    date: '2022-04-18'
   2.36.1:
     commit_sha: 89753168fae3a40aa6edad841d68a912498fd7c2
     tree_sha: dc3d0156b95303a305c69ba9113c94ff114b7cd3
     committed: 2022-05-05 21:36:37.000000000 +00:00
-    date: 05/05/22
+    date: '2022-05-05'
   2.36.2:
     commit_sha: 3cd3c6ebe9469676746364818c1a7173b37bef03
     tree_sha: 2853cd151ea2b12ca2d62d7f24a5877c9e4961c0
     committed: 2022-06-23 10:40:44.000000000 +00:00
-    date: 06/23/22
+    date: '2022-06-23'
   2.36.3:
     commit_sha: 71f947ba7929720d84aaacbd6d80feac16842ad8
     tree_sha: a64be4c03e2ff08fb15ee74d79804774c65d6e32
     committed: 2022-10-06 21:45:10.000000000 +00:00
-    date: 10/06/22
+    date: '2022-10-06'
   2.36.4:
     commit_sha: d96f63402618257de03b0b34f39526b8c6c3103d
     tree_sha: 45a3b23c89630c5f56acb477f9ff636c434cee47
     committed: 2022-12-13 12:19:24.000000000 +00:00
-    date: 12/13/22
+    date: '2022-12-13'
   2.36.5:
     commit_sha: e607ffe325caae5de63a9489105c27791df3f57b
     tree_sha: 5c48349fbfcc706d1f54e6823f4f481c40c8f4ec
     committed: 2023-02-06 08:37:53.000000000 +00:00
-    date: 02/06/23
+    date: '2023-02-06'
   2.36.6:
     commit_sha: c1299efdcc5c722206ada5e6eeb8be9aca0aaaed
     tree_sha: c2aec2a23517a7d660da393c8c59669d673ddef6
     committed: 2023-04-17 19:16:03.000000000 +00:00
-    date: 04/17/23
+    date: '2023-04-17'
   2.37.0:
     commit_sha: ffaf52ec9d9e1b9b119753559f70b7ae266cfc7a
     tree_sha: a4a2aa60ab45e767b52a26fc80a0a576aef2a010
     committed: 2022-06-27 16:17:55.000000000 +00:00
-    date: 06/27/22
+    date: '2022-06-27'
   2.37.1:
     commit_sha: 301f633c63bc9e5c55fc428f281bc8598dbd7e79
     tree_sha: 430fb9dda5d208ab2621c723a6711f9122f8b25e
     committed: 2022-07-04 20:45:08.000000000 +00:00
-    date: 07/04/22
+    date: '2022-07-04'
   2.37.2:
     commit_sha: 31522284abaed82ec22567d3905a4fc2c02db14f
     tree_sha: 490f5997dae9e8998f874ff249092f350c694eb9
     committed: 2022-08-11 04:52:36.000000000 +00:00
-    date: '08/11/22'
+    date: '2022-08-11'
   2.37.3:
     commit_sha: bd4f5110c66aa8c439ffa1c6a369710ca76bdde2
     tree_sha: e06bd907d0ec0ac9de664e74d78f0a8fb4b58bd3
     committed: 2022-08-30 17:22:10.000000000 +00:00
-    date: '08/30/22'
+    date: '2022-08-30'
   2.37.4:
     commit_sha: '0968e3909345fd8564a51d5dc74b24bb8bfbeffa'
     tree_sha: 9573b8a92526089f11764672741eb875b73b17c7
     committed: 2022-10-06 23:58:33.000000000 +00:00
-    date: 10/06/22
+    date: '2022-10-06'
   2.37.5:
     commit_sha: 0ddfdceab2cb2ea07765b2fd6ceab8dfb97d67ce
     tree_sha: 1d54409b704e64d90d22e782cdcf7e96aaed3bd7
     committed: 2022-12-13 12:20:47.000000000 +00:00
-    date: 12/13/22
+    date: '2022-12-13'
   2.37.6:
     commit_sha: 290881ac9ebea84c6c5e3b60078bb31fb0433d43
     tree_sha: b287d9a0d61d33db0ac2a04244fcdc960cb7c0c6
     committed: 2023-02-06 08:38:32.000000000 +00:00
-    date: 02/06/23
+    date: '2023-02-06'
   2.37.7:
     commit_sha: bc24c502ea9142e8f3a35fc52b1c0a0071200a6f
     tree_sha: 04cb334968c26542856141bd8e245ecc1bb4cdd5
     committed: 2023-04-17 19:16:05.000000000 +00:00
-    date: 04/17/23
+    date: '2023-04-17'
   2.38.0:
     commit_sha: ef268c1f84d61feedc177ebb55f32ed1dde705be
     tree_sha: 17f1b818715fb25bbdf8c9f83261c9ce9317fd31
     committed: 2022-10-02 15:43:56.000000000 +00:00
-    date: 10/02/22
+    date: '2022-10-02'
   2.38.1:
     commit_sha: 9b4febb68072d3df23e9cc06fc3cea7845dc936c
     tree_sha: 29842e04945d11eaff51bdb8aadcc6d754177076
     committed: 2022-10-07 00:00:33.000000000 +00:00
-    date: 10/07/22
+    date: '2022-10-07'
   2.38.2:
     commit_sha: 30817e9f820c84385a62b47b3732ca059f213e48
     tree_sha: 128dc4d18b44356d98d72526d8284fc0eaa0471a
     committed: 2022-12-11 00:32:48.000000000 +00:00
-    date: 12/11/22
+    date: '2022-12-11'
   2.38.3:
     commit_sha: 5d670e267352d49b90192a59733d8263765c6493
     tree_sha: 033c779c08009fe085e85c51fca0aec6a7c8142e
     committed: 2022-12-13 12:24:14.000000000 +00:00
-    date: 12/13/22
+    date: '2022-12-13'
   2.38.4:
     commit_sha: 6d019bf2d21a77ef869141eb01a63c7b75c33b1d
     tree_sha: 3bd807bf7795806bc4975d37728cef6a9060869a
     committed: 2023-02-06 08:43:30.000000000 +00:00
-    date: 02/06/23
+    date: '2023-02-06'
   2.38.5:
     commit_sha: '0586476e09a02303693fed1b03f8153df97e5001'
     tree_sha: 9b67735938a1b39bee28bd96a7504d090ed3615b
     committed: 2023-04-17 19:16:07.000000000 +00:00
-    date: 04/17/23
+    date: '2023-04-17'
   2.39.0:
     commit_sha: '081c686fea3ad65ddcfe7cc1fe5c9787c5f3cf9f'
     tree_sha: 18fc2034c1b8dbe85f4f813ebb73eb46e8027caf
     committed: 2022-12-12 00:59:08.000000000 +00:00
-    date: 12/12/22
+    date: '2022-12-12'
   2.39.1:
     commit_sha: 4ba47a70426332b35eb66d6f4663eb816543049f
     tree_sha: ee521150bc3b3f45b2d7454649696b566eab2f46
     committed: 2022-12-13 12:25:28.000000000 +00:00
-    date: 12/13/22
+    date: '2022-12-13'
   2.39.2:
     commit_sha: 485a869c64a68cc5795dd99689797c5900f4716d
     tree_sha: 439da52f5aa26cbd625b870bf9754f95069d0c95
     committed: 2023-02-06 08:43:41.000000000 +00:00
-    date: 02/06/23
+    date: '2023-02-06'
   2.39.3:
     commit_sha: 39f241519f9a3346372eade7bab019f35c2eff88
     tree_sha: 4c076d0ceb8795b217741e066f07a7267956067b
     committed: 2023-04-17 19:16:08.000000000 +00:00
-    date: 04/17/23
+    date: '2023-04-17'
   2.39.4:
     commit_sha: bf3293b92e48a9fb2e1e86a57dde100920fbfa10
     tree_sha: 58b8a47acdb13d5a1e654bdf89f99a9b2788cffa
     committed: 2024-04-19 10:38:33.000000000 +00:00
-    date: 04/19/24
+    date: '2024-04-19'
   2.39.5:
     commit_sha: a622a3b35cdd26de91f55bfd7dac49f23593d825
     tree_sha: e75563d332976e4065afdb3344067d821b92e1eb
     committed: 2024-05-30 23:52:52.000000000 +00:00
-    date: 05/30/24
+    date: '2024-05-30'
   2.40.0:
     commit_sha: d4ca2e3147b409459955613c152220f4db848ee1
     tree_sha: 7c102aa9fb0a549ce6c114c344f0ec6fd6809595
     committed: 2023-03-12 21:34:41.000000000 +00:00
-    date: 03/12/23
+    date: '2023-03-12'
   2.40.1:
     commit_sha: 2df31abb3c37155debb96d121b3d76f26bd8526b
     tree_sha: 7e6e8f435b01989a8c1c9f1b569ced6d1a5d067f
     committed: 2023-04-17 19:16:10.000000000 +00:00
-    date: 04/17/23
+    date: '2023-04-17'
   2.40.2:
     commit_sha: a8506c743b605b62fa515ce9945803a08ea6ab99
     tree_sha: bbb5e786546d52ee6d4e3dd4dec5922145c302ef
     committed: 2024-04-19 10:38:38.000000000 +00:00
-    date: 04/19/24
+    date: '2024-04-19'
   2.40.3:
     commit_sha: f7d5d2b71e6a82c509a82482e77819d4d71f6d18
     tree_sha: 64f46d83b7641071802964f8144a7fdf4d8f1482
     committed: 2024-05-30 23:57:31.000000000 +00:00
-    date: 05/30/24
+    date: '2024-05-30'
   2.41.0:
     commit_sha: 32d03a12c77c1c6e0bbd3f3cfe7f7c7deaf1dc5e
     tree_sha: a8a578ecdef9e856bf9351d95819981184bec16f
     committed: 2023-06-01 06:28:26.000000000 +00:00
-    date: 06/01/23
+    date: '2023-06-01'
   2.41.1:
     commit_sha: b7a9f9c4c03329408717282815e79fc4bc9d7992
     tree_sha: 235d93ffcc1a6ba35f90efdfcc1de8531683a12e
     committed: 2024-04-19 10:38:43.000000000 +00:00
-    date: 04/19/24
+    date: '2024-04-19'
   2.41.2:
     commit_sha: 31d54373ad8142bce7779bebb978f254929592c5
     tree_sha: 7e7eb33af6469fa0747523a6de80691e18d93a64
     committed: 2024-05-31 00:00:29.000000000 +00:00
-    date: 05/31/24
+    date: '2024-05-31'
   2.42.0:
     commit_sha: cf8a07e482fa5f8aa31a25dd8e9ecfcea18aaa1f
     tree_sha: ec44278158a284553bcd943ecb8ab9a791a95a80
     committed: 2023-08-21 16:34:58.000000000 +00:00
-    date: '08/21/23'
+    date: '2023-08-21'
   2.42.1:
     commit_sha: d57c5329d6549c5656c4b7e77d7e630fb2c3126d
     tree_sha: b75696b4d737ac478075a85e69a91306e28c131d
     committed: 2023-11-02 07:59:16.000000000 +00:00
-    date: 11/02/23
+    date: '2023-11-02'
   2.42.2:
     commit_sha: 703f477e2a4cd7e5225a23ee177edcaa7ac077aa
     tree_sha: 28c083318e6936fccbdba0b16edbfffa071300a6
     committed: 2024-04-19 10:38:48.000000000 +00:00
-    date: 04/19/24
+    date: '2024-04-19'
   2.42.3:
     commit_sha: f9b0dce23dd9ee264133e29402a6305dd90d9404
     tree_sha: 92cbccda9478f81c90273613b71672d699d45f65
     committed: 2024-05-31 00:03:31.000000000 +00:00
-    date: 05/31/24
+    date: '2024-05-31'
   2.43.0:
     commit_sha: c089584ac8dedc3aa7c2c404839bc098050298a2
     tree_sha: 203ad4fd3f91e9990c72a65d820068d4ccbdac4f
     committed: 2023-11-20 01:28:15.000000000 +00:00
-    date: 11/20/23
+    date: '2023-11-20'
   2.43.1:
     commit_sha: 9c98e72e0329036735d6b873b88d0d840f5d8214
     tree_sha: bdbc25c9c43df42121a1cec69dd5cf4feaf5b274
     committed: 2024-02-09 00:22:12.000000000 +00:00
-    date: 02/09/24
+    date: '2024-02-09'
   2.43.2:
     commit_sha: fa5abd7cde36a96a0382823a474990e3fe57d227
     tree_sha: 802e2b628fe9eeb49ed53a4060d395c1a4a7d1c3
     committed: 2024-02-13 22:44:51.000000000 +00:00
-    date: 02/13/24
+    date: '2024-02-13'
   2.43.3:
     commit_sha: e8575b54b66b31f09046fd7184ee5d33f183a966
     tree_sha: e432a0cbfb7690156c3d417f9bc5b5e7d506e8aa
     committed: 2024-02-23 00:13:38.000000000 +00:00
-    date: 02/23/24
+    date: '2024-02-23'
   2.43.4:
     commit_sha: 7394f4f2acdf7453ee6276c73e04f601cc8398f1
     tree_sha: 672d462ba07d32bdcf8feb1ece676f3b304966ef
     committed: 2024-04-19 10:38:52.000000000 +00:00
-    date: 04/19/24
+    date: '2024-04-19'
   2.43.5:
     commit_sha: 1cc8979c261f706a7931530cf636cbf9aa3076d6
     tree_sha: b84eb40ac9304353c17e14ef018c03161503ba73
     committed: 2024-05-31 00:06:24.000000000 +00:00
-    date: 05/31/24
+    date: '2024-05-31'
   2.44.0:
     commit_sha: 400ca53f4bafa3cf0c15e27d86ccbd18e3c04599
     tree_sha: 81d85707e35634e0afa1acc943d5ac44b2767c2d
     committed: 2024-02-23 00:14:53.000000000 +00:00
-    date: 02/23/24
+    date: '2024-02-23'
   2.44.1:
     commit_sha: 78594763ce07f52dfdd4802e2e609d60e7d296fd
     tree_sha: 399b1f2b49d237ffd8725eb066c6ff4b33e07d4d
     committed: 2024-04-19 10:38:56.000000000 +00:00
-    date: 04/19/24
+    date: '2024-04-19'
   2.44.2:
     commit_sha: 01a825578e79203a87b832731ed1fc7c23a3e77f
     tree_sha: ff160aeecbae27eb6a0752702e00ba4a1c32149d
     committed: 2024-05-31 00:16:34.000000000 +00:00
-    date: 05/31/24
+    date: '2024-05-31'
   2.45.0:
     commit_sha: 8be58deda2ccce7d036072ec34439f9fad88204f
     tree_sha: 438f12e893b21682101337e58b250c762022170a
     committed: 2024-04-29 14:30:29.000000000 +00:00
-    date: 04/29/24
+    date: '2024-04-29'
   2.45.1:
     commit_sha: 52c30914cbfa90105d8f0cefffa5b1c611821d34
     tree_sha: 1c36d77e98bd9c0067841954f8000dbd8cdfd348
     committed: 2024-04-29 18:42:46.000000000 +00:00
-    date: 04/29/24
+    date: '2024-04-29'
   2.45.2:
     commit_sha: 156e3c39e3948cf65ec7476c937a2b6f5d0ec281
     tree_sha: fe5721ebe96d0d7d3278d762237bea7e590ff036
     committed: 2024-05-31 00:18:43.000000000 +00:00
-    date: 05/31/24
+    date: '2024-05-31'
   2.46.0:
     commit_sha: 75a062f03c1c151fb46427b44cc0c7d89a5fc73d
     tree_sha: e5380a155df5f6cf0cb3a9b37df2e43284923eee
     committed: 2024-07-29 14:14:09.000000000 +00:00
-    date: 07/29/24
+    date: '2024-07-29'
   2.46.1:
     commit_sha: a372972baef250595e1fc4d40fee841b4e333222
     tree_sha: 4088ad4870da72ba86e62a1bdc2ad9472b26bdb8
     committed: 2024-09-13 22:26:52.000000000 +00:00
-    date: '09/13/24'
+    date: '2024-09-13'
   2.46.2:
     commit_sha: 466b63bd086c499668f5a0ec7f4ff8cdbbe7c32a
     tree_sha: ddffa72fcc8e3352ca422c57758bbe0cb0b13024
     committed: 2024-09-23 17:33:01.000000000 +00:00
-    date: '09/23/24'
+    date: '2024-09-23'
   2.47.0:
     commit_sha: 4ec4435df758668055cc904ef64c275bc8d1089b
     tree_sha: e4e659abcf688f66c03918bfaf0ada121e850ff1
     committed: 2024-10-06 22:56:06.000000000 +00:00
-    date: 10/06/24
+    date: '2024-10-06'
   2.47.1:
     commit_sha: 316fc8e77222aeba6c4afb3bec43bf2e1e93ef14
     tree_sha: 31ad9e4f39e1694633ff30d7e0f6e6a0716c7988
     committed: 2024-11-25 03:32:21.000000000 +00:00
-    date: 11/25/24
+    date: '2024-11-25'
   2.48.0:
     commit_sha: e42a29c4b39962e03c43b7ee6e32fd81ce8315a3
     tree_sha: 9d6497bb29ce5185c54eac86d5e54847ddeb4039
     committed: 2025-01-10 17:20:20.000000000 +00:00
-    date: 01/10/25
+    date: '2025-01-10'
   2.40.4:
     commit_sha: 6ac5b341b89be0dbabb8780a8e89d1bb59dcb535
     tree_sha: 811b2d30f5a93f890425bbb7daad0b062951d95d
     committed: 2024-11-26 21:14:57.000000000 +00:00
-    date: 11/26/24
+    date: '2024-11-26'
   2.41.3:
     commit_sha: 7e122199d2fac08cec62e6f9ef0edec53075c426
     tree_sha: b700b110215087c44b57975e668eed6bcb271068
     committed: 2024-11-26 21:14:58.000000000 +00:00
-    date: 11/26/24
+    date: '2024-11-26'
   2.42.4:
     commit_sha: 192c4a60a726ab6016eabf9d770891893b075bbc
     tree_sha: b92581d4d850882eb78666b8f333bc1a92b7ad29
     committed: 2024-11-26 21:14:58.000000000 +00:00
-    date: 11/26/24
+    date: '2024-11-26'
   2.43.6:
     commit_sha: 6783e1c66ae63b78a3eadd33cca3c6a9376ba7b2
     tree_sha: a9c8346dc6ba5c037669461e2416a048edb8d756
     committed: 2024-11-26 21:14:59.000000000 +00:00
-    date: 11/26/24
+    date: '2024-11-26'
   2.44.3:
     commit_sha: ba064fe15df005e17e0f44be73670c1353e5bf67
     tree_sha: decea4be0d4bf98f624fa02cad1674faa37db9f0
     committed: 2024-11-26 21:15:00.000000000 +00:00
-    date: 11/26/24
+    date: '2024-11-26'
   2.45.3:
     commit_sha: 3946f9147477c65cc97d6cd23bc403cdaf2206b0
     tree_sha: 7f2b90e9411201ec515bffc79c9abeffb46d4b04
     committed: 2024-11-26 21:15:00.000000000 +00:00
-    date: 11/26/24
+    date: '2024-11-26'
   2.46.3:
     commit_sha: b58a7f57fe93dd97b44a9dbf5dc2e54c55ca05e6
     tree_sha: d4b0b69a843f20f977ec85d7c611066b9947a341
     committed: 2024-11-26 21:15:01.000000000 +00:00
-    date: 11/26/24
+    date: '2024-11-26'
   2.47.2:
     commit_sha: 237a7b6739ea4bcdbf3e234be1bb5c0157b016b3
     tree_sha: 51ed041a189c9fdbd36b26e1e8a5388b887417d7
     committed: 2024-11-26 21:15:02.000000000 +00:00
-    date: 11/26/24
+    date: '2024-11-26'
   2.48.1:
     commit_sha: 6768cd3982a5cf8df192224d4da8c3f03d4cb964
     tree_sha: 809d7245607d77c09eb3fd2a2a45f7592a984a6c
     committed: 2025-01-13 20:57:19.000000000 +00:00
-    date: 01/13/25
+    date: '2025-01-13'
   2.49.0:
     commit_sha: 8c9ea59d6eeabbfc5642d99353fce2192645ba1c
     tree_sha: 36e1e0124ae1e88ff2337c8a5b6a2f4a46517200
     committed: 2025-03-14 16:19:41.000000000 +00:00
-    date: 03/14/25
+    date: '2025-03-14'
 pages:
   SubmittingPatches:
     version-map:

--- a/script/update-docs.rb
+++ b/script/update-docs.rb
@@ -322,7 +322,7 @@ def index_doc(filter_tags, doc_list, get_content)
     version_data["commit_sha"] = commit_sha
     version_data["tree_sha"] = tree_sha
     version_data["committed"] = ts
-    version_data["date"] = ts.strftime("%m/%d/%y")
+    version_data["date"] = ts.strftime("%Y-%m-%d")
 
     ext = Version.version_to_num(version) < 2_490_000 ? 'txt' : 'adoc'
     tag_files = doc_list.call(tree_sha)


### PR DESCRIPTION
## Changes

The script script/update-git-version.rb already uses ISO-8601 dates,
which are less confusing for most people.

Update script/update-docs.rb to use ISO-8601 date format too.

## Context

![image](https://github.com/user-attachments/assets/1e659f8b-7eb2-46da-8fca-f8e9026cf490)
