### PR TITLE
reference.scss: adapt tooltip to dark mode

### DIFF
--- a/assets/sass/reference.scss
+++ b/assets/sass/reference.scss
@@ -64,8 +64,8 @@ h3.plumbing {
   visibility: hidden;
 
   .tooltip-content {
-    background: white;
-    border: 1px solid #ccc;
+    background: var(--main-bg);
+    border: 1px solid var(--base-border-color);
     border-radius: 4px;
     padding: 10px;
     box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);


### PR DESCRIPTION
## Changes

<!-- List the changes this PR makes. -->

- reference.scss: adapt tooltip to dark mode (a757b2ba8dfcf6f6317f428690a335112608474e)

## Context

<!-- Explain why you're making these changes. -->

Hello! I think the tooltip was forgotten. Please see the comparison of "before vs. after" below:

<img width="1605" height="1030" alt="dark" src="https://github.com/user-attachments/assets/1277c960-5c2f-444b-b018-c46465c664a2" />

<img width="1604" height="1031" alt="light" src="https://github.com/user-attachments/assets/5019ca7b-28f1-407b-981f-f4af90e9260a" />

.