### PR TITLE
Add imap-send to the list of email helpers

### DIFF
--- a/data/doc_categories/email.yml
+++ b/data/doc_categories/email.yml
@@ -4,6 +4,7 @@ name: "Email"
 commands:
   - doc: "git-am"
   - doc: "git-apply"
+  - doc: "git-imap-send"
   - doc: "git-format-patch"
   - doc: "git-send-email"
   - doc: "git-request-pull"


### PR DESCRIPTION
## Changes

<!-- List the changes this PR makes. -->

- This PR adds the link of [git imap-send docs](https://git-scm.com/docs/git-imap-send) to the Email category on the main page.

## Context

git imap-send is a git command that enables a person to send an email in mbox format generated by git format-patch to a folder using IMAP.

Its link was missing from https://git-scm.com/docs