### PR TITLE
Update Hugo and Pagefind to their respective latest versions

### DIFF
--- a/content/blog/_index.html
+++ b/content/blog/_index.html
@@ -3,6 +3,9 @@ title: "Git - Blog Moved"
 section: "blog"
 layout: "default"
 sidebar: "blog"
+url: /blog.html
+aliases:
+- /blog/index.html
 ---
 
 <div id="main" class="blog">

--- a/content/downloads/_index.html
+++ b/content/downloads/_index.html
@@ -4,6 +4,8 @@ title: "Git - Downloads"
 url: /downloads.html
 aliases:
 - /downloads/index.html
+- /download/index.html
+- /download.html
 ---
 
 <div id="main">

--- a/content/downloads/guis/_index.html
+++ b/content/downloads/guis/_index.html
@@ -7,6 +7,8 @@ aliases:
 - /downloads/guis/index.html
 - /download/guis/index.html
 - /download/guis.html
+- /download/gui/index.html
+- /download/gui.html
 ---
 
 <div id="main">

--- a/content/videos/_index.html
+++ b/content/videos/_index.html
@@ -5,6 +5,8 @@ title: "Git - Videos"
 url: /videos.html
 aliases:
 - /videos/index.html
+- /video/index.html
+- /video.html
 ---
 
 <div id='main'>

--- a/external/book/content/book/az/v2/_index.html
+++ b/external/book/content/book/az/v2/_index.html
@@ -16,5 +16,7 @@ url: "/book/az/v2.html"
 aliases:
 - "/book/az/v2/index.html"
 - "/book/az/v1/index.html"
+- "/book/az/v1.html"
 - "/book/az/index.html"
+- "/book/az.html"
 ---

--- a/external/book/content/book/be/v2/_index.html
+++ b/external/book/content/book/be/v2/_index.html
@@ -16,5 +16,7 @@ url: "/book/be/v2.html"
 aliases:
 - "/book/be/v2/index.html"
 - "/book/be/v1/index.html"
+- "/book/be/v1.html"
 - "/book/be/index.html"
+- "/book/be.html"
 ---

--- a/external/book/content/book/bg/v2/_index.html
+++ b/external/book/content/book/bg/v2/_index.html
@@ -17,5 +17,7 @@ url: "/book/bg/v2.html"
 aliases:
 - "/book/bg/v2/index.html"
 - "/book/bg/v1/index.html"
+- "/book/bg/v1.html"
 - "/book/bg/index.html"
+- "/book/bg.html"
 ---

--- a/external/book/content/book/cs/v2/_index.html
+++ b/external/book/content/book/cs/v2/_index.html
@@ -14,5 +14,7 @@ url: "/book/cs/v2.html"
 aliases:
 - "/book/cs/v2/index.html"
 - "/book/cs/v1/index.html"
+- "/book/cs/v1.html"
 - "/book/cs/index.html"
+- "/book/cs.html"
 ---

--- a/external/book/content/book/de/v2/_index.html
+++ b/external/book/content/book/de/v2/_index.html
@@ -16,5 +16,7 @@ url: "/book/de/v2.html"
 aliases:
 - "/book/de/v2/index.html"
 - "/book/de/v1/index.html"
+- "/book/de/v1.html"
 - "/book/de/index.html"
+- "/book/de.html"
 ---

--- a/external/book/content/book/en/v2/_index.html
+++ b/external/book/content/book/en/v2/_index.html
@@ -16,7 +16,11 @@ url: "/book/en/v2.html"
 aliases:
 - "/book/en/v2/index.html"
 - "/book/en/v1/index.html"
+- "/book/en/v1.html"
 - "/book/en/index.html"
+- "/book/en.html"
 - "/book/index.html"
+- "/book.html"
 - "/book/v1/index.html"
+- "/book/v1.html"
 ---

--- a/external/book/content/book/es/v2/_index.html
+++ b/external/book/content/book/es/v2/_index.html
@@ -16,5 +16,7 @@ url: "/book/es/v2.html"
 aliases:
 - "/book/es/v2/index.html"
 - "/book/es/v1/index.html"
+- "/book/es/v1.html"
 - "/book/es/index.html"
+- "/book/es.html"
 ---

--- a/external/book/content/book/fa/v2/_index.html
+++ b/external/book/content/book/fa/v2/_index.html
@@ -14,5 +14,7 @@ url: "/book/fa/v2.html"
 aliases:
 - "/book/fa/v2/index.html"
 - "/book/fa/v1/index.html"
+- "/book/fa/v1.html"
 - "/book/fa/index.html"
+- "/book/fa.html"
 ---

--- a/external/book/content/book/fr/v2/_index.html
+++ b/external/book/content/book/fr/v2/_index.html
@@ -16,5 +16,7 @@ url: "/book/fr/v2.html"
 aliases:
 - "/book/fr/v2/index.html"
 - "/book/fr/v1/index.html"
+- "/book/fr/v1.html"
 - "/book/fr/index.html"
+- "/book/fr.html"
 ---

--- a/external/book/content/book/gr/v2/_index.html
+++ b/external/book/content/book/gr/v2/_index.html
@@ -17,5 +17,7 @@ url: "/book/gr/v2.html"
 aliases:
 - "/book/gr/v2/index.html"
 - "/book/gr/v1/index.html"
+- "/book/gr/v1.html"
 - "/book/gr/index.html"
+- "/book/gr.html"
 ---

--- a/external/book/content/book/id/v2/_index.html
+++ b/external/book/content/book/id/v2/_index.html
@@ -14,5 +14,7 @@ url: "/book/id/v2.html"
 aliases:
 - "/book/id/v2/index.html"
 - "/book/id/v1/index.html"
+- "/book/id/v1.html"
 - "/book/id/index.html"
+- "/book/id.html"
 ---

--- a/external/book/content/book/it/v2/_index.html
+++ b/external/book/content/book/it/v2/_index.html
@@ -16,5 +16,7 @@ url: "/book/it/v2.html"
 aliases:
 - "/book/it/v2/index.html"
 - "/book/it/v1/index.html"
+- "/book/it/v1.html"
 - "/book/it/index.html"
+- "/book/it.html"
 ---

--- a/external/book/content/book/ja/v2/_index.html
+++ b/external/book/content/book/ja/v2/_index.html
@@ -16,5 +16,7 @@ url: "/book/ja/v2.html"
 aliases:
 - "/book/ja/v2/index.html"
 - "/book/ja/v1/index.html"
+- "/book/ja/v1.html"
 - "/book/ja/index.html"
+- "/book/ja.html"
 ---

--- a/external/book/content/book/ko/v2/_index.html
+++ b/external/book/content/book/ko/v2/_index.html
@@ -16,5 +16,7 @@ url: "/book/ko/v2.html"
 aliases:
 - "/book/ko/v2/index.html"
 - "/book/ko/v1/index.html"
+- "/book/ko/v1.html"
 - "/book/ko/index.html"
+- "/book/ko.html"
 ---

--- a/external/book/content/book/mk/v2/_index.html
+++ b/external/book/content/book/mk/v2/_index.html
@@ -14,5 +14,7 @@ url: "/book/mk/v2.html"
 aliases:
 - "/book/mk/v2/index.html"
 - "/book/mk/v1/index.html"
+- "/book/mk/v1.html"
 - "/book/mk/index.html"
+- "/book/mk.html"
 ---

--- a/external/book/content/book/ms/v2/_index.html
+++ b/external/book/content/book/ms/v2/_index.html
@@ -14,5 +14,7 @@ url: "/book/ms/v2.html"
 aliases:
 - "/book/ms/v2/index.html"
 - "/book/ms/v1/index.html"
+- "/book/ms/v1.html"
 - "/book/ms/index.html"
+- "/book/ms.html"
 ---

--- a/external/book/content/book/nl/v2/_index.html
+++ b/external/book/content/book/nl/v2/_index.html
@@ -16,5 +16,7 @@ url: "/book/nl/v2.html"
 aliases:
 - "/book/nl/v2/index.html"
 - "/book/nl/v1/index.html"
+- "/book/nl/v1.html"
 - "/book/nl/index.html"
+- "/book/nl.html"
 ---

--- a/external/book/content/book/pl/v2/_index.html
+++ b/external/book/content/book/pl/v2/_index.html
@@ -16,5 +16,7 @@ url: "/book/pl/v2.html"
 aliases:
 - "/book/pl/v2/index.html"
 - "/book/pl/v1/index.html"
+- "/book/pl/v1.html"
 - "/book/pl/index.html"
+- "/book/pl.html"
 ---

--- a/external/book/content/book/pt-br/v2/_index.html
+++ b/external/book/content/book/pt-br/v2/_index.html
@@ -16,5 +16,7 @@ url: "/book/pt-br/v2.html"
 aliases:
 - "/book/pt-br/v2/index.html"
 - "/book/pt-br/v1/index.html"
+- "/book/pt-br/v1.html"
 - "/book/pt-br/index.html"
+- "/book/pt-br.html"
 ---

--- a/external/book/content/book/pt-pt/v2/_index.html
+++ b/external/book/content/book/pt-pt/v2/_index.html
@@ -14,5 +14,7 @@ url: "/book/pt-pt/v2.html"
 aliases:
 - "/book/pt-pt/v2/index.html"
 - "/book/pt-pt/v1/index.html"
+- "/book/pt-pt/v1.html"
 - "/book/pt-pt/index.html"
+- "/book/pt-pt.html"
 ---

--- a/external/book/content/book/ru/v2/_index.html
+++ b/external/book/content/book/ru/v2/_index.html
@@ -16,5 +16,7 @@ url: "/book/ru/v2.html"
 aliases:
 - "/book/ru/v2/index.html"
 - "/book/ru/v1/index.html"
+- "/book/ru/v1.html"
 - "/book/ru/index.html"
+- "/book/ru.html"
 ---

--- a/external/book/content/book/sl/v2/_index.html
+++ b/external/book/content/book/sl/v2/_index.html
@@ -16,5 +16,7 @@ url: "/book/sl/v2.html"
 aliases:
 - "/book/sl/v2/index.html"
 - "/book/sl/v1/index.html"
+- "/book/sl/v1.html"
 - "/book/sl/index.html"
+- "/book/sl.html"
 ---

--- a/external/book/content/book/sr/v2/_index.html
+++ b/external/book/content/book/sr/v2/_index.html
@@ -16,5 +16,7 @@ url: "/book/sr/v2.html"
 aliases:
 - "/book/sr/v2/index.html"
 - "/book/sr/v1/index.html"
+- "/book/sr/v1.html"
 - "/book/sr/index.html"
+- "/book/sr.html"
 ---

--- a/external/book/content/book/sv/v2/_index.html
+++ b/external/book/content/book/sv/v2/_index.html
@@ -14,5 +14,7 @@ url: "/book/sv/v2.html"
 aliases:
 - "/book/sv/v2/index.html"
 - "/book/sv/v1/index.html"
+- "/book/sv/v1.html"
 - "/book/sv/index.html"
+- "/book/sv.html"
 ---

--- a/external/book/content/book/tl/v2/_index.html
+++ b/external/book/content/book/tl/v2/_index.html
@@ -14,5 +14,7 @@ url: "/book/tl/v2.html"
 aliases:
 - "/book/tl/v2/index.html"
 - "/book/tl/v1/index.html"
+- "/book/tl/v1.html"
 - "/book/tl/index.html"
+- "/book/tl.html"
 ---

--- a/external/book/content/book/tr/v2/_index.html
+++ b/external/book/content/book/tr/v2/_index.html
@@ -14,5 +14,7 @@ url: "/book/tr/v2.html"
 aliases:
 - "/book/tr/v2/index.html"
 - "/book/tr/v1/index.html"
+- "/book/tr/v1.html"
 - "/book/tr/index.html"
+- "/book/tr.html"
 ---

--- a/external/book/content/book/uk/v2/_index.html
+++ b/external/book/content/book/uk/v2/_index.html
@@ -16,5 +16,7 @@ url: "/book/uk/v2.html"
 aliases:
 - "/book/uk/v2/index.html"
 - "/book/uk/v1/index.html"
+- "/book/uk/v1.html"
 - "/book/uk/index.html"
+- "/book/uk.html"
 ---

--- a/external/book/content/book/uz/v2/_index.html
+++ b/external/book/content/book/uz/v2/_index.html
@@ -14,5 +14,7 @@ url: "/book/uz/v2.html"
 aliases:
 - "/book/uz/v2/index.html"
 - "/book/uz/v1/index.html"
+- "/book/uz/v1.html"
 - "/book/uz/index.html"
+- "/book/uz.html"
 ---

--- a/external/book/content/book/zh-tw/v2/_index.html
+++ b/external/book/content/book/zh-tw/v2/_index.html
@@ -17,5 +17,7 @@ url: "/book/zh-tw/v2.html"
 aliases:
 - "/book/zh-tw/v2/index.html"
 - "/book/zh-tw/v1/index.html"
+- "/book/zh-tw/v1.html"
 - "/book/zh-tw/index.html"
+- "/book/zh-tw.html"
 ---

--- a/external/book/content/book/zh/v2/_index.html
+++ b/external/book/content/book/zh/v2/_index.html
@@ -17,5 +17,7 @@ url: "/book/zh/v2.html"
 aliases:
 - "/book/zh/v2/index.html"
 - "/book/zh/v1/index.html"
+- "/book/zh/v1.html"
 - "/book/zh/index.html"
+- "/book/zh.html"
 ---

--- a/hugo.yml
+++ b/hugo.yml
@@ -31,8 +31,8 @@ module:
   - source: external/docs/content
     target: content
 params:
-  hugo_version: 0.139.4
-  pagefind_version: 1.1.1
+  hugo_version: 0.148.2
+  pagefind_version: 1.3.0
   latest_version: 2.50.1
   latest_relnote_url: https://raw.github.com/git/git/master/Documentation/RelNotes/2.50.1.adoc
   latest_release_date: '2025-06-16'

--- a/script/book.rb
+++ b/script/book.rb
@@ -134,11 +134,15 @@ class Book
     front_matter["aliases"] = [
       "/book/#{@language_code}/v#{@edition}/index.html",
       "/book/#{@language_code}/v1/index.html",
-      "/book/#{@language_code}/index.html"
+      "/book/#{@language_code}/v1.html",
+      "/book/#{@language_code}/index.html",
+      "/book/#{@language_code}.html"
     ]
     if @language_code == "en"
       front_matter["aliases"].push("/book/index.html")
+      front_matter["aliases"].push("/book.html")
       front_matter["aliases"].push("/book/v1/index.html")
+      front_matter["aliases"].push("/book/v1.html")
     end
     front_matter["book"]["front_page"] = true
     front_matter["book"]["repository_url"] = "https://github.com/#{@@all_books[@language_code]}"

--- a/script/upgrade-hugo.sh
+++ b/script/upgrade-hugo.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+die() {
+    echo "$*" >&2
+    exit 1
+}
+
+HUGO_VERSION=$(sed -n 's/^ *hugo_version: *//p' <hugo.yml) &&
+test -n "$HUGO_VERSION" ||
+die "hugo_version not found in hugo.yml"
+
+echo "Upgrading to Hugo v${HUGO_VERSION}" >&2
+
+download_url=https://github.com/gohugoio/hugo/releases/download &&
+curl -Lo /tmp/hugo.deb $download_url/v$HUGO_VERSION/hugo_extended_${HUGO_VERSION}_linux-amd64.deb &&
+sudo dpkg -i /tmp/hugo.deb ||
+die "Failed to install Hugo version $HUGO_VERSION"


### PR DESCRIPTION
## Changes

- Updates Hugo and Pagefind.

## Context

It is always good to stay reasonably up to date. In particular with the recent updates of Hugo's template logic, it opens the door for uncluttering `layouts/_default/baseof.html` a little, and now that that flurry of Hugo updates (to make said new template logic work) seems to have calmed down, it's a good idea to go for that update and see where it leads us.

This fixes https://github.com/git/git-scm.com/issues/1995.