### PR TITLE
content/about/trademark.html: update trademark policy

### DIFF
--- a/content/about/trademark.html
+++ b/content/about/trademark.html
@@ -131,10 +131,14 @@ aliases:
 
   <p>In addition, you may not use any of the Marks as a syllable in a new word
   or as part of a portmanteau (e.g., "Gitalicious", "Gitpedia") used as a
-  mark for a third-party product or service without Conservancy's written
-  permission.  For the avoidance of doubt, this provision applies even to
-  third-party marks that use the Marks as a syllable or as part of a
-  portmanteau to refer to a product or service's use of Git code.</p>
+  mark for a third-party product or service. For the avoidance of doubt, this
+  provision applies even to third-party marks that use the Marks as a syllable
+  or as part of a portmanteau to refer to a product or service's use of Git
+  code.</p>
+
+  <p>Please be aware that GitHub and GitLab are exceptions to this Policy
+  because they are subject to explicit licensing arrangements that pre-date, and
+  thus take precedence, over this Policy.</p>
 
   <h4>2.4 Limitations to this Policy</h4>
 
@@ -147,10 +151,9 @@ aliases:
 
   <h4>2.5 Use of the Marks in merchandising</h4>
 
-  <p>You may not create and/or sell merchandise bearing any of the Marks
-  without Conservancy's express written permission.  If you are interested
-  in using creating and/or selling merchandise bearing any of the the Marks,
-  please send proofs of your designs to us at
+  <p>You may not create and/or sell merchandise bearing any of the Marks. If
+  you are interested in using creating and/or selling merchandise bearing any of
+  the Marks, please send proofs of your designs to us at
   <a href="mailto:trademark@sfconservancy.org">TRADEMARK@SFCONSERVANCY.ORG</a>.
   </p>
 


### PR DESCRIPTION
Git's existing trademark policy forbids using the Mark as a syllable in another word or portmanteau "without Conservancy's written permission". It similarly forbids creating and/or selling merchandise "without Conservancy's expression written permission".

The quoted portions of the Policy have no legal effect, because a trademark owner may always give permission regardless of whatever policy might be in place. But they have the unintended side-effect of encouraging others to write to Conservancy and ask for an exception to one and/or the other, though such an exception is rarely (if ever) granted.

Remove that portion of the trademark policy, and add a new one explaining that GitHub and GitLab are historical exceptions to the policy.

Acked-by: Junio C Hamano \<gitster@pobox.com\>
Acked-by: Christian Couder \<christian.couder@gmail.com\>