### PR TITLE
Switch to other github URL to fix SSL error

### DIFF
--- a/hugo.yml
+++ b/hugo.yml
@@ -38,7 +38,7 @@ params:
   hugo_version: 0.148.2
   pagefind_version: 1.4.0
   latest_version: 2.51.0
-  latest_relnote_url: https://raw.github.com/git/git/master/Documentation/RelNotes/2.51.0.adoc
+  latest_relnote_url: https://github.com/git/git/raw/HEAD/Documentation/RelNotes/2.51.0.adoc
   latest_release_date: '2025-08-18'
   macos_installer:
     url: https://sourceforge.net/projects/git-osx-installer/files/git-2.33.0-intel-universal-mavericks.dmg/download?use_mirror=autoselect

--- a/script/update-git-version.rb
+++ b/script/update-git-version.rb
@@ -20,7 +20,7 @@ date = tag.tagger.date
 config = YAML.load_file("hugo.yml")
 config["params"] = {} if config["params"].nil?
 config["params"]["latest_version"] = version
-config["params"]["latest_relnote_url"] = "https://raw.github.com/git/git/master/Documentation/RelNotes/#{version}.adoc"
+config["params"]["latest_relnote_url"] = "https://github.com/git/git/raw/HEAD/Documentation/RelNotes/#{version}.adoc"
 config["params"]["latest_release_date"] = date.strftime("%Y-%m-%d")
 yaml = YAML.dump(config).gsub(/ *$/, "")
 File.write("hugo.yml", yaml)


### PR DESCRIPTION
While using the  https://raw.githubusercontent.com/... URL would have worked, Johannes Schindelin (@dscho) suggested to use these for robustness.

## Changes

Changed URL pattern of Github for the the release notes.

## Context

https://git-scm.com/ Release notes point to https://raw.github.com/git/git/master/Documentation/RelNotes/2.51.0.adoc which at least for me suddenly result in a certificate error (Error 503 hostname doesn't match against certificate), while https://raw.githubusercontent.com/git/git/master/Documentation/RelNotes/2.51.0.adoc works