### PR TITLE
`.js`/`.css` fixes

### DIFF
--- a/assets/js/application.js
+++ b/assets/js/application.js
@@ -343,11 +343,11 @@ var Search = {
     (async () => {
       const pagefindURL =
         `${baseURLPrefix}pagefind/pagefind.js`
-	  // adjust the `baseURLPrefix` if it is relative: the `import`
-	  // is relative to the _script URL_ here, which is in /js/.
-	  // That is different from other uses of `baseURLPrefix`, which
-	  // replace `href` and `src` attributes which are relative to the
-	  // page itself that is outside of /js/.
+          // adjust the `baseURLPrefix` if it is relative: the `import`
+          // is relative to the _script URL_ here, which is in /js/.
+          // That is different from other uses of `baseURLPrefix`, which
+          // replace `href` and `src` attributes which are relative to the
+          // page itself that is outside of /js/.
           .replace(/^\.\//, '../')
       Search.pagefind = await import(pagefindURL);
       const options = {

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -64,8 +64,8 @@
 
   <link href="{{ relURL "favicon.ico" }}" rel='shortcut icon' type='image/x-icon'>
 
-  {{ $style := resources.Get "sass/application.scss" | resources.ExecuteAsTemplate "application.scss" . | css.Sass | resources.Minify }}
-  <link rel="stylesheet" href="{{ $style.RelPermalink }}">
+  {{ $style := resources.Get "sass/application.scss" | resources.ExecuteAsTemplate "application.scss" . | css.Sass | resources.Minify | fingerprint }}
+  <link rel="stylesheet" href="{{ $style.RelPermalink }}"{{ if (hasPrefix .Site.BaseURL "https://") }} integrity="{{ $style.Data.Integrity }}"{{ end }}>
   <!--[if (gte IE 6)&(lte IE 8)]>
   <script src="{{ relURL "js/selectivizr-min.js" }}"></script>
   <![endif]-->

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -18,5 +18,5 @@
 <script src="{{ relURL "js/modernizr.js" }}"></script>
 <script src="{{ relURL "js/modernize.js" }}"></script>
 {{ if eq (.Scratch.Get "section") "search" }}<script src="{{ relURL "pagefind/pagefind-ui.js" }}"></script>{{ end }}
-{{ $js := resources.Get "js/application.js" | resources.ExecuteAsTemplate "js/application.js" . | resources.Minify }}
-<script src="{{ $js.RelPermalink }}"></script>
+{{ $js := resources.Get "js/application.js" | resources.ExecuteAsTemplate "js/application.js" . | resources.Minify | fingerprint }}
+<script src="{{ $js.RelPermalink }}"{{ if (hasPrefix .Site.BaseURL "https://") }} integrity="{{ $js.Data.Integrity }}"{{ end }}></script>

--- a/tests/git-scm.spec.js
+++ b/tests/git-scm.spec.js
@@ -254,7 +254,7 @@ test('404', async ({ page }) => {
   await expect(page.locator('.inner h1')).toHaveText(`That page doesn't exist.`)
 
   // the 404 page should be styled
-  await expect(page.locator('link[rel="stylesheet"]')).toHaveAttribute('href', /application(\.min)?\.css$/)
+  await expect(page.locator('link[rel="stylesheet"]')).toHaveAttribute('href', /application(\.min)?(\.[0-9a-f]+)?\.css$/)
 
   // the search box is shown
   await expect(page.locator('#search-text')).toBeVisible()


### PR DESCRIPTION
## Changes

- Implement Cache Busting for the `.js`/`.css` files.

## Context

When new versions of the JavaScript and CSS files are deployed, for a while some users' browsers will still hold onto cached versions of them and the style or JavaScript-based functionality might still be messed up. Even if the browser caches do not have the stale files, the CDN still might have them.

To avoid running afoul of stale cached versions of these files, employ the simple-yet-effective method of using a filename suffix that is based on the file's contents. That way, there cannot be a stale cached copy of the file under the same filename.

While at it, fix the indentation of the JavaScript file which I had inadvertently made incorrect in https://github.com/git/git-scm.com/pull/1980.