### PR TITLE
Fix broken link to maintain-git documentation

### DIFF
--- a/content/community/_index.html
+++ b/content/community/_index.html
@@ -101,7 +101,7 @@ aliases:
   <h2 id="contributing"><a class="anchor" href="#contributing"></a> Contributing to Git </h2>
 
   <p>
-    The <a href="https://github.com/git/git/tree/master/Documentation">Documentation directory</a> in the Git source code has several files of interest to developers who are looking to help contribute. After reading the <a href="{{< relurl "docs/CodingGuidelines" >}}">coding guidelines</a> and <a href="https://github.com/git/git/blob/master/CODE_OF_CONDUCT.md">code of conduct</a>, you can learn <a href="{{< relurl "docs/SubmittingPatches" >}}">how to submit patches</a>. If you are just starting out, you can read the <a href="{{< relurl "docs/MyFirstContribution" >}}">My First Contribution tutorial</a>. For those looking to get more deeply involved, there is a <a href="https://github.com/git/git/blob/master/Documentation/howto/maintain-git.txt">howto for Git maintainers</a>.
+    The <a href="https://github.com/git/git/tree/master/Documentation">Documentation directory</a> in the Git source code has several files of interest to developers who are looking to help contribute. After reading the <a href="{{< relurl "docs/CodingGuidelines" >}}">coding guidelines</a> and <a href="https://github.com/git/git/blob/master/CODE_OF_CONDUCT.md">code of conduct</a>, you can learn <a href="{{< relurl "docs/SubmittingPatches" >}}">how to submit patches</a>. If you are just starting out, you can read the <a href="{{< relurl "docs/MyFirstContribution" >}}">My First Contribution tutorial</a>. For those looking to get more deeply involved, there is a <a href="https://github.com/git/git/blob/master/Documentation/howto/maintain-git.adoc">howto for Git maintainers</a>.
   </p>
 
   <p>


### PR DESCRIPTION
## Summary
This PR fixes a broken link in the Community page that points to the Git maintainer's documentation.

## Changes
- Updated the link from `maintain-git.txt` to `maintain-git.adoc`

## Context
The documentation file was renamed from `.txt` to `.adoc` format in the git/git repository, but the link on the git-scm.com website was not updated accordingly. This was causing a 404 error when users clicked on the "howto for Git maintainers" link.