### PR TITLE
cheat sheet: mark transplanted commits with prime

### DIFF
--- a/content/cheat-sheet/_index.html
+++ b/content/cheat-sheet/_index.html
@@ -344,8 +344,8 @@ headings:
             D [label="D", style="dashed", color="#f14e32", pos="2,0!"];
             E [label="E", style="dashed", color="#f14e32", pos="3,0!"];
 
-            D2 [label="D", color="#f14e32", pos="3,1!"];
-            E2 [label="E", color="#f14e32", pos="4,1!"];
+            D2 [label="D&#x2032;", color="#f14e32", pos="3,1!"];
+            E2 [label="E&#x2032;", color="#f14e32", pos="4,1!"];
 
 
             main_label [label="main", shape=plaintext, pos="2,2!", fixedsize=false];
@@ -510,7 +510,7 @@ headings:
             C [label="C", pos="2,1!"];
             D [label="D", color="#f14e32", pos="2,0!"];
             E [label="E", color="#f14e32", pos="3,0!"];
-            S [label="D\nE", color="#f14e32", pos="3,1!", width=0.6, height=0.8];
+            S [label="D&#x2032;\nE&#x2032;", color="#f14e32", pos="3,1!", width=0.6, height=0.8];
 
             main_label [label="main", shape=plaintext, pos="5,1!", fixedsize=false];
             main_label -> S [dir=forward];
@@ -655,7 +655,7 @@ headings:
         A [label="A", pos="0,1!"];
         B [label="B", pos="1,1!"];
         C [label="C", pos="2,1!"];
-        D2 [label="D", color="#f14e32", pos="3,1!"];
+        D2 [label="D&#x2032;", color="#f14e32", pos="3,1!"];
 
         D [label="D", color="#f14e32", pos="2,0!"];
         E [label="E", pos="3,0!"];


### PR DESCRIPTION
Mark transplanted commits with prime, similar to how manpages [git-rebase(1)](https://git-scm.com/docs/git-rebase) and [git-cherry-pick(1)](https://git-scm.com/docs/git-cherry-pick) indicate them.

## Changes

<!-- List the changes this PR makes. -->

- add a prime symbol (`′` `U+2032`) to letters representing commits transplanted by
  - `git rebase`
  - `git merge --squash`
  - `git cherry-pick`

## Context

<!-- Explain why you're making these changes. -->
Like in the manpages [git-rebase(1)](https://git-scm.com/docs/git-rebase) and [git-cherry-pick(1)](https://git-scm.com/docs/git-cherry-pick), we should (also in the new cheat sheet) distinguish between a commit and the commit resulting from transplanting it. They will usually represent the same change, but they aren't the same commit and might (due to different ancestors) not have the same file contents in the trees they refer to (and also some metadata like commit date will differ in general), thus they aren't the _same_ commit.

The manpages use the straight apostrophe (`'` a.k.a. "single quote") for this, presumably to stay with ASCII-only for compatibility. I guess the cheat sheet may dare to use the semantically more precise Unicode character `PRIME` instead. For source encoding safety, I've used the corresponding HTML entity.

If I should use the un-escaped Unicode character instead or even just the ASCII straight apostrophe/single quote, please let me know.