### PR TITLE
feat: removed mac binary download link since it is outdated

### DIFF
--- a/content/downloads/mac.html
+++ b/content/downloads/mac.html
@@ -24,12 +24,7 @@ aliases:
 
   <h3>Xcode</h3>
   <p>Apple ships a binary package of Git with <a href="https://developer.apple.com/xcode/">Xcode</a>.</p>
-
-  <h3>Binary installer</h3>
-  <p>Tim Harper provides an <a href="https://sourceforge.net/projects/git-osx-installer/">installer</a>
-  for Git. The latest version is <a href="{{< site-param macos_installer.url >}}">{{< site-param macos_installer.version >}}</a>,
-  which was released <span id="relative-release-date"></span>on <span id="auto-download-date">{{< site-param macos_installer.release_date >}}</span>.
-
+  
   <h3>Building from Source</h3>
   <p>If you prefer to build from source, you can find tarballs
   <a href="https://www.kernel.org/pub/software/scm/git/">on kernel.org</a>.


### PR DESCRIPTION
## Changes

Simply removed the Git binary from macOS download page

-

## Context

#2057 
