### PR TITLE
Two fixes to Community / Logos page

### DIFF
--- a/content/community/logos.html
+++ b/content/community/logos.html
@@ -15,7 +15,7 @@ aliases:
     <div class="column-left">
       <ul class="content-list">
         <li>
-          <a href=""><img src="{{< relurl "images/logos/2color-lightbg@2x.png" >}}" width="294" height="100"></a>
+          <img src="{{< relurl "images/logos/2color-lightbg@2x.png" >}}" width="294" height="100">
           <h4>Full color Git logo for light backgrounds</h4>
           <p class="description">
             <a href="{{< relurl "images/logos/downloads/Git-Logo-2Color.png" >}}">PNG (bitmap)</a>
@@ -26,7 +26,7 @@ aliases:
           </p>
         </li>
         <li>
-          <a href=""><img src="{{< relurl "images/logos/1color-orange-lightbg@2x.png" >}}" width="294" height="100"></a>
+          <img src="{{< relurl "images/logos/1color-orange-lightbg@2x.png" >}}" width="294" height="100">
           <h4>Orange Git logo for light backgrounds</h4>
           <p class="description">
             <a href="{{< relurl "images/logos/downloads/Git-Logo-1788C.png" >}}">PNG (bitmap)</a>
@@ -37,7 +37,7 @@ aliases:
           </p>
         </li>
         <li>
-          <a href=""><img src="{{< relurl "images/logos/1color-lightbg@2x.png" >}}" width="294" height="100"></a>
+          <img src="{{< relurl "images/logos/1color-lightbg@2x.png" >}}" width="294" height="100">
           <h4>One color Git logo for light backgrounds</h4>
           <p class="description">
             <a href="{{< relurl "images/logos/downloads/Git-Logo-Black.png" >}}">PNG (bitmap)</a>
@@ -48,7 +48,7 @@ aliases:
           </p>
         </li>
         <li>
-          <a href=""><img src="{{< relurl "images/logos/1color-darkbg@2x.png" >}}" width="294" height="100"></a>
+          <img src="{{< relurl "images/logos/1color-darkbg@2x.png" >}}" width="294" height="100">
           <h4>One color Git logo for dark backgrounds</h4>
           <p class="description">
             <a href="{{< relurl "images/logos/downloads/Git-Logo-White.png" >}}">PNG (bitmap)</a>
@@ -63,7 +63,7 @@ aliases:
     <div class="column-right">
       <ul class="content-list">
         <li>
-          <a href=""><img src="{{< relurl "images/logos/logomark-orange@2x.png" >}}" width="100" height="100"></a>
+          <img src="{{< relurl "images/logos/logomark-orange@2x.png" >}}" width="100" height="100">
           <h4>Orange logomark for light backgrounds</h4>
           <p class="description">
             <a href="{{< relurl "images/logos/downloads/Git-Icon-1788C.png" >}}">PNG (bitmap)</a>
@@ -74,7 +74,7 @@ aliases:
           </p>
         </li>
         <li>
-          <a href=""><img src="{{< relurl "images/logos/logomark-black@2x.png" >}}" width="100" height="100"></a>
+          <img src="{{< relurl "images/logos/logomark-black@2x.png" >}}" width="100" height="100">
           <h4>Black logomark for light backgrounds</h4>
           <p class="description">
             <a href="{{< relurl "images/logos/downloads/Git-Icon-Black.png" >}}">PNG (bitmap)</a>
@@ -85,7 +85,7 @@ aliases:
           </p>
         </li>
         <li>
-          <a href=""><img src="{{< relurl "images/logos/logomark-white@2x.png" >}}" width="100" height="100"></a>
+          <img src="{{< relurl "images/logos/logomark-white@2x.png" >}}" width="100" height="100">
           <h4>White logomark for dark backgrounds</h4>
           <p class="description">
             <a href="{{< relurl "images/logos/downloads/Git-Icon-White.png" >}}">PNG (bitmap)</a>

--- a/content/community/logos.html
+++ b/content/community/logos.html
@@ -15,7 +15,7 @@ aliases:
     <div class="column-left">
       <ul class="content-list">
         <li>
-          <a href=""><img src="{{< relurl "images/logos/2color-lightbg@2x.png" >}}" width="294", height="100"></a>
+          <a href=""><img src="{{< relurl "images/logos/2color-lightbg@2x.png" >}}" width="294" height="100"></a>
           <h4>Full color Git logo for light backgrounds</h4>
           <p class="description">
             <a href="{{< relurl "images/logos/downloads/Git-Logo-2Color.png" >}}">PNG (bitmap)</a>
@@ -26,7 +26,7 @@ aliases:
           </p>
         </li>
         <li>
-          <a href=""><img src="{{< relurl "images/logos/1color-orange-lightbg@2x.png" >}}" width="294", height="100"></a>
+          <a href=""><img src="{{< relurl "images/logos/1color-orange-lightbg@2x.png" >}}" width="294" height="100"></a>
           <h4>Orange Git logo for light backgrounds</h4>
           <p class="description">
             <a href="{{< relurl "images/logos/downloads/Git-Logo-1788C.png" >}}">PNG (bitmap)</a>
@@ -37,7 +37,7 @@ aliases:
           </p>
         </li>
         <li>
-          <a href=""><img src="{{< relurl "images/logos/1color-lightbg@2x.png" >}}" width="294", height="100"></a>
+          <a href=""><img src="{{< relurl "images/logos/1color-lightbg@2x.png" >}}" width="294" height="100"></a>
           <h4>One color Git logo for light backgrounds</h4>
           <p class="description">
             <a href="{{< relurl "images/logos/downloads/Git-Logo-Black.png" >}}">PNG (bitmap)</a>
@@ -48,7 +48,7 @@ aliases:
           </p>
         </li>
         <li>
-          <a href=""><img src="{{< relurl "images/logos/1color-darkbg@2x.png" >}}" width="294", height="100"></a>
+          <a href=""><img src="{{< relurl "images/logos/1color-darkbg@2x.png" >}}" width="294" height="100"></a>
           <h4>One color Git logo for dark backgrounds</h4>
           <p class="description">
             <a href="{{< relurl "images/logos/downloads/Git-Logo-White.png" >}}">PNG (bitmap)</a>
@@ -63,7 +63,7 @@ aliases:
     <div class="column-right">
       <ul class="content-list">
         <li>
-          <a href=""><img src="{{< relurl "images/logos/logomark-orange@2x.png" >}}" width="100", height="100"></a>
+          <a href=""><img src="{{< relurl "images/logos/logomark-orange@2x.png" >}}" width="100" height="100"></a>
           <h4>Orange logomark for light backgrounds</h4>
           <p class="description">
             <a href="{{< relurl "images/logos/downloads/Git-Icon-1788C.png" >}}">PNG (bitmap)</a>
@@ -74,7 +74,7 @@ aliases:
           </p>
         </li>
         <li>
-          <a href=""><img src="{{< relurl "images/logos/logomark-black@2x.png" >}}" width="100", height="100"></a>
+          <a href=""><img src="{{< relurl "images/logos/logomark-black@2x.png" >}}" width="100" height="100"></a>
           <h4>Black logomark for light backgrounds</h4>
           <p class="description">
             <a href="{{< relurl "images/logos/downloads/Git-Icon-Black.png" >}}">PNG (bitmap)</a>
@@ -85,7 +85,7 @@ aliases:
           </p>
         </li>
         <li>
-          <a href=""><img src="{{< relurl "images/logos/logomark-white@2x.png" >}}" width="100", height="100"></a>
+          <a href=""><img src="{{< relurl "images/logos/logomark-white@2x.png" >}}" width="100" height="100"></a>
           <h4>White logomark for dark backgrounds</h4>
           <p class="description">
             <a href="{{< relurl "images/logos/downloads/Git-Icon-White.png" >}}">PNG (bitmap)</a>


### PR DESCRIPTION
Firstly, remove bogus comma inside the `<img>` tags.  I believe this was
a left over from when the images were inserted via a function, such as:

    image_tag('logos/logomark-orange@2x.png', {:width => 100, :height => 100})

becoming

    <img src="/images/logos/logomark-orange@2x.png" width="100", height="100">

Secondly, remove links with an empty href.  Those only serve to confuse the
user.
