### PR TITLE
Update git rankings based on google trends results

### DIFF
--- a/data/guis/git-extensions.yml
+++ b/data/guis/git-extensions.yml
@@ -6,5 +6,5 @@ platforms:
   - "Windows"
 price: "Free"
 license: "GNU GPL"
-order: 4
+order: 6
 ---

--- a/data/guis/gitkraken-desktop.yml
+++ b/data/guis/gitkraken-desktop.yml
@@ -9,5 +9,5 @@ platforms:
 # Free tier only works with local and public repositories
 price: "Free / $48+/user annually"
 license: "Proprietary"
-order: 5
+order: 3
 ---

--- a/data/guis/magit.yml
+++ b/data/guis/magit.yml
@@ -8,5 +8,5 @@ platforms:
   - "Linux"
 price: "Free"
 license: "GNU GPL"
-order: 6
+order: 5
 ---

--- a/data/guis/tortoisegit.yml
+++ b/data/guis/tortoisegit.yml
@@ -6,5 +6,5 @@ platforms:
   - "Windows"
 price: "Free"
 license: "GNU GPL"
-order: 3
+order: 4
 ---


### PR DESCRIPTION
Results updated based on this Google Trends link:
https://trends.google.com/explore?q=GitKraken%2CGitHub%2520Desktop%2CSourceTree%2CGit%2520Tower%2CGit%2520Extensions%2CTortoiseGit%2CSmartGit%2CMagit&date=today%201-y&geo=Worldwide

## Changes

This PR changes the order value of 4 Git GUIs based on their ranking in recent Google Trends.

## Context

After reviewing previously merged PRs, it seems that the sort order is based on Google Trends results.
