### PR TITLE
Fix `downloads/` and `doc/` redirects

### DIFF
--- a/content/doc/_index.html
+++ b/content/doc/_index.html
@@ -1,0 +1,3 @@
+---
+redirect_to: docs
+---

--- a/content/download/gui/_index.html
+++ b/content/download/gui/_index.html
@@ -1,3 +1,0 @@
----
-redirect_to: downloads/guis
----


### PR DESCRIPTION
## Changes

- Fixes the URLs https://git-scm.com/doc/ and https://git-scm.com/download/ (to redirect to https://git-scm.com/docs and https://git-scm.com/install/, respectively)

## Context

Fixes #2111 