### PR TITLE
reference: link to our own cheat sheet

### DIFF
--- a/layouts/partials/ref/index.html
+++ b/layouts/partials/ref/index.html
@@ -3,10 +3,8 @@
   <h1>Reference</h1>
   <div class='callout quickref'>
     <p>
-      Quick reference guides:
-      <a href="https://github.github.com/training-kit/">GitHub Cheat Sheet</a>
-      |
-      <a href="https://ndpsoftware.com/git-cheatsheet.html">Visual Git Cheat Sheet</a>
+      Quick reference guide:
+      <a href="{{ relURL "cheat-sheet" }}">Cheat Sheet</a>
     </p>
   </div>
   <div class="callout all-commands">


### PR DESCRIPTION
From the reference overview we were linking to two cheat sheets:

* https://training.github.com/: By GitHub, but doesn't look really well maintained.
* https://ndpsoftware.com/git-cheatsheet.html: Which looks fancy, but is behind a self-signed SSL certificate.

Since https://github.com/git/git-scm.com/pull/2049 we have our own cheat sheet, link to that one instead.

Preview at: https://to1ne.github.io/git-scm.com/docs