### PR TITLE
Add a Git cheat sheet

### DIFF
--- a/assets/sass/application.scss
+++ b/assets/sass/application.scss
@@ -27,6 +27,7 @@ $baseurl: "{{ .Site.BaseURL }}{{ if (and (ne .Site.BaseURL "/") (ne .Site.BaseUR
 @import 'book2';
 @import 'lists';
 @import 'about';
+@import 'cheat-sheet';
 @import 'dark-mode';
 @import 'git-turns-20';
 

--- a/assets/sass/cheat-sheet.scss
+++ b/assets/sass/cheat-sheet.scss
@@ -1,0 +1,117 @@
+@import "variables";
+
+.cheat-sheet {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+
+  .item {
+    background: var(--bg-color);
+    padding: 10px;
+    border-radius: 10px;
+    border: 1px solid var(--callout-color);
+    display: flex;
+    font-size: 1rem;
+    flex-direction: column;
+    gap: 5px;
+
+    p {
+      font-size: 1rem;
+      margin: 0 8px;
+    }
+
+    svg {
+      height: auto;
+      width: 100%;
+    }
+
+    h3 {
+      color: var(--font-color);
+      line-height: 1em;
+      font-size: 1.1rem;
+      margin-bottom: 8px;
+      font-weight: 500;
+    }
+
+    label {
+      display: block;
+      margin-top: 10px;
+    }
+
+    code {
+      background: var(--callout-color);
+      color: var(--font-color);
+      border-radius: 3px;
+      padding: 4px 8px;
+      font-family: Courier, monospace;
+      margin-bottom: 0;
+    }
+
+    h3 code {
+      padding: 0;
+      background: transparent;
+    }
+
+    .or {
+      font-weight: 700;
+      font-size: 0.8em;
+      display: block;
+      margin-left: 30px;
+      font-family: sans-serif;
+    }
+  }
+
+  section {
+    margin-bottom: 20px;
+    display: grid;
+    gap: 10px;
+    grid-template-columns: 1fr 1fr;
+
+    @media (max-width: $mobile-m) {
+      & {
+        display: flex;
+        flex-direction: column;
+      }
+    }
+
+    h2 {
+      grid-column: 1/3;
+
+      margin-top: 0;
+      font-size: 1.2rem;
+      font-weight: 700;
+      line-height: 1.2;
+      color: var(--orange);
+    }
+  }
+
+  .commit-reference {
+    background: var(--callout-color);
+    border-left: 4px solid var(--orange);
+    display: block;
+    padding: 10px;
+    border-radius: 10px;
+
+    .intro {
+      margin: 16px 0;
+    }
+
+    dl {
+      display: grid;
+      grid-template-columns: auto 1fr;
+      gap: 8px 16px;
+      margin: 0;
+
+      dt {
+        &::before {
+          content: "★ ";
+          font-size: 18px;
+          color: #666;
+        }
+      }
+
+      dd {
+        font-family: monospace;
+        padding: 4px 8px;
+      }
+    }
+  }
+}

--- a/assets/sass/cheat-sheet.scss
+++ b/assets/sass/cheat-sheet.scss
@@ -18,11 +18,6 @@
       margin: 0 8px;
     }
 
-    svg {
-      height: auto;
-      width: 100%;
-    }
-
     h3 {
       color: var(--font-color);
       line-height: 1em;

--- a/assets/sass/dark-mode.css
+++ b/assets/sass/dark-mode.css
@@ -152,6 +152,10 @@
             #l10n-versions-dropdown footer a {
                 color: #6969dd;
             }
+
+            .cheat-sheet svg {
+                filter: invert(60%);
+            }
         }
     }
 

--- a/assets/sass/dark-mode.css
+++ b/assets/sass/dark-mode.css
@@ -153,7 +153,7 @@
                 color: #6969dd;
             }
 
-            .cheat-sheet svg {
+            .cheat-sheet img {
                 filter: invert(60%);
             }
         }

--- a/content/cheat-sheet/_index.html
+++ b/content/cheat-sheet/_index.html
@@ -1,0 +1,775 @@
+---
+section: "documentation"
+subsection: "cheat-sheet"
+title: "Git Cheat Sheet"
+url: /cheat-sheet.html
+headings:
+  - text: "Getting Started"
+    id: "getting-started"
+  - text: "Prepare to Commit"
+    id: "prepare-to-commit"
+  - text: "Make Commits"
+    id: "make-commits"
+  - text: "Move Between Branches"
+    id: "move-between-branches"
+  - text: "Diff Staged/Unstaged Changes"
+    id: "diff-staged-unstaged-changes"
+  - text: "Diff Commits"
+    id: "diff-commits"
+  - text: "Ways to refer to a commit"
+    id: "ways-to-refer-to-a-commit"
+  - text: "Discard Your Changes"
+    id: "discard-your-changes"
+  - text: "Edit History"
+    id: "edit-history"
+  - text: "Code Archaeology"
+    id: "code-archaeology"
+  - text: "Combine Diverged Branches"
+    id: "combine-diverged-branches"
+  - text: "Restore an Old File"
+    id: "restore-an-old-file"
+  - text: "Add a Remote"
+    id: "add-a-remote"
+  - text: "Push Your Changes"
+    id: "push-your-changes"
+  - text: "Pull Changes"
+    id: "pull-changes"
+  - text: "Configure Git"
+    id: "configure-git"
+  - text: "Important Files"
+    id: "important-files"
+---
+
+<div id="main" class="cheat-sheet">
+  <h1>Git Cheat Sheet</h1>
+
+  <section>
+    <h2 id="getting-started">Getting Started</h2>
+    <div class="item">
+      <h3>Start a new repo:</h3>
+      <code>git init</code>
+    </div>
+    <div class="item">
+      <h3>Clone an existing repo:</h3>
+      <code>git clone &lt;url&gt;</code>
+    </div>
+  </section>
+
+  <section>
+    <h2 id="prepare-to-commit">Prepare to Commit</h2>
+    <div class="item">
+      <h3>Add untracked file or unstaged changes:</h3>
+      <code>git add &lt;file&gt;</code>
+    </div>
+    <div class="item">
+      <h3>Add all untracked files and unstaged changes:</h3>
+      <code>git add .</code>
+    </div>
+    <div class="item">
+      <h3>Choose which parts of a file to stage:</h3>
+      <code>git add -p</code>
+    </div>
+
+    <div class="item">
+      <h3>Move file:</h3>
+      <code>git mv &lt;old&gt; &lt;new&gt;</code>
+    </div>
+    <div class="item">
+      <h3>Delete file:</h3>
+      <code>git rm &lt;file&gt;</code>
+    </div>
+
+    <div class="item">
+      <h3>Tell Git to forget about a file without deleting it:</h3>
+      <code>git rm --cached &lt;file&gt;</code>
+    </div>
+    <div class="item">
+      <h3>Unstage one file:</h3>
+      <code>git reset &lt;file&gt;</code>
+    </div>
+    <div class="item">
+      <h3>Unstage everything:</h3>
+      <code>git reset</code>
+    </div>
+    <div class="item">
+      <h3>Check what you added:</h3>
+      <code>git status</code>
+    </div>
+  </section>
+
+  <section>
+    <h2 id="make-commits">Make Commits</h2>
+    <div class="item">
+      <h3>Make a commit (and open text editor to write message):</h3>
+      <code>git commit</code>
+    </div>
+    <div class="item">
+      <h3>Make a commit:</h3>
+      <code>git commit -m 'message'</code>
+    </div>
+    <div class="item">
+      <h3>Commit all unstaged changes:</h3>
+      <code>git commit -am 'message'</code>
+    </div>
+  </section>
+
+  <section>
+    <h2 id="move-between-branches">Move Between Branches</h2>
+    <div class="item">
+      <h3>Switch branches:</h3>
+      <code>git switch &lt;name&gt;</code>
+      <span class="or">OR</span>
+      <code>git checkout &lt;name&gt;</code>
+    </div>
+    <div class="item">
+      <h3>Create a branch:</h3>
+      <code>git switch -c &lt;name&gt;</code>
+      <span class="or">OR</span>
+      <code>git checkout -b &lt;name&gt;</code>
+    </div>
+    <div class="item">
+      <h3>List branches:</h3>
+      <code>git branch</code>
+    </div>
+    <div class="item">
+      <h3>List branches by most recently committed to:</h3>
+      <code>git branch --sort=-committerdate</code>
+    </div>
+    <div class="item">
+      <h3>Delete a branch:</h3>
+      <code>git branch -d &lt;name&gt;</code>
+    </div>
+    <div class="item">
+      <h3>Force delete a branch:</h3>
+      <code>git branch -D &lt;name&gt;</code>
+    </div>
+  </section>
+
+  <section>
+    <h2 id="diff-staged-unstaged-changes">Diff Staged/Unstaged Changes</h2>
+    <div class="item">
+      <h3>Diff all staged and unstaged changes:</h3>
+      <code>git diff HEAD</code>
+    </div>
+    <div class="item">
+      <h3>Diff just staged changes:</h3>
+      <code>git diff --staged</code>
+    </div>
+    <div class="item">
+      <h3>Diff just unstaged changes:</h3>
+      <code>git diff</code>
+    </div>
+  </section>
+
+  <section>
+    <h2 id="diff-commits">Diff Commits</h2>
+    <div class="item">
+      <h3>Show diff between a commit and its parent:</h3>
+      <code>git show &lt;commit&gt;</code>
+    </div>
+    <div class="item">
+      <h3>Diff two commits:</h3>
+      <code>git diff &lt;commit&gt; &lt;commit&gt;</code>
+    </div>
+    <div class="item">
+      <h3>Diff one file since a commit:</h3>
+      <code>git diff &lt;commit&gt; &lt;file&gt;</code>
+    </div>
+    <div class="item">
+      <h3>Show a summary of a diff:</h3>
+      <code>git diff &lt;commit&gt; --stat</code>
+      <code>git show &lt;commit&gt; --stat</code>
+    </div>
+  </section>
+  <section class="commit-reference">
+    <h2 id="ways-to-refer-to-a-commit">Ways to refer to a commit</h2>
+    <p class="intro">
+      Every time we say <code>&lt;commit&gt;</code>, you can use any of these:
+    </p>
+
+    <dl>
+      <dt>a branch</dt>
+      <dd>main</dd>
+
+      <dt>a tag</dt>
+      <dd>v0.1</dd>
+
+      <dt>a commit ID</dt>
+      <dd>3e887ab</dd>
+
+      <dt>a remote branch</dt>
+      <dd>origin/main</dd>
+
+      <dt>current commit</dt>
+      <dd>HEAD</dd>
+
+      <dt>3 commits ago</dt>
+      <dd>HEAD^^^ or HEAD~3</dd>
+    </dl>
+  </section>
+
+  <section>
+    <h2 id="discard-your-changes">Discard Your Changes</h2>
+    <div class="item">
+      <h3>Delete unstaged changes to one file:</h3>
+      <code>git checkout &lt;file&gt;</code>
+    </div>
+    <div class="item">
+      <h3>Delete all staged and unstaged changes to one file:</h3>
+      <code>git checkout HEAD &lt;file&gt;</code>
+    </div>
+    <div class="item">
+      <h3>Delete all staged and unstaged changes:</h3>
+      <code>git reset --hard</code>
+    </div>
+    <div class="item">
+      <h3>Delete untracked files:</h3>
+      <code>git clean</code>
+    </div>
+    <div class="item">
+      <h3>'Stash' all staged and unstaged changes:</h3>
+      <code>git stash</code>
+    </div>
+  </section>
+
+  <section>
+    <h2 id="edit-history">Edit History</h2>
+    <div class="item">
+      <h3>"Undo" the most recent commit (keep your working directory the same):</h3>
+      <code>git reset HEAD^</code>
+    </div>
+    <div class="item">
+      <h3>Squash the last 5 commits into one:</h3>
+      <code>git rebase -i HEAD~6</code>
+      <p>Then change "pick" to "fixup" for any commit you want to combine with the previous one</p>
+    </div>
+    <div class="item">
+      <h3>Undo a failed rebase:</h3>
+      <code>git reflog BRANCHNAME</code>
+      <p>Then manually find the right commit ID in the reflog, then run:</p>
+      <code>git reset --hard &lt;commit&gt;</code>
+    </div>
+    <div class="item">
+      <h3>Change a commit message (or add a file you forgot):</h3>
+      <code>git commit --amend</code>
+    </div>
+  </section>
+
+  <section>
+    <h2 id="code-archaeology">Code Archaeology</h2>
+    <div class="item">
+      <h3>Look at a branch's history:</h3>
+      <code>git log main</code>
+      <code>git log --graph main</code>
+      <code>git log --oneline</code>
+    </div>
+    <div class="item">
+      <h3>Show every commit that modified a file:</h3>
+      <code>git log &lt;file&gt;</code>
+    </div>
+    <div class="item">
+      <h3>Show every commit that modified a file, including before it was renamed:</h3>
+      <code>git log --follow &lt;file&gt;</code>
+    </div>
+    <div class="item">
+      <h3>Find every commit that added or removed some text:</h3>
+      <code>git log -G banana</code>
+    </div>
+    <div class="item">
+      <h3>Show who last changed each line of a file:</h3>
+      <code>git blame &lt;file&gt;</code>
+    </div>
+  </section>
+
+  <section>
+    <h2 id="combine-diverged-branches">Combine Diverged Branches</h2>
+    <div class="item">
+      <h3>Combine with rebase:</h3>
+      <code>git switch banana</code>
+      <code>git rebase main</code>
+
+      <label>Before:</label>
+      {{< graphviz engine="neato">}}
+        digraph G {
+
+        bgcolor="transparent";
+        rankdir=TB;
+        node [
+        shape=box, width=0.6, height=0.6, penwidth=3,
+        fixedsize=true, fontname="monospace",
+        fontsize=24
+        ];
+        edge [arrowsize=1.0, dir=none, penwidth=3];
+
+
+        // Nodes
+        A [label="A", pos="0,1!"];
+        B [label="B", pos="1,1!"];
+        C [label="C", pos="2,1!"];
+        D [label="D", color="#f14e32", pos="2,0!"];
+        E [label="E", color="#f14e32", pos="3,0!"];
+
+        main_label [label="main", shape=plaintext, pos="5,1!", fixedsize=false];
+        main_label -> C [dir=forward];
+
+        banana_label [label="banana", shape=plaintext, pos="5.2,0!", fixedsize=false];
+        banana_label -> E [dir=forward];
+
+        // Edges
+        A -> B;
+        B -> C;
+        B -> D;
+        D -> E;
+        }
+
+        {{< /graphviz>}}
+          <label>After:</label>
+          {{< graphviz engine="neato">}}
+            digraph G {
+
+            bgcolor="transparent";
+            rankdir=TB;
+            node [
+            shape=box, width=0.6, height=0.6, penwidth=3,
+            fixedsize=true, fontname="monospace",
+            fontsize=24
+            ];
+            edge [arrowsize=1.0, dir=none, penwidth=3];
+
+
+            // Nodes
+            A [label="A", pos="0,1!"];
+            B [label="B", pos="1,1!"];
+            C [label="C", pos="2,1!"];
+            D [label="D", style="dashed", color="#f14e32", pos="2,0!"];
+            E [label="E", style="dashed", color="#f14e32", pos="3,0!"];
+
+            D2 [label="D", color="#f14e32", pos="3,1!"];
+            E2 [label="E", color="#f14e32", pos="4,1!"];
+
+
+            main_label [label="main", shape=plaintext, pos="2,2!", fixedsize=false];
+            main_label -> C [dir=forward];
+
+            banana_label [label="banana", shape=plaintext, pos="4,2!", fixedsize=false];
+            banana_label -> E2 [dir=forward];
+
+
+            lost_label [label="\"lost\"", shape=plaintext, pos="5.2,0!", fixedsize=false];
+            lost_label -> E [dir=forward];
+
+            // Edges
+            A -> B;
+            B -> C;
+            C -> D2;
+            D2 -> E2;
+
+            B -> D;
+            D -> E;
+            }
+
+            {{< /graphviz>}}
+    </div>
+    <div class="item">
+      <h3>Combine with merge:</h3>
+      <code>git switch main</code>
+      <code>git merge banana</code>
+
+      <label>Before:</label>
+      {{< graphviz engine="neato">}}
+        digraph G {
+
+        bgcolor="transparent";
+        rankdir=TB;
+        node [
+        shape=square, width=0.6, height=0.6, penwidth=3,
+        fixedsize=true, fontname="monospace",
+        fontsize=24
+        ];
+        edge [arrowsize=1.0, dir=none, penwidth=3];
+
+
+        // Nodes
+        A [label="A", pos="0,1!"];
+        B [label="B", pos="1,1!"];
+        C [label="C", pos="2,1!"];
+        D [label="D", color="#f14e32", pos="2,0!"];
+        E [label="E", color="#f14e32", pos="3,0!"];
+
+        main_label [label="main", shape=plaintext, pos="5,1!", fixedsize=false];
+        main_label -> C [dir=forward];
+
+        banana_label [label="banana", shape=plaintext, pos="5.2,0!", fixedsize=false];
+        banana_label -> E [dir=forward];
+
+        // Edges
+        A -> B;
+        B -> C;
+        B -> D;
+        D -> E;
+        }
+
+      {{< /graphviz>}}
+      <label>After:</label>
+      {{< graphviz engine="neato">}}
+        digraph G {
+
+        bgcolor="transparent";
+        rankdir=TB;
+        node [
+        shape=square, width=0.6, height=0.6, penwidth=3,
+        fixedsize=true, fontname="monospace",
+        fontsize=24
+        ];
+        edge [arrowsize=1.0, dir=none, penwidth=3];
+
+
+        // Nodes
+        A [label="A", pos="0,1!"];
+        B [label="B", pos="1,1!"];
+        C [label="C", pos="2,1!"];
+        D [label="D", color="#f14e32", pos="2,0!"];
+        E [label="E", color="#f14e32", pos="3,0!"];
+        M [label="◇", pos="4,1!"];
+
+        main_label [label="main", shape=plaintext, pos="5,1!", fixedsize=false];
+        main_label -> M [dir=forward];
+
+        banana_label [label="banana", shape=plaintext, pos="5.2,0!", fixedsize=false];
+        banana_label -> E [dir=forward];
+
+        // Edges
+        A -> B;
+        B -> C;
+        B -> D;
+        D -> E;
+        C -> M;
+        E -> M;
+        }
+
+    {{< /graphviz>}}
+    </div>
+    <div class="item">
+      <h3>Combine with squash merge:</h3>
+      <code>git switch main</code>
+      <code>git merge --squash banana</code>
+      <code>git commit</code>
+
+      <label>Before:</label>
+      {{< graphviz engine="neato">}}
+        digraph G {
+
+        bgcolor="transparent";
+        rankdir=TB;
+        node [
+        shape=square, width=0.6, height=0.6, penwidth=3,
+        fixedsize=true, fontname="monospace",
+        fontsize=24
+        ];
+        edge [arrowsize=1.0, dir=none, penwidth=3];
+
+
+        // Nodes
+        A [label="A", pos="0,1!"];
+        B [label="B", pos="1,1!"];
+        C [label="C", pos="2,1!"];
+        D [label="D", color="#f14e32", pos="2,0!"];
+        E [label="E", color="#f14e32", pos="3,0!"];
+
+        main_label [label="main", shape=plaintext, pos="5,1!", fixedsize=false];
+        main_label -> C [dir=forward];
+
+        banana_label [label="banana", shape=plaintext, pos="5.2,0!", fixedsize=false];
+        banana_label -> E [dir=forward];
+
+        // Edges
+        A -> B;
+        B -> C;
+        B -> D;
+        D -> E;
+        }
+
+        {{< /graphviz>}}
+          <label>After:</label>
+          {{< graphviz engine="neato">}}
+            digraph G {
+
+            bgcolor="transparent";
+            rankdir=TB;
+            node [
+            shape=rect, width=0.6, height=0.6, penwidth=3,
+            fixedsize=true, fontname="monospace",
+            fontsize=24
+            ];
+            edge [arrowsize=1.0, dir=none, penwidth=3];
+
+
+            // Nodes
+            A [label="A", pos="0,1!"];
+            B [label="B", pos="1,1!"];
+            C [label="C", pos="2,1!"];
+            D [label="D", color="#f14e32", pos="2,0!"];
+            E [label="E", color="#f14e32", pos="3,0!"];
+            S [label="D\nE", color="#f14e32", pos="3,1!", width=0.6, height=0.8];
+
+            main_label [label="main", shape=plaintext, pos="5,1!", fixedsize=false];
+            main_label -> S [dir=forward];
+
+            banana_label [label="banana", shape=plaintext, pos="5.2,0!", fixedsize=false];
+            banana_label -> E [dir=forward];
+
+            // Edges
+            A -> B;
+            B -> C;
+            B -> D;
+            D -> E;
+            C -> S;
+            }
+
+            {{< /graphviz>}}
+    </div>
+    <div class="item">
+      <h3>Bring a branch up to date with another branch (aka "fast-forward merge"):</h3>
+      <code>git switch main</code>
+      <code>git merge banana</code>
+
+      <label>Before:</label>
+      {{< graphviz engine="neato">}}
+        digraph G {
+
+        bgcolor="transparent";
+        rankdir=LR;
+        node [
+        shape=rect, width=0.6, height=0.6, penwidth=3,
+        fixedsize=true, fontname="monospace",
+        fontsize=24
+        ];
+        edge [arrowsize=1.0, dir=none, penwidth=3];
+
+
+        // Nodes
+        A [label="A", pos="0,0!"];
+        B [label="B", pos="1,0!"];
+        C [label="C", pos="2,0!"];
+        D [label="D", pos="3,0!"];
+        E [label="E", pos="4,0!"];
+        invisible [label="", shape=plaintext,pos="6,0!"];
+
+        main_label [label="main", fontcolor="#f14e32", shape=plaintext, pos="2,-1!", fixedsize=false];
+        main_label -> C [dir=forward];
+
+        banana_label [label="banana", shape=plaintext, pos="4,-1!", fixedsize=false];
+        banana_label -> E [dir=forward];
+
+        // Edges
+        A -> B;
+        B -> C;
+        C -> D;
+        D -> E;
+        }
+    {{< /graphviz>}}
+    <label>After:</label>
+    {{< graphviz engine="neato">}}
+      digraph G {
+
+      bgcolor="transparent";
+      rankdir=LR;
+      node [
+      shape=rect, width=0.6, height=0.6, penwidth=3,
+      fixedsize=true, fontname="monospace",
+      fontsize=24
+      ];
+      edge [arrowsize=1.0, dir=none, penwidth=3];
+
+
+      // Nodes
+      A [label="A", pos="0,0!"];
+      B [label="B", pos="1,0!"];
+      C [label="C", pos="2,0!"];
+      D [label="D", pos="3,0!"];
+      E [label="E", pos="4,0!"];
+
+      main_label [label="main", fontcolor="#f14e32", shape=plaintext, pos="6, 0!", fixedsize=false];
+      main_label -> E [dir=forward];
+
+      banana_label [label="banana", shape=plaintext, pos="4,-1!", fixedsize=false];
+      banana_label -> E [dir=forward];
+
+      // Edges
+      A -> B;
+      B -> C;
+      C -> D;
+      D -> E;
+      }
+    {{< /graphviz>}}
+    </div>
+    <div class="item">
+      <h3>Copy one commit onto the current branch:</h3>
+      <code>git cherry-pick &lt;commit&gt;</code>
+      <label>Before:</label>
+
+      {{< graphviz engine="neato">}}
+        digraph G {
+        bgcolor="transparent";
+        rankdir=TB;
+        node [
+        shape=box, width=0.6, height=0.6, penwidth=3,
+        fixedsize=true, fontname="monospace",
+        fontsize=24
+        ];
+        edge [arrowsize=1.0, dir=none, penwidth=3];
+
+
+        // Nodes
+        A [label="A", pos="0,1!"];
+        B [label="B", pos="1,1!"];
+        C [label="C", pos="2,1!"];
+        D [label="D", color="#f14e32", pos="2,0!"];
+        E [label="E", pos="3,0!"];
+
+        main_label [label="main", shape=plaintext, pos="5,1!", fixedsize=false];
+        main_label -> C [dir=forward];
+
+        // Edges
+        A -> B;
+        B -> C;
+        B -> D;
+        D -> E;
+        }
+      {{< /graphviz>}}
+      <label>After:</label>
+
+      {{< graphviz engine="neato">}}
+        digraph G {
+        bgcolor="transparent";
+        rankdir=TB;
+        node [
+        shape=box, width=0.6, height=0.6, penwidth=3,
+        fixedsize=true, fontname="monospace",
+        fontsize=24
+        ];
+        edge [arrowsize=1.0, dir=none, penwidth=3];
+
+
+        // Nodes
+        A [label="A", pos="0,1!"];
+        B [label="B", pos="1,1!"];
+        C [label="C", pos="2,1!"];
+        D2 [label="D", color="#f14e32", pos="3,1!"];
+
+        D [label="D", color="#f14e32", pos="2,0!"];
+        E [label="E", pos="3,0!"];
+
+        main_label [label="main", shape=plaintext, pos="5,1!", fixedsize=false];
+        main_label -> D2 [dir=forward];
+
+        // Edges
+        A -> B;
+        B -> C;
+        C -> D2;
+        B -> D;
+        D -> E;
+        }
+        {{< /graphviz>}}
+    </div>
+  </section>
+
+  <section>
+    <h2 id="restore-an-old-file">Restore an Old File</h2>
+    <div class="item">
+      <h3>Get the version of a file from another commit:</h3>
+      <code>git checkout &lt;commit&gt; &lt;file&gt;</code>
+      <span class="or">OR</span>
+      <code>git restore &lt;file&gt; --source &lt;commit&gt;</code>
+    </div>
+  </section>
+
+  <section>
+    <h2 id="add-a-remote">Add a Remote</h2>
+    <div class="item">
+      <code>git remote add &lt;name&gt; &lt;url&gt;</code>
+    </div>
+  </section>
+
+  <section>
+    <h2 id="push-your-changes">Push Your Changes</h2>
+    <div class="item">
+      <h3>Push the <code>main</code> branch to the remote <code>origin</code>:</h3>
+      <code>git push origin main</code>
+    </div>
+    <div class="item">
+      <h3>Push the current branch to its remote "tracking branch":</h3>
+      <code>git push</code>
+    </div>
+    <div class="item">
+      <h3>Push a branch that you've never pushed before:</h3>
+      <code>git push -u origin &lt;name&gt;</code>
+    </div>
+    <div class="item">
+      <h3>Force push:</h3>
+      <code>git push --force-with-lease</code>
+    </div>
+    <div class="item">
+      <h3>Push tags:</h3>
+      <code>git push --tags</code>
+    </div>
+  </section>
+
+  <section>
+    <h2 id="pull-changes">Pull Changes</h2>
+    <div class="item">
+      <h3>Fetch changes (but don't change any of your local branches):</h3>
+      <code>git fetch origin main</code>
+    </div>
+    <div class="item">
+      <h3>Fetch changes and then rebase your current branch:</h3>
+      <code>git pull --rebase</code>
+    </div>
+    <div class="item">
+      <h3>Fetch changes and then merge them into your current branch:</h3>
+      <code>git pull origin main</code>
+      <span class="or">OR</span>
+      <code>git pull</code>
+    </div>
+    <div class="item">
+      <h3>Fetch all branches:</h3>
+      <code>git fetch --all</code>
+    </div>
+  </section>
+
+  <section>
+    <h2 id="configure-git">Configure Git</h2>
+    <div class="item">
+      <h3>Set a config option:</h3>
+      <code>git config user.name 'Your Name'</code>
+    </div>
+    <div class="item">
+      <h3>Set option globally:</h3>
+      <code>git config --global ...</code>
+    </div>
+    <div class="item">
+      <h3>Add an alias:</h3>
+      <code>git config alias.st status</code>
+    </div>
+    <div class="item">
+      <h3>See all possible config options:</h3>
+      <code>man git-config</code>
+    </div>
+  </section>
+
+  <section>
+    <h2 id="important-files">Important Files</h2>
+    <div class="item">
+      <h3>Local git config:</h3>
+      <code>.git/config</code>
+    </div>
+    <div class="item">
+      <h3>Global git config:</h3>
+      <code>~/.gitconfig</code>
+    </div>
+    <div class="item">
+      <h3>List of files to ignore:</h3>
+      <code>.gitignore</code>
+    </div>
+  </section>
+</div>

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -24,6 +24,9 @@
             <a href="{{ relURL "docs" }}"{{ if or (eq .Params.Subsection "reference") (eq .Params.Subsection "manual") }} class="active"{{ end }}>Reference</a>
           </li>
           <li>
+            <a href="{{ relURL "cheat-sheet" }}"{{ if (eq .Params.Subsection "cheat-sheet") }} class="active"{{ end }}>Cheat Sheet</a>
+          </li>
+          <li>
             <a href="{{ relURL "book" }}"{{ if (eq .Params.Subsection "book") }} class="active"{{ end }}>Book</a>
           </li>
           <li>


### PR DESCRIPTION
Someone [on Mastodon](https://mastodon.online/@blami/115140353050908406) suggested it would be nice to have a cheat sheet on the Git website, so I thought I'd put together a prototype to see if it's of interest, perhaps for a future "Learn" section of the site. You can see it in action here: [Git cheat sheet](https://jvns.github.io/git-scm.com/cheat-sheet)

There are definitely lots of Git cheat sheets out there already (for example [from github](https://training.github.com/downloads/github-git-cheat-sheet.pdf) and [from ndpsoftware](http://ndpsoftware.com/git-cheatsheet.html#loc=remote_repo;)), but it feels like it would be nice to have one that's lower tech and not GitHub branded.

The content and styling both definitely need work -- right now it's basically an import of [this cheat sheet](https://wizardzines.com/git-cheat-sheet.pdf), which has some of my personal Git idiosyncracies in it (like insisting on using `HEAD^^^^^^` instead of `HEAD~5` 🙈).

I got a bit carried away writing handwritten SVG Git graphs, and I'm not sure they'll display in all browsers as is. Here's what they're meant to look like. I think I'll figure out a better solution than the handwritten SVGs, maybe graphviz.

<img width="300" alt="image" src="https://github.com/user-attachments/assets/d2f5175d-2a7f-4fbd-8ce1-8f300bf5d49f" />
