### PR TITLE
Changing link color in footer as it fixes #2015

### DIFF
--- a/assets/sass/layout.scss
+++ b/assets/sass/layout.scss
@@ -351,7 +351,7 @@ footer {
     color: var(--light-font-color-darker-35);
 
     &:hover {
-      color: var(--light-font-color-darker-55);
+      color: var(--orange);
     }
   }
 

--- a/assets/sass/layout.scss
+++ b/assets/sass/layout.scss
@@ -351,7 +351,7 @@ footer {
     color: var(--light-font-color-darker-35);
 
     &:hover {
-      color: var(--orange);
+      color: var(--link-color);
     }
   }
 


### PR DESCRIPTION
## Changes

<!-- List the changes this PR makes. -->
The color of the hyperlinks when hovered is changed to the orange (This orange is not actually orange in light theme as it is defined two color values in the [assets/sass/dark-mode.css](https://github.com/git/git-scm.com/blob/gh-pages/assets/sass/dark-mode.css).


## Context
This helps in better visibility as the previous color for the link hovering almost blended with the background
This was discussed with @dscho in issue #2015  
<!-- Explain why you're making these changes. -->
