### PR TITLE
cheat sheet: Suggest git-restore for discarding changes

### DIFF
--- a/content/cheat-sheet/_index.html
+++ b/content/cheat-sheet/_index.html
@@ -212,10 +212,14 @@ headings:
     <h2 id="discard-your-changes">Discard Your Changes</h2>
     <div class="item">
       <h3>Delete unstaged changes to one file:</h3>
+      <code>git restore &lt;file&gt;</code>
+      <span class="or">OR</span>
       <code>git checkout &lt;file&gt;</code>
     </div>
     <div class="item">
       <h3>Delete all staged and unstaged changes to one file:</h3>
+      <code>git restore --staged --worktree &lt;file&gt;</code>
+      <span class="or">OR</span>
       <code>git checkout HEAD &lt;file&gt;</code>
     </div>
     <div class="item">


### PR DESCRIPTION
In modern versions of Git, `git status` will suggest using `git restore` in these cases. Also, in all other instances, the cheat sheet already lists `git switch` or `git restore` alternatives to `git checkout`.

## Changes

<!-- List the changes this PR makes. -->

- Add `git restore <file>` and `git restore --staged --worktree <file>` as alternatives to `git checkout <file>` and `git checkout HEAD <file>`, respectively.

## Context

Make the cheat sheet more consistent with `git status`. Also, when teaching Git to new users, using `git switch` and `git restore` consistently in place of `git checkout` arguably makes common workflows easier to understand; and being able to point those new users to the official cheat sheet without introducing new commands would be a big bonus.
