### PR TITLE
GUI: giggle is no longer in active development

### DIFF
--- a/data/guis/giggle.yml
+++ b/data/guis/giggle.yml
@@ -1,5 +1,5 @@
 ---
-name: "giggle"
+name: "giggle (no longer under active development)"
 project_url: "https://wiki.gnome.org/Apps/giggle/"
 image_tag: "images/guis/giggle@2x.png"
 platforms:


### PR DESCRIPTION
## Changes

- Mark the "giggle" client as "no longer in development"

## Context

The website points to https://gitlab.gnome.org/Archive/giggle, which is marked as "archived" ; [latest tag 0.7 is 12 years old](https://gitlab.gnome.org/Archive/giggle/-/tags) now.
