### PR TITLE
Removing git fetch --all

### DIFF
--- a/content/cheat-sheet/_index.html
+++ b/content/cheat-sheet/_index.html
@@ -732,7 +732,7 @@ headings:
       <code>git pull</code>
     </div>
     <div class="item">
-      <h3>Fetch all branches:</h3>
+      <h3>Fetch all remotes:</h3>
       <code>git fetch --all</code>
     </div>
   </section>

--- a/content/cheat-sheet/_index.html
+++ b/content/cheat-sheet/_index.html
@@ -731,10 +731,6 @@ headings:
       <span class="or">OR</span>
       <code>git pull</code>
     </div>
-    <div class="item">
-      <h3>Fetch all remotes:</h3>
-      <code>git fetch --all</code>
-    </div>
   </section>
 
   <section>


### PR DESCRIPTION
## Changes

- Original change: ```git fetch --all``` fetches all remotes. The cheat sheet stated that it's fetching all branches.
- Updated change: Remove the entry altogether since it's rarely used and therefore might not be well placed in a cheat sheet. 

## Context

A colleague of mine pointed out, that ```git fetch --all``` doesn't fetch all branches but all remotes.
```git fetch --help``` confirms that.
After discussing in the PR I now suggest to remove it with an updated change.
