### PR TITLE
cheat sheet: don't wrap in the middle of --sort=-committerdate

### DIFF
--- a/content/cheat-sheet/_index.html
+++ b/content/cheat-sheet/_index.html
@@ -133,7 +133,7 @@ headings:
     </div>
     <div class="item">
       <h3>List branches by most recently committed to:</h3>
-      <code>git branch --sort=-committerdate</code>
+      <code>git branch <span style="white-space: nowrap;">--sort=-committerdate</span></code>
     </div>
     <div class="item">
       <h3>Delete a branch:</h3>


### PR DESCRIPTION

@michaelblyons commented in https://github.com/git/git-scm.com/pull/2049#issuecomment-3300069823 :

> May I request that git branch --sort=-committerdate use CSS that breaks at git branch / --sort=... instead of at --sort=- / committerdate if possible?

I think it looks better this way too

<img width="327" height="123" alt="image" src="https://github.com/user-attachments/assets/8ebe0a0a-024d-4c9e-92b2-1646ff2c6ddd" />
