### PR TITLE
Remove obsolete references to screenshot snapshots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,3 @@
 /node_modules/
 /test-results/
 /playwright-report/
-/tests/git-scm.spec.js-snapshots/*-darwin.png
-/tests/git-scm.spec.js-snapshots/*-win32.png

--- a/README.md
+++ b/README.md
@@ -189,9 +189,6 @@ $ PLAYWRIGHT_TEST_URL='http://localhost:5000/' npx playwright test --project=fir
 
 For more fine-grained testing, you can pass `-g <regex>` to run only the matching test cases.
 
-> [!NOTE]
-> When running the test suite on platforms other than Linux, the first run will "fail" in the `dark mode` test case. That is expected! This test case relies on previously-generated screenshots that are stored in `tests/git-scm.spec.js-snapshots/`, and for bandwidth reasons only the Linux ones are committed in the Git repository (because they are required to run the PR/CI builds). The first run will store those screenshots so that subsequent runs of this test case will succeed, though.
-
 ## Update manual pages
 
 First, install the Ruby prerequisites:


### PR DESCRIPTION
## Changes

- Ties up a few loose ends of https://github.com/git/git-scm.com/pull/2097

## Context

In e3c066ef2 ("test: verify dark/light mode via normalized relative luminance"), the dark mode test was rewritten to use an average-brightness approach instead of comparing against reference screenshots. Follow-up commit f3d324074 ("test: remove screenshot snapshots for dark/light mode tests") removed the tracked Linux snapshot images, but left behind the `.gitignore` entries that suppressed the non-Linux (macOS and Windows) snapshots, as well as the README note explaining that the first test run on those platforms would "fail" while generating the baseline screenshots.

Since `toHaveScreenshot` is no longer used anywhere in the test suite, clean up these leftovers: remove the two `.gitignore` patterns for `*-darwin.png` and `*-win32.png` in the snapshots directory, and remove the now-inaccurate README paragraph about first-run screenshot failures on non-Linux platforms.