### PR TITLE
Fix "Install" link on Windows

### DIFF
--- a/assets/js/application.js
+++ b/assets/js/application.js
@@ -819,7 +819,7 @@ var InstallPageLink = {
     if (os === "Mac") {
       installLink.href = installLink.href.replace('/install', '/install/mac');
     } else if (os === "Windows") {
-      installLink.href = installLink.href.replace('/install', '/install/win');
+      installLink.href = installLink.href.replace('/install', '/install/windows');
     } else if (os === "Linux") {
       installLink.href = installLink.href.replace('/install', '/install/linux');
     }

--- a/content/install/windows.html
+++ b/content/install/windows.html
@@ -4,6 +4,7 @@ title: "Git - Install for Windows"
 aliases:
 - /download/win
 - /downloads/win
+- /install/win
 ---
 
 <div id="main">


### PR DESCRIPTION
## Changes

This makes the "Install" link on the front page work again.

## Context

In #2096, the link location was changed, but one conversion was incomplete: Clicking the "Install" link on the front page directs to `/install/win`, which does not currently exist (but `/install/windows` does).

To help this, not only do we fix the link here, but we also add a redirect for the `/install/win` URL.