### PR TITLE
fix the fixups in historical mistakes in the documentation

### DIFF
--- a/script/update-docs.rb
+++ b/script/update-docs.rb
@@ -434,16 +434,16 @@ def index_doc(filter_tags, doc_list, get_content)
         content = expand_content((get_content.call sha).force_encoding("UTF-8"), path, get_content_f, generated, ext)
         # Handle `link:../howto/maintain-git.txt`, which should point to
         # a `.html` target instead
-        content.gsub!(/link:\.\.\/howto\/maintain-git\.#{ext}/, 'link:../howto/maintain-git.html')
+        content.gsub!(/link:\.\.\/howto\/maintain-git\.txt/, 'link:../howto/maintain-git.html')
         # Handle `gitlink:` mistakes (the last of which was fixed in
         # dbf47215e32b (rebase docs: fix "gitlink" typo, 2019-02-27))
         content.gsub!(/gitlink:/, "linkgit:")
         # Handle erroneous `link:api-trace2.txt`, see 4945f046c7f5 (api docs:
         # link to html version of api-trace2, 2022-09-16)
-        content.gsub!(/link:api-trace2.#{ext}/, 'link:api-trace2.html')
+        content.gsub!(/link:api-trace2.txt/, 'link:api-trace2.html')
         # Handle `linkgit:git-config.txt` mistake, fixed in ad52148a7d0
         # (Documentation: fix broken linkgit to git-config, 2016-03-21)
-        content.gsub!(/linkgit:git-config.#{ext}/, 'linkgit:git-config')
+        content.gsub!(/linkgit:git-config.txt/, 'linkgit:git-config')
         content.gsub!(/link:(?:technical\/)?(\S*?)\.html(\#\S*?)?\[(.*?)\]/m, "link:/docs/\\1\\2[\\3]")
 
         asciidoc = make_asciidoc(content)


### PR DESCRIPTION
The historical mistakes in the documentation were all referring to .txt files, not .adoc files.

We were too hasty to change the `.txt` suffix everywhere.