### PR TITLE
Adjust the Windows download links

### DIFF
--- a/content/downloads/win.html
+++ b/content/downloads/win.html
@@ -8,26 +8,26 @@ aliases:
 <div id="main">
   <h1>Download for Windows</h1>
   <p>
-  <strong><a id="auto-download-link" href="{{< site-param windows_installer.installer64.url >}}">Click here to download </a></strong>
-    the latest (<strong id="auto-download-version">{{< site-param windows_installer.installer64.version >}}</strong>)
-    <strong id="auto-download-bitness">64-bit</strong> version of <strong>Git for Windows</strong>.
+  <strong><a id="auto-download-link" href="{{< site-param windows_installer.installer_x64.url >}}">Click here to download </a></strong>
+    the latest (<strong id="auto-download-version">{{< site-param windows_installer.installer_x64.version >}}</strong>)
+    <strong id="auto-download-architecture">x64</strong> version of <strong>Git for Windows</strong>.
     This is the most recent <a href="https://git-for-windows.github.io/">maintained build</a>.
-    It was released <span id="relative-release-date"></span>on <span id="auto-download-date">{{< site-param windows_installer.installer64.release_date >}}</span>.
+    It was released <span id="relative-release-date"></span>on <span id="auto-download-date">{{< site-param windows_installer.installer_x64.release_date >}}</span>.
   </p>
   <h3>Other Git for Windows downloads</h3>
   <h4>Standalone Installer</h4>
   <p>
-  <strong><a href="{{< site-param windows_installer.installer32.url >}}">32-bit Git for Windows Setup</a>.</strong>
+    <strong><a href="{{< site-param windows_installer.installer_x64.url >}}">Git for Windows/x64 Setup</a>.</strong>
   </p>
   <p>
-    <strong><a href="{{< site-param windows_installer.installer64.url >}}">64-bit Git for Windows Setup</a>.</strong>
+    <strong><a href="{{< site-param windows_installer.installer_arm64.url >}}">Git for Windows/ARM64 Setup</a>.</strong>
   </p>
   <h4>Portable ("thumbdrive edition")</h4>
   <p>
-    <strong><a href="{{< site-param windows_installer.portable32.url >}}">32-bit Git for Windows Portable</a>.</strong>
+    <strong><a href="{{< site-param windows_installer.portable_x64.url >}}">Git for Windows/x64 Portable</a>.</strong>
   </p>
   <p>
-    <strong><a href="{{< site-param windows_installer.portable64.url >}}">64-bit Git for Windows Portable</a>.</strong>
+    <strong><a href="{{< site-param windows_installer.portable_arm64.url >}}">Git for Windows/ARM64 Portable</a>.</strong>
   </p>
   <h4>Using winget tool</h4>
   <p>

--- a/hugo.yml
+++ b/hugo.yml
@@ -62,3 +62,23 @@ params:
       release_date: '2025-03-17'
       version: 2.49.0
       url: https://github.com/git-for-windows/git/releases/download/v2.49.0.windows.1/Git-2.49.0-64-bit.exe
+    installer_x64:
+      filename: Git-2.49.0-64-bit.exe
+      release_date: '2025-03-17'
+      version: 2.49.0
+      url: https://github.com/git-for-windows/git/releases/download/v2.49.0.windows.1/Git-2.49.0-64-bit.exe
+    installer_arm64:
+      filename: Git-2.49.0-arm64.exe
+      release_date: '2025-03-17'
+      version: 2.49.0
+      url: https://github.com/git-for-windows/git/releases/download/v2.49.0.windows.1/Git-2.49.0-arm64.exe
+    portable_x64:
+      filename: PortableGit-2.49.0-64-bit.7z.exe
+      release_date: '2025-03-17'
+      version: 2.49.0
+      url: https://github.com/git-for-windows/git/releases/download/v2.49.0.windows.1/PortableGit-2.49.0-64-bit.7z.exe
+    portable_arm64:
+      filename: PortableGit-2.49.0-arm64.7z.exe
+      release_date: '2025-03-17'
+      version: 2.49.0
+      url: https://github.com/git-for-windows/git/releases/download/v2.49.0.windows.1/PortableGit-2.49.0-arm64.7z.exe

--- a/hugo.yml
+++ b/hugo.yml
@@ -42,26 +42,6 @@ params:
     release_date: '2021-08-30'
     filename: git-2.33.0-intel-universal-mavericks.dmg
   windows_installer:
-    portable32:
-      filename: PortableGit-2.48.1-32-bit.7z.exe
-      release_date: '2025-02-13'
-      version: 2.48.1
-      url: https://github.com/git-for-windows/git/releases/download/v2.48.1.windows.1/PortableGit-2.48.1-32-bit.7z.exe
-    portable64:
-      filename: PortableGit-2.49.0-64-bit.7z.exe
-      release_date: '2025-03-17'
-      version: 2.49.0
-      url: https://github.com/git-for-windows/git/releases/download/v2.49.0.windows.1/PortableGit-2.49.0-64-bit.7z.exe
-    installer32:
-      filename: Git-2.48.1-32-bit.exe
-      release_date: '2025-02-13'
-      version: 2.48.1
-      url: https://github.com/git-for-windows/git/releases/download/v2.48.1.windows.1/Git-2.48.1-32-bit.exe
-    installer64:
-      filename: Git-2.49.0-64-bit.exe
-      release_date: '2025-03-17'
-      version: 2.49.0
-      url: https://github.com/git-for-windows/git/releases/download/v2.49.0.windows.1/Git-2.49.0-64-bit.exe
     installer_x64:
       filename: Git-2.49.0-64-bit.exe
       release_date: '2025-03-17'

--- a/layouts/partials/monitor.html
+++ b/layouts/partials/monitor.html
@@ -10,7 +10,7 @@
   <span class="release-date">
     ({{ .Site.Params.latest_release_date }})
   </span>
-  <span data-mac="{{ .Site.Params.macos_installer.version }}" data-win="{{ .Site.Params.windows_installer.installer64.version }}" id="installer-version"></span>
+  <span data-mac="{{ .Site.Params.macos_installer.version }}" data-win="{{ .Site.Params.windows_installer.installer_x64.version }}" id="installer-version"></span>
 
   <a href="https://www.kernel.org/pub/software/scm/git/" class="button" id="download-link">Download Source Code</a>
 </div>

--- a/script/update-download-data.rb
+++ b/script/update-download-data.rb
@@ -15,7 +15,7 @@ class DownloadData
   # name, version, url & date with Feedzirra
   SOURCEFORGE_URL = "https://sourceforge.net/projects/git-osx-installer/rss?limit=20"
 
-  GIT_FOR_WINDOWS_REGEX           = /^(Portable|)Git-(\d+\.\d+\.\d+(?:\.\d+)?)-(?:.+-)*(32|64)-bit(?:\..*)?\.exe/
+  GIT_FOR_WINDOWS_REGEX           = /^(Portable|)Git-(\d+\.\d+\.\d+(?:\.\d+)?)-(?:.+-)*(64-bit|arm64)(?:\..*)?\.exe/
   GIT_FOR_WINDOWS_NAME_WITH_OWNER = "git-for-windows/git"
 
   class << self
@@ -26,13 +26,14 @@ class DownloadData
     def update_download_windows_versions(config)
       files_from_github(GIT_FOR_WINDOWS_NAME_WITH_OWNER).each do |name, date, url|
         # Git for Windows uses the following naming system
-        # [Portable]Git-#.#.#.#[-dev-preview]-32/64-bit[.7z].exe
+        # [Portable]Git-#.#.#.#[-dev-preview]-64-bit/arm64[.7z].exe
         match = GIT_FOR_WINDOWS_REGEX.match(name)
 
         next unless match
 
         portable = match[1]
-        bitness  = match[3]
+        architecture = match[3]
+        architecture = "x64" if architecture == "64-bit"
 
         # Git for windows sometimes creates extra releases all based off of the same upstream Git version
         # so we first want to crop versions like 2.16.1.4 to just 2.16.1
@@ -44,9 +45,9 @@ class DownloadData
           config["windows_installer"] = {} if config["windows_installer"].nil?
           win_config = config["windows_installer"]
           if portable.empty?
-            key = "installer#{bitness}"
+            key = "installer_#{architecture}"
           else
-            key = "portable#{bitness}"
+            key = "portable_#{architecture}"
           end
           win_config[key] = {} if win_config[key].nil?
           return if version_compare(version, win_config[key]["version"]) < 0


### PR DESCRIPTION
## Changes

- Accommodate changes in Git for Windows when adjusting the download links.

## Context

Git for Windows v2.47.1 was the first version to provide an ARM64 version, and v2.49.0 stopped providing an i686 version. This needs to be reflected in the download link handling.

I got inspired to make this change by https://github.com/git-for-windows/git-for-windows.github.io/pull/61 of which this here PR is a natural companion.

@dennisameling would you mind testing (but not in Firefox, where this is known not to work) whether https://dscho.github.io/git-scm.com/downloads/win shows the ARM64 download link for you, i.e. _not_ the following?

![image](https://github.com/user-attachments/assets/0bb3ef4a-9d72-4dd4-b4f4-975cca004845)
