### PR TITLE
script/serve-public.js: use PORT environment variable

### DIFF
--- a/script/serve-public.js
+++ b/script/serve-public.js
@@ -64,4 +64,4 @@ const server = http.createServer(handler);
 server.on("listening", () => {
     console.log(`Now listening on: http://localhost:${server.address().port}/`);
 });
-server.listen(5000);
+server.listen(process.env.PORT || 5000);


### PR DESCRIPTION
I had another service running on port 5000 so couldn't run the serve script. This makes it use the PORT environment variable so the port can be changed.