### PR TITLE
Add credential helpers for Gmail, Outlook and Yahoo

### DIFF
--- a/content/doc/credential-helpers.html
+++ b/content/doc/credential-helpers.html
@@ -33,6 +33,9 @@ aliases:
   <ul>
     <li><a href="https://github.com/git-ecosystem/git-credential-manager">Git Credential Manager</a>: included with Git for Windows. Supports multiple credential stores.</li>
     <li><a href="https://github.com/hickford/git-credential-oauth">git-credential-oauth</a>: included in many Linux distributions.</li>
+    <li><a href="https://github.com/AdityaGarg8/git-credential-email">git-credential-gmail</a>: cross platform, can be used to authenticate Gmail accounts for <a href="https://git-scm.com/docs/git-send-email">git send-email</a>.</li>
+    <li><a href="https://github.com/AdityaGarg8/git-credential-email">git-credential-outlook</a>: cross platform, can be used to authenticate Microsoft Outlook accounts for <a href="https://git-scm.com/docs/git-send-email">git send-email</a>.</li>
+    <li><a href="https://github.com/AdityaGarg8/git-credential-email">git-credential-yahoo</a>: cross platform, can be used to authenticate Yahoo accounts for <a href="https://git-scm.com/docs/git-send-email">git send-email</a>.</li>
   </ul>
 
   <h2>Storage specific</h2>


### PR DESCRIPTION
## Changes

This PR adds links of OAuth2.0 based credential helpers for Gmail, Yahoo and Outlook

## Context

OAuth2.0 is a new and more secure way of authentication which many popular email providers are preferring over traditional app based passwords. Support for OAuth2.0 on git send email has been achieved and a documentation to use the same is also available here: https://github.com/git/git/commit/6eb746c6c2b17d3329e670a6a8aff5a5f2781b87

So, adding credential helpers for some popular email providers.