### PR TITLE
Tweak the CSS of the TOC sidebar

### DIFF
--- a/assets/sass/layout.scss
+++ b/assets/sass/layout.scss
@@ -26,37 +26,6 @@ body {
   overflow: visible;
 }
 
-aside {
-  width: 218px;
-  margin-bottom: 35px;
-  position: sticky;
-  top: 0;
-  max-height: 100vh;
-  overflow-y: auto;
-  /* align with the top of the content */
-  padding-top: 46px;
-}
-
-#toc {
-  border: 1px solid var(--main-border);
-  padding: .5em;
-  margin-top: 1rem;
-  border-top: 1px solid var(--main-border);
-  background: var(--sidebar-toc-bg-color);
-  margin-right: 0.5rem;
-}
-
-#toc ul {
-  list-style-type: square;
-}
-
-#toc li {
-  /* use margin instead of line height for spacing because sometimes the
-     headings wrap onto multiple lines */
-  line-height: 1.2em;
-  margin: 6px 0;
-}
-
 #content {
   width: 702px;
 }
@@ -153,47 +122,6 @@ header {
 
     em {
       letter-spacing: 1px;
-    }
-  }
-}
-
-// Navigation
-aside nav ul {
-  margin-bottom: 1.4em;
-  margin-left: 0;
-  font-size: 16px;
-  font-weight: bold;
-  list-style: none;
-
-  li {
-    margin-bottom: 0.5em;
-
-    a {
-      color: var(--nav-link-color);
-
-      &.active, &:hover {
-        color: var(--orange);
-      }
-    }
-
-    ul {
-      display: none;
-      margin-top: 0.3em;
-      margin-left: 20px;
-      font-size: 13px;
-      font-weight: normal;
-
-      li {
-        margin-bottom: 0;
-
-        a.active {
-          font-weight: bold;
-        }
-      }
-
-      &.expanded {
-        display: block;
-      }
     }
   }
 }

--- a/assets/sass/sidebar.scss
+++ b/assets/sass/sidebar.scss
@@ -12,10 +12,8 @@ hr.sidebar {
 aside {
   width: 218px;
   margin-bottom: 35px;
-  position: sticky;
   top: 0;
   max-height: 100vh;
-  overflow-y: auto;
   /* align with the top of the content */
   padding-top: 46px;
 }
@@ -23,28 +21,32 @@ aside {
 #toc {
   border: 1px solid var(--main-border);
   padding: .5em;
-  margin-top: 1rem;
-  border-top: 1px solid var(--main-border);
-  background: var(--sidebar-toc-bg-color);
-  margin-right: 0.5rem;
-}
+  margin: 0 -1px 0 0; /* eat the #main border */
+  border-right: none;
+  z-index: 100;
+  position: relative;
+  background: var(--main-bg);
 
-#toc ul {
-  list-style-type: square;
-}
+  summary {
 
-#toc li {
-  /* use margin instead of line height for spacing because sometimes the
-     headings wrap onto multiple lines */
-  line-height: 1.2em;
-  margin: 6px 0;
+  }
+
+  ul {
+    list-style-type: square;
+
+    li {
+      /* use margin instead of line height for spacing because sometimes the
+         headings wrap onto multiple lines */
+      line-height: 1.2em;
+      margin: 6px 0;
+      font-size: 0.8em;
+    }
+  }
 }
 
 aside.sidebar {
-  font-size: 13px !important;
   line-height: $base-line-height * 0.75;
   p {
-    font-size: 13px !important;
     line-height: $base-line-height * 0.75;
   }
 
@@ -108,6 +110,11 @@ aside.sidebar.active {
 }
 .sidebar-btn {
   display: none;
+}
+
+aside details,
+aside nav {
+  padding: 0 1.5em;
 }
 
 // Breakpoint ----------------

--- a/assets/sass/sidebar.scss
+++ b/assets/sass/sidebar.scss
@@ -9,6 +9,37 @@ hr.sidebar {
   @include background-image-2x($baseurl + "images/sidebar-divider", 218px, 12px);
 }
 
+aside {
+  width: 218px;
+  margin-bottom: 35px;
+  position: sticky;
+  top: 0;
+  max-height: 100vh;
+  overflow-y: auto;
+  /* align with the top of the content */
+  padding-top: 46px;
+}
+
+#toc {
+  border: 1px solid var(--main-border);
+  padding: .5em;
+  margin-top: 1rem;
+  border-top: 1px solid var(--main-border);
+  background: var(--sidebar-toc-bg-color);
+  margin-right: 0.5rem;
+}
+
+#toc ul {
+  list-style-type: square;
+}
+
+#toc li {
+  /* use margin instead of line height for spacing because sometimes the
+     headings wrap onto multiple lines */
+  line-height: 1.2em;
+  margin: 6px 0;
+}
+
 aside.sidebar {
   font-size: 13px !important;
   line-height: $base-line-height * 0.75;
@@ -29,6 +60,48 @@ aside.sidebar {
     }
   }
 }
+
+// Navigation
+aside nav ul {
+  margin-bottom: 1.4em;
+  margin-left: 0;
+  font-size: 16px;
+  font-weight: bold;
+  list-style: none;
+
+  li {
+    margin-bottom: 0.5em;
+
+    a {
+      color: var(--nav-link-color);
+
+      &.active, &:hover {
+        color: var(--orange);
+      }
+    }
+
+    ul {
+      display: none;
+      margin-top: 0.3em;
+      margin-left: 20px;
+      font-size: 13px;
+      font-weight: normal;
+
+      li {
+        margin-bottom: 0;
+
+        a.active {
+          font-weight: bold;
+        }
+      }
+
+      &.expanded {
+        display: block;
+      }
+    }
+  }
+}
+
 // Floating sidebar button for tablet and smaller screens
 aside.sidebar.active {
     @include responsive-sidebar-ui;

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -53,15 +53,15 @@
 
   {{ $headings := .Params.headings }}
   {{ if $headings }}
-  <ul id="toc">
-    <li> Table of Contents
-      <ul class="expanded">
+  <details id="toc" open>
+    <summary>Table of Contents</summary>
+    <ul>
         {{ range $i, $item := $headings }}
           <li><a href="#{{ .id }}">{{ .text }}</a> </li>
         {{ end }}
       </ul>
     </li>
-  </ul>
+  </details>
   {{ end }}
 
   {{ if (eq .Params.Sidebar "book") }}

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -49,40 +49,40 @@
         <a href="{{ relURL "community" }}"{{ if (eq $section "community") }} class="active"{{ end }}>Community</a>
       </li>
     </ul>
+  </nav>
 
-    {{ $headings := .Params.headings }}
-    {{ if $headings }}
-    <ul id="toc">
-      <li> Table of Contents
-        <ul class="expanded">
-          {{ range $i, $item := $headings }}
-            <li><a href="#{{ .id }}">{{ .text }}</a> </li>
-          {{ end }}
-        </ul>
-      </li>
-    </ul>
-    {{ end }}
+  {{ $headings := .Params.headings }}
+  {{ if $headings }}
+  <ul id="toc">
+    <li> Table of Contents
+      <ul class="expanded">
+        {{ range $i, $item := $headings }}
+          <li><a href="#{{ .id }}">{{ .text }}</a> </li>
+        {{ end }}
+      </ul>
+    </li>
+  </ul>
+  {{ end }}
 
-    {{ if (eq .Params.Sidebar "book") }}
-      <hr class="sidebar">
-      {{- /* If this page displays a section of the ProGit book, map all the translations thereof */ -}}
-      {{ with $.Page.Params.book }}
-        {{ $cs_number := .section.cs_number }}
-        {{ range $.Page.Site.Data.book }}
-          {{ $language_code := .language_code }}
-          {{ range .chapters }}
-            {{ range .sections }}
-              {{ if (eq .cs_number $cs_number) }}
-                {{ $.Scratch.SetInMap "translations" $language_code .url }}
-              {{ end }}
+  {{ if (eq .Params.Sidebar "book") }}
+    <hr class="sidebar">
+    {{- /* If this page displays a section of the ProGit book, map all the translations thereof */ -}}
+    {{ with $.Page.Params.book }}
+      {{ $cs_number := .section.cs_number }}
+      {{ range $.Page.Site.Data.book }}
+        {{ $language_code := .language_code }}
+        {{ range .chapters }}
+          {{ range .sections }}
+            {{ if (eq .cs_number $cs_number) }}
+              {{ $.Scratch.SetInMap "translations" $language_code .url }}
             {{ end }}
           {{ end }}
         {{ end }}
       {{ end }}
-      {{ partial "translations.html" . }}
-    {{ else if (and (ne $section "documentation") (ne $section "site")) }}
-      <hr class="sidebar">
-      {{ partial "book.html" }}
     {{ end }}
-  </nav>
+    {{ partial "translations.html" . }}
+  {{ else if (and (ne $section "documentation") (ne $section "site")) }}
+    <hr class="sidebar">
+    {{ partial "book.html" }}
+  {{ end }}
 </aside>


### PR DESCRIPTION
## Changes

An attempt to make it look more pretty.

## Context

Recently the TOC was added, in the sidebar. This PR attempts to make it integrate better into the aesthetic.

<img width="1923" height="843" alt="20250815_13h57m44s_grim" src="https://github.com/user-attachments/assets/8fe595e2-30bd-4c72-bbd4-2550fa3abd35" />

Deployed to https://to1ne.github.io/git-scm.com/docs/git-rebase

## TODO

- [ ] Bring back the sticky sidebars
- [ ] Better on mobile
- [ ] Maybe put above the rest of the page nav?
- [ ] Check/fix book pages