### PR TITLE
book: mark the Persian translation as complete!

### DIFF
--- a/layouts/partials/translations.html
+++ b/layouts/partials/translations.html
@@ -9,6 +9,7 @@ This book is available in
     <tr><td><a href="{{ partial "translated-chapter.html" (dict "ctx" . "lang" "bg") }}">български език</a>,</td></tr>
     <tr><td><a href="{{ partial "translated-chapter.html" (dict "ctx" . "lang" "de") }}">Deutsch</a>,</td></tr>
     <tr><td><a href="{{ partial "translated-chapter.html" (dict "ctx" . "lang" "es") }}">Español</a>,</td></tr>
+    <tr><td><a href="{{ partial "translated-chapter.html" (dict "ctx" . "lang" "fa") }}" dir="rtl">فارسی</a>,</td></tr>
     <tr><td><a href="{{ partial "translated-chapter.html" (dict "ctx" . "lang" "fr") }}">Français</a>,</td></tr>
     <tr><td><a href="{{ partial "translated-chapter.html" (dict "ctx" . "lang" "gr") }}">Ελληνικά</a>,</td></tr>
     <tr><td><a href="{{ partial "translated-chapter.html" (dict "ctx" . "lang" "ja") }}">日本語</a>,</td></tr>
@@ -36,7 +37,6 @@ This book is available in
   Translations started for
   <table>
     <tr><td><a href="{{ partial "translated-chapter.html" (dict "ctx" . "lang" "be") }}">Беларуская</a>,</td></tr>
-    <tr><td><a href="{{ partial "translated-chapter.html" (dict "ctx" . "lang" "fa") }}" dir="rtl">فارسی</a>,</td></tr>
     <tr><td><a href="{{ partial "translated-chapter.html" (dict "ctx" . "lang" "id") }}">Indonesian</a>,</td></tr>
     <tr><td><a href="{{ partial "translated-chapter.html" (dict "ctx" . "lang" "it") }}">Italiano</a>,</td></tr>
     <tr><td><a href="{{ partial "translated-chapter.html" (dict "ctx" . "lang" "ms") }}">Bahasa Melayu</a>,</td></tr>


### PR DESCRIPTION
## Changes

- Moves the Persian translation of the ProGit book from the "translation started" section to the "full translation available one".

## Context

🎉

Huge shout-out to @YasinDehfuli for the enormous effort to overhaul and complete the translation! For full details (and a _glimpse_ on the size), see https://github.com/progit/progit2-fa/pull/19.

| before | after |
| - | - |
| <img width="272" height="1283" alt="Screen Shot 2025-09-27 at 14 39 37" src="https://github.com/user-attachments/assets/6367dd64-5a78-4b77-96b5-addeb4ee8f4e" /> | <img width="272" height="1283" alt="Screen Shot 2025-09-27 at 14 40 05" src="https://github.com/user-attachments/assets/485fd690-2638-414c-b0c4-6253e7f80c7a" /> |
| toc | toc |
| <img width="877" height="2830" alt="Screen Shot 2025-09-27 at 14 27 07" src="https://github.com/user-attachments/assets/ed91fb04-1566-4d32-8f1d-336153738a00" /> | <img width="877" height="4522" alt="Screen Shot 2025-09-27 at 14 31 25" src="https://github.com/user-attachments/assets/be90200b-93e1-4792-b575-368eeeadd794" /> |
