### PR TITLE
Add a GitHub workflow cache to manually purge the Cloudflare cache

### DIFF
--- a/.github/workflows/purge-cache.yml
+++ b/.github/workflows/purge-cache.yml
@@ -1,0 +1,25 @@
+name: Purge Cloudflare Cache
+
+on:
+  workflow_dispatch:
+
+jobs:
+  purge-cache:
+    concurrency:
+      group: "purge-cache"
+      cancel-in-progress: false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Purge Cloudflare cache
+        shell: bash
+        env:
+          CLOUDFLARE_TOKEN: ${{ secrets.CLOUDFLARE_TOKEN }}
+          CLOUDFLARE_ZONE: ${{ secrets.CLOUDFLARE_ZONE }}
+        if: env.CLOUDFLARE_TOKEN != ''
+        run: |
+          curl "https://api.cloudflare.com/client/v4/zones/$CLOUDFLARE_ZONE/purge_cache" \
+            -H "Authorization: Bearer $CLOUDFLARE_TOKEN" \
+            -H "Content-Type: application/json" \
+            -d '{ "purge_everything": true }'
+
+


### PR DESCRIPTION
## Changes

- Adds a workflow definition to manually trigger a Cloudflare purge

## Context

In https://github.com/git/git-scm.com/issues/2086, and then also in https://github.com/git/git-scm.com/issues/2093, we saw problems where the cache-purging logic that is supposed to be run as part of deploying the site seems not to have worked as expected. The symptom is that the CSS (whose file name now changes when its contents change) isn't loading, because the front-page still serves an older version (one that references a no-longer-existing CSS).

Let's add a way to manually purge the cache. It is totally possible that this is one of those [famous "Close Door" elevator buttons](https://www.sciencealert.com/the-close-door-buttons-in-elevators-don-t-actually-do-anything) that fool us into believing that we did something, _anything_. But _just_ in case it isn't such a no-op, let's have a GitHub workflow so that we can trigger a Cloudflare cache purge manually.

[Here](https://github.com/git/git-scm.com/actions/runs/18134159656/job/51608395791) is the workflow run that I would like to believe fixed the issue.