### PR TITLE
Fix the external link to the course “Versioned and reproducible storage of code and data”

### DIFF
--- a/layouts/shortcodes/external/courses.html
+++ b/layouts/shortcodes/external/courses.html
@@ -13,7 +13,7 @@
 <div class='column-right'>
 <ul class='course-list'>
   <li>
-    <h4><a href="https://cusy.io/en/our-training-courses/versioned-and-reproducible-storage-of-code-and-data">Versioned and reproducible storage of code and data</a></h4>
+    <h4><a href="https://cusy.io/en/our-training-courses/versioned-and-reproducible-storage-of-code-and-data.html">Versioned and reproducible storage of code and data</a></h4>
     <p class='description'>
       Three-day course on Git in data science
     </p>


### PR DESCRIPTION
## Changes

Changing the link to https://cusy.io/en/our-training-courses/versioned-and-reproducible-storage-of-code-and-data.html

-

## Context

The previous link no longer worked.
