### PR TITLE
Git Klient renamed to Kommit

### DIFF
--- a/data/guis/kommit.yml
+++ b/data/guis/kommit.yml
@@ -1,6 +1,6 @@
 ---
-name: "Git Klient"
-project_url: "https://invent.kde.org/sdk/gitklient"
+name: "Kommit"
+project_url: "https://invent.kde.org/sdk/kommit"
 image_tag: "images/guis/gitklient@2x.png"
 platforms:
   - "Linux"


### PR DESCRIPTION
## Changes

- Changes the entry in the GUIs page for Git Klient to Kommit, and updates links. (Does not update the screenshot, however)

## Context

- The project has been renamed to Kommit by SDK, and the old link in the GUIs page automatically redirects with a warning to update URLs