### PR TITLE
Upgrade pagefind

### DIFF
--- a/.github/actions/deploy-to-github-pages/action.yml
+++ b/.github/actions/deploy-to-github-pages/action.yml
@@ -83,7 +83,7 @@ runs:
 
     - name: run Pagefind ${{ env.PAGEFIND_VERSION }} to build the search index
       shell: bash
-      run: npx -y pagefind@${{ env.PAGEFIND_VERSION }} --site public
+      run: npx -y pagefind@${{ env.PAGEFIND_VERSION }} --site public --write-playground
 
     - name: Temporarily copy some Rails assets to help the transition
       shell: bash

--- a/.github/actions/deploy-to-github-pages/action.yml
+++ b/.github/actions/deploy-to-github-pages/action.yml
@@ -126,10 +126,33 @@ runs:
           -H "Content-Type: application/json" \
           -d '{ "purge_everything": true }'
 
-    - name: construct `--remap` options for lychee
+    - name: construct `--remap` options, root-dir for lychee
       id: remap
       shell: bash
       run: |
+        # Prepare the root-dir for use with the `--root-dir` option
+        echo "root-dir-arg=$PWD/root-dir" >>$GITHUB_OUTPUT &&
+        case "$base_url" in
+        https://*/?*|http://*/?*)
+          # The base URL is not at the top-level of the URL
+          subdir="${base_url#http*://*/}"
+          target="root-dir/${subdir%/}"
+          source="$(echo "${subdir%/}" | sed 's/[^/]*/../g')/public"
+          mkdir -p "${target%/*}" &&
+          ln -s "$source" "$target" &&
+          echo "root-dir=$target/" >>$GITHUB_OUTPUT
+          ;;
+        https://*|http://*)
+          # The base URL is at the top-level of the URL
+          ln -s public root-dir &&
+          echo 'root-dir=root-dir/' >>$GITHUB_OUTPUT
+          ;;
+        *)
+          echo "::error::Unexpected base_url '$base_url'" >&2
+          echo exit 1
+          ;;
+        esac || exit
+
         echo "result=$(echo "$base_url" |
           sed 's|^\(.*\)\(/git-scm\.com\)$|^(\1)?\2(.*)|') file://$PWD/public\$2" \
           >>$GITHUB_OUTPUT
@@ -163,7 +186,7 @@ runs:
         args: >-
           --offline
           --fallback-extensions html
-          --base '${{ env.base_url }}'
+          --root-dir '${{ steps.remap.outputs.root-dir-arg }}'
           --remap '${{ steps.remap.outputs.result }}'
           ${{ steps.remap.outputs.remap-dotdot }}
           ${{ steps.remap.outputs.remap-git-scm }}
@@ -174,7 +197,7 @@ runs:
           --exclude file:///Pfad/zum/Repo.git/
           --exclude file:///chemin/du/d%C3%A9p%C3%B4t.git/
           --exclude file:///srv/git/project.git
-          public/
+          '${{ steps.remap.outputs.root-dir }}'
         output: lychee.md
         jobSummary: true
         fail: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
         fi
 
     - name: run Pagefind ${{ env.PAGEFIND_VERSION }} to build the search index
-      run: npx -y pagefind@${{ env.PAGEFIND_VERSION }} --site public
+      run: npx -y pagefind@${{ env.PAGEFIND_VERSION }} --site public --write-playground
 
     - name: build tar archive
       run: cd public && tar czvf ../pages.tar.gz *

--- a/hugo.yml
+++ b/hugo.yml
@@ -32,7 +32,7 @@ module:
     target: content
 params:
   hugo_version: 0.148.2
-  pagefind_version: 1.3.0
+  pagefind_version: 1.4.0
   latest_version: 2.51.0
   latest_relnote_url: https://raw.github.com/git/git/master/Documentation/RelNotes/2.51.0.adoc
   latest_release_date: '2025-08-18'


### PR DESCRIPTION
## Changes

- Update Pagefind (the library that implements the search on the site)
- Enable the "Pagefind Playground"

## Context

The [recently-released new version](https://github.com/Pagefind/pagefind/releases/tag/v1.4.0) of Pagefind sports a pretty neat [Playground](https://pagefind.app/docs/playground/) for experimenting with the search parameters (to optimize them for better search results).

I mentioned this [here](https://github.com/git/git-scm.com/issues/2046#issuecomment-3246589649), and don't want to derail the _highly_ desirable effort to refresh the website, therefore I'll not even mention it _there_ that I opened this PR.

@jvns @To1ne FYI this is the PR to upgrade Pagefind and enable the Playground.