### PR TITLE
Use rendered docs URLs for release notes

### DIFF
--- a/hugo.yml
+++ b/hugo.yml
@@ -38,7 +38,7 @@ params:
   hugo_version: 0.148.2
   pagefind_version: 1.4.0
   latest_version: 2.52.0
-  latest_relnote_url: https://github.com/git/git/raw/HEAD/Documentation/RelNotes/2.52.0.adoc
+  latest_relnote_url: https://gitlab.com/git-scm/git/-/blob/HEAD/Documentation/RelNotes/2.52.0.adoc
   latest_release_date: '2025-11-17'
   windows_installer:
     installer_x64:

--- a/layouts/shortcodes/install-header.html
+++ b/layouts/shortcodes/install-header.html
@@ -4,7 +4,7 @@
     <h1>Install</h1>
     <div class="version-badge">
       Latest version: {{ site.Params.latest_version }}
-      (<a href="https://github.com/git/git/blob/HEAD/Documentation/RelNotes/{{ site.Params.latest_version }}.adoc">Release Notes</a>)
+      (<a href="{{ site.Params.latest_relnote_url }}">Release Notes</a>)
     </div>
   </div>
 

--- a/script/update-git-version.rb
+++ b/script/update-git-version.rb
@@ -20,7 +20,7 @@ date = tag.tagger.date
 config = YAML.load_file("hugo.yml")
 config["params"] = {} if config["params"].nil?
 config["params"]["latest_version"] = version
-config["params"]["latest_relnote_url"] = "https://github.com/git/git/raw/HEAD/Documentation/RelNotes/#{version}.adoc"
+config["params"]["latest_relnote_url"] = "https://gitlab.com/git-scm/git/-/blob/HEAD/Documentation/RelNotes/#{version}.adoc"
 config["params"]["latest_release_date"] = date.strftime("%Y-%m-%d")
 yaml = YAML.dump(config).gsub(/ *$/, "")
 File.write("hugo.yml", yaml)


### PR DESCRIPTION
## Changes

<!-- List the changes this PR makes. -->

- This PR updates those URLs to the raw release notes so that they appear well formatted, making them easier to read for contributors and users.

### Files Changed

- `hugo.yml`
- `script/update-git-version.rb`
- `layouts/shortcodes/install-header.html`

Example before:
https://github.com/git/git/raw/HEAD/Documentation/RelNotes/2.52.0.adoc

Example after:
https://gitlab.com/git-scm/git/-/blob/v2.52.0/Documentation/RelNotes/2.52.0.adoc

## Context

The existing release notes URLs reference the raw AsciiDoc files on raw.githubusercontent.com, which renders as plain text without formatting. As a result, the release notes are harder to read.

This update replaces those raw URLs with links to the rendered AsciiDoc view on the GitLab mirror, making the release notes more readable and user-friendly. The links now reference the tagged version (v2.52.0) to ensure they remain stable and accurately reflect the contents of the 2.52.0 release.
