### PR TITLE
ci: update actions due to deprecation of Node 20

### DIFF
--- a/.github/actions/deploy-to-github-pages/action.yml
+++ b/.github/actions/deploy-to-github-pages/action.yml
@@ -299,7 +299,7 @@ runs:
         # avoid test failures when HTTPS is enforced half-way through
         PLAYWRIGHT_EXTERNAL_HTTPS: ${{ inputs.external-https }}
       run: npx playwright test --project=chrome
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       if: always() && steps.playwright.outputs.result != ''
       with:
         name: playwright-report

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: configure Hugo and Pagefind version
       run: |
@@ -50,7 +50,7 @@ jobs:
       run: cd public && tar czvf ../pages.tar.gz *
 
     - name: Upload build artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: pages
         path: pages.tar.gz
@@ -96,7 +96,7 @@ jobs:
       run: |
         echo "result=$PLAYWRIGHT_TEST_URL" >>$GITHUB_OUTPUT &&
         npx playwright test --project=chrome
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       if: always() && steps.playwright.outputs.result != ''
       with:
         name: playwright-report

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,7 @@ jobs:
       name: github-pages
       url: ${{ steps.deploy.outputs.url }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: deploy to GitHub Pages
         id: deploy
         uses: ./.github/actions/deploy-to-github-pages

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -11,7 +11,7 @@ jobs:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - uses: actions/setup-node@v4
       with:
         node-version: lts/*
@@ -21,7 +21,7 @@ jobs:
       env:
         PLAYWRIGHT_TEST_URL: ${{ github.event.inputs.url }}
       run: npx playwright test --project=chrome
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       if: always()
       with:
         name: playwright-report

--- a/.github/workflows/update-book.yml
+++ b/.github/workflows/update-book.yml
@@ -16,7 +16,7 @@ jobs:
     if: github.event.repository.fork == false || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           sparse-checkout: |
             external/book/sync
@@ -48,7 +48,7 @@ jobs:
         language: ${{ fromJson(needs.check-for-updates.outputs.matrix) }}
       fail-fast: false
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           sparse-checkout: |
             script
@@ -111,7 +111,7 @@ jobs:
         run: |
           git branch -m book-${{ matrix.language.lang }}
           git bundle create ${{ matrix.language.lang }}.bundle refs/remotes/origin/${{ github.ref_name }}..book-${{ matrix.language.lang }}
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: bundle-${{ matrix.language.lang }}
           path: ${{ matrix.language.lang }}.bundle
@@ -131,7 +131,7 @@ jobs:
       url: ${{ steps.deploy.outputs.url }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/download-artifact@v4
       - name: apply updates
         id: apply

--- a/.github/workflows/update-download-data.yml
+++ b/.github/workflows/update-download-data.yml
@@ -22,7 +22,7 @@ jobs:
       name: github-pages
       url: ${{ steps.deploy.outputs.url }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           sparse-checkout: |
             .github/actions

--- a/.github/workflows/update-git-version-and-manual-pages.yml
+++ b/.github/workflows/update-git-version-and-manual-pages.yml
@@ -27,7 +27,7 @@ jobs:
       name: github-pages
       url: ${{ steps.deploy.outputs.url }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           sparse-checkout: |
             .github/actions

--- a/.github/workflows/update-translated-manual-pages.yml
+++ b/.github/workflows/update-translated-manual-pages.yml
@@ -19,7 +19,7 @@ jobs:
     if: github.event.repository.fork == false || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           sparse-checkout: |
             external/docs/sync
@@ -46,7 +46,7 @@ jobs:
       name: github-pages
       url: ${{ steps.deploy.outputs.url }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: ruby setup
         uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
## Changes

<!-- List the changes this PR makes. -->

- ci: update actions due to deprecation of Node 20

## Context

> <div>Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4, actions/upload-artifact@v4. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: <a href="https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/" class="link-gray" rel="noreferrer noopener nofollow" data-test-selector="linkified">https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/</a></div>

.
