### PR TITLE
update mac download details 

### DIFF
--- a/content/install/mac.html
+++ b/content/install/mac.html
@@ -24,8 +24,11 @@ aliases:
   <p>Install <a href="https://www.macports.org">MacPorts</a> if you don't already have it, then:<br>
   <code>$ sudo port install git</code></p>
 
-  <h3>Xcode</h3>
-  <p>Apple ships a binary package of Git with <a href="https://developer.apple.com/xcode/">Xcode</a>.</p>
+  <h3>Xcode Command Line Tools</h3>
+  <p>Apple ships a binary package of Git with <a
+  href="https://developer.apple.com/xcode/resources/">Xcode Command Line
+  Tools</a>. You can install this via:<br>
+  <code>$ xcode-select --install</code></p>
 
   <h3>Installing git-gui</h3>
   <p>If you would like to install <a href="https://git-scm.com/docs/git-gui/">git-gui</a> and <a href="https://git-scm.com/docs/gitk/">gitk</a>,

--- a/content/install/mac.html
+++ b/content/install/mac.html
@@ -30,6 +30,11 @@ aliases:
   Tools</a>. You can install this via:<br>
   <code>$ xcode-select --install</code></p>
 
+  <h3>Binary installer</h3>
+  <p>Tim Harper provided an installer for Git until version 2.33.0 / 2021.
+  These installers are no longer linked from here because there are no updates
+  since that version, nor are there plans to provide any.</p>
+
   <h3>Installing git-gui</h3>
   <p>If you would like to install <a href="https://git-scm.com/docs/git-gui/">git-gui</a> and <a href="https://git-scm.com/docs/gitk/">gitk</a>,
   git's commit GUI and interactive history browser, you can do so using <a href="https://brew.sh/">homebrew</a><br>


### PR DESCRIPTION
This will update the mac downloads page replacing Xcode with Xcode Command Line Tools which is smaller in installation size compared to full Xcode and can be installed via command line. It also re adds mentioning the binary installer to reduce confusion, a lot of locations on the internet and print are point to this page indicating there is a binary installer.