### PR TITLE
cheat sheet: Tweak the transplanted commit annotations

### DIFF
--- a/content/cheat-sheet/_index.html
+++ b/content/cheat-sheet/_index.html
@@ -510,7 +510,7 @@ headings:
             C [label="C", pos="2,1!"];
             D [label="D", color="#f14e32", pos="2,0!"];
             E [label="E", color="#f14e32", pos="3,0!"];
-            S [label="D&#x2032;\nE&#x2032;", color="#f14e32", pos="3,1!", width=0.6, height=0.8];
+            S [label="D\nE", color="#f14e32", pos="3,1!", width=0.6, height=0.9];
 
             main_label [label="main", shape=plaintext, pos="5,1!", fixedsize=false];
             main_label -> S [dir=forward];


### PR DESCRIPTION
Made a couple of tweaks to #2076 that I think will make things clearer:

1. Make the D' boxes a bit wider, so it doesn't look so cramped
2. Remove the "prime" from the stacked D and E

The idea of the "prime" annotation is that D is somehow a shorthand for a commit ID, and D' is meant to suggest that the transplanted commit has a different commit ID. I think this makes sense.

But with the stacked D and E, the two D and E being grouped together are already doing the work to show that the new commit is modified in some way, so we don't need to add the "prime" (and it's not clear to me what the prime could actually mean).