### PR TITLE
book: render the Persian translation right-to-left

### DIFF
--- a/assets/sass/book.scss
+++ b/assets/sass/book.scss
@@ -156,6 +156,10 @@ ol.book-toc {
   margin: -20px 40px 0 40px;
 }
 
+#content[dir="rtl"] .book-wrapper {
+  float: left;
+}
+
 @media (min-width: $mobile-m) {
   .book-toc {
     width: 60%

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -93,7 +93,7 @@
     <div class="inner">
       <div id="content-wrapper">
         {{ partial "sidebar.html" . }}
-        <div id="content">
+        <div id="content"{{ if eq "fa" .Params.book.language_code }} dir="rtl"{{ end }}>
           {{ if isset .Params.book "front_page" }}
             {{ partial "book-front-page.html" . }}
           {{ else }}


### PR DESCRIPTION
## Changes

- Render `book/fa/v2/` right-to-left.

## Context

The Persian translation needs to be rendered right-to-left, as suggested in https://github.com/progit/progit2-fa/pull/1#issuecomment-2816624433.

Here is how it looks:

|page|before|after|
|-|-|-|
|https://git-scm.com/book/fa/v2 ([preview](https://dscho.github.io/git-scm.com/book/fa/v2))|![image](https://github.com/user-attachments/assets/0e59b11f-5f10-411e-9c72-1f01ad3237e2)|![image](https://github.com/user-attachments/assets/932a0ef0-6fe1-4b16-aa2e-2e49c5c97c36)|
|https://dscho.github.io/git-scm.com/book/fa/v2/%d8%b4%d8%b1%d9%88%d8%b9-%d8%a8%d9%87-%da%a9%d8%a7%d8%b1-%d8%af%d8%b1%d8%a8%d8%a7%d8%b1%d9%87%d9%94-%da%a9%d9%86%d8%aa%d8%b1%d9%84-%d9%86%d8%b3%d8%ae%d9%87 ([preview](https://dscho.github.io/git-scm.com/book/fa/v2/%d8%b4%d8%b1%d9%88%d8%b9-%d8%a8%d9%87-%da%a9%d8%a7%d8%b1-%d8%af%d8%b1%d8%a8%d8%a7%d8%b1%d9%87%d9%94-%da%a9%d9%86%d8%aa%d8%b1%d9%84-%d9%86%d8%b3%d8%ae%d9%87))|![image](https://github.com/user-attachments/assets/76aed0b4-99c3-4f56-ba94-d8710b7c5139)|![image](https://github.com/user-attachments/assets/b14e038a-aeda-436f-b29a-0bf22b24dcd4)|
