### PR TITLE
dark-mode: allow following the system preference again

### DIFF
--- a/assets/js/application.js
+++ b/assets/js/application.js
@@ -643,7 +643,8 @@ var DarkMode = {
         theme = document.documentElement.dataset.theme === "dark" ? "light" : "dark"
       }
       document.documentElement.dataset.theme = theme
-      localStorage.setItem("theme", theme);
+      if (prefersDarkScheme === (theme === "dark")) localStorage.removeItem("theme");
+      else localStorage.setItem("theme", theme);
       button.attr("src", `${baseURLPrefix}images/${theme === "dark" ? "light" : "dark"}-mode.svg`);
     });
   },

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -49,7 +49,8 @@
     if (currentTheme) {
       // Check dark mode preference at the OS level
       const prefersDarkScheme = window.matchMedia("(prefers-color-scheme: dark)").matches
-      if ((prefersDarkScheme && currentTheme === "light")
+      if (prefersDarkScheme === (currentTheme === "dark")) localStorage.removeItem("theme")
+      else if ((prefersDarkScheme && currentTheme === "light")
         || (!prefersDarkScheme && currentTheme === "dark")) {
 	document.documentElement.dataset.theme = currentTheme
       }


### PR DESCRIPTION
## Changes

- With this PR, the user preference regarding dark mode will only be stored when it differs from the system, otherwise no user preference will be stored (because it is not necessary, and it accommodates for situations where the user toggles the system preference back and forth).

## Context

After toggling dark mode on and off again, a subsequent change of the system preference to dark mode will currently not be respected because the manual toggling stored the user's preference as "light mode", no matter what the system preference is.

Let's store the user preference only when it differs from the system preference. That way, in the scenario above the system preference would be followed again.

/cc @To1ne 