### PR TITLE
fixed/Build from Source’ tab partially hidden in mobile view on Install page #2106

### DIFF
--- a/assets/sass/install.scss
+++ b/assets/sass/install.scss
@@ -42,9 +42,11 @@
 
   @media (max-width: $mobile-m) {
     a[role="tab"] {
-      padding: .5rem;
+      padding: .5rem .25rem;
+      font-size: 0.75rem;
       line-height: 1.2em;
       display: flex;
+      flex: 1;
 
       span {
         margin: auto;

--- a/assets/sass/install.scss
+++ b/assets/sass/install.scss
@@ -43,14 +43,6 @@
   @media (max-width: $mobile-m) {
     a[role="tab"] {
       padding: .5rem .25rem;
-      font-size: 0.75rem;
-      line-height: 1.2em;
-      display: flex;
-      flex: 1;
-
-      span {
-        margin: auto;
-      }
     }
   }
 }


### PR DESCRIPTION
…ll page #2106

# screenshots

previously 

<img width="408" height="797" alt="Screenshot From 2025-11-11 11-24-19" src="https://github.com/user-attachments/assets/1ee246d6-c7f3-460f-8f15-13a1592965f0" />

fixed

<img width="408" height="797" alt="Screenshot From 2025-11-11 13-00-49" src="https://github.com/user-attachments/assets/83f42286-175f-4668-af61-af09b404d514" />



## Changes

font size and  padding reduced so clearly visible on phone view 

edit install.css file   for mobile view
