### PR TITLE
l10n: fix typo "NITES" → "NOTES" in French translation

### DIFF
--- a/external/docs/asciidoc/261ca1a21c465cd4848902a4a993789ef9433fde
+++ b/external/docs/asciidoc/261ca1a21c465cd4848902a4a993789ef9433fde
@@ -2114,7 +2114,7 @@ C'est identique à l ' option `--decorate` de `git log` .
 Ce réglage peut être remplacé en passant l'option `--strategy` à linkgit:git-notes[1].
 
 `notes.<nom>.mergeStrategy`::
-	La stratégie de fusion à choisir lors de la fusion denote dans `refs/notes/ <nom>`. Cela remplace le plus général `notes.mergeStrategy`. Voir la section « STRATÉGIES DE FUSION DE NITES » dans linkgit:git-notes[1] pour plus d'informations sur les stratégies disponibles.
+	La stratégie de fusion à choisir lors de la fusion denote dans `refs/notes/ <nom>`. Cela remplace le plus général `notes.mergeStrategy`. Voir la section « STRATÉGIES DE FUSION DE NOTES » dans linkgit:git-notes[1] pour plus d'informations sur les stratégies disponibles.
 
 `notes.displayRef`::
 	Depuis quelle réf (ou réfs, si un glob ou si spécifié plus d'une fois), en plus de la configuration réglée par défaut par `core.notesRef ' ou `GIT_NOTES_REF ' , lire les notes lors de l'affichage des messages de validation avec la famille de commandes `git log`.

--- a/external/docs/asciidoc/640867fbc88d9e7288a2b173f0e3b8c7fee7cece
+++ b/external/docs/asciidoc/640867fbc88d9e7288a2b173f0e3b8c7fee7cece
@@ -227,7 +227,7 @@ Tout ce qui se trouve au-dessus de cette ligne dans cette section n'est pas incl
 Ce réglage peut être remplacé en passant l'option `--strategy` à linkgit:git-notes[1].
 
 `notes.<nom>.mergeStrategy`::
-	La stratégie de fusion à choisir lors de la fusion denote dans `refs/notes/ <nom>`. Cela remplace le plus général `notes.mergeStrategy`. Voir la section « STRATÉGIES DE FUSION DE NITES » dans linkgit:git-notes[1] pour plus d'informations sur les stratégies disponibles.
+	La stratégie de fusion à choisir lors de la fusion denote dans `refs/notes/ <nom>`. Cela remplace le plus général `notes.mergeStrategy`. Voir la section « STRATÉGIES DE FUSION DE NOTES » dans linkgit:git-notes[1] pour plus d'informations sur les stratégies disponibles.
 
 `notes.displayRef`::
 	Depuis quelle réf (ou réfs, si un glob ou si spécifié plus d'une fois), en plus de la configuration réglée par défaut par `core.notesRef ' ou `GIT_NOTES_REF ' , lire les notes lors de l'affichage des messages de validation avec la famille de commandes `git log`.

--- a/external/docs/asciidoc/edc0ac6b225ae6c5f59a2d5cb79172a02534581f
+++ b/external/docs/asciidoc/edc0ac6b225ae6c5f59a2d5cb79172a02534581f
@@ -1686,7 +1686,7 @@ endif::[]
 Ce réglage peut être remplacé en passant l'option `--strategy` à linkgit:git-notes[1].
 
 `notes.<nom>.mergeStrategy`::
-	La stratégie de fusion à choisir lors de la fusion denote dans `refs/notes/ <nom>`. Cela remplace le plus général `notes.mergeStrategy`. Voir la section « STRATÉGIES DE FUSION DE NITES » dans linkgit:git-notes[1] pour plus d'informations sur les stratégies disponibles.
+	La stratégie de fusion à choisir lors de la fusion denote dans `refs/notes/ <nom>`. Cela remplace le plus général `notes.mergeStrategy`. Voir la section « STRATÉGIES DE FUSION DE NOTES » dans linkgit:git-notes[1] pour plus d'informations sur les stratégies disponibles.
 
 `notes.displayRef`::
 	Depuis quelle réf (ou réfs, si un glob ou si spécifié plus d'une fois), en plus de la configuration réglée par défaut par `core.notesRef ' ou `GIT_NOTES_REF ' , lire les notes lors de l'affichage des messages de validation avec la famille de commandes `git log`.

--- a/external/docs/content/docs/git-config/fr.html
+++ b/external/docs/content/docs/git-config/fr.html
@@ -2532,7 +2532,7 @@ la section de <a href='{{< relurl "docs/git-mergetool/fr" >}}'>git-mergetool[1]<
 </dd>
 <dt class="hdlist1" id="git-config-spanclasssynopsiscodenotescodeemltnomgtemcodemergeStrategycodespan"> <a class="anchor" href="#git-config-notesnommergeStrategy"></a> <a class="anchor" href="#git-config-spanclasssynopsiscodenotescodeemltnomgtemcodemergeStrategycodespan"></a><span class='synopsis'><code>notes.</code><em>&lt;nom&gt;</em><code>.mergeStrategy</code></span> </dt>
 <dd>
-<p>La stratégie de fusion à choisir lors de la fusion denote dans <span class='synopsis'><code>refs/notes/</code> <em>&lt;nom&gt;</em></span>. Cela remplace le plus général <span class='synopsis'><code>notes.mergeStrategy</code></span>. Voir la section « STRATÉGIES DE FUSION DE NITES » dans <a href='{{< relurl "docs/git-notes/fr" >}}'>git-notes[1]</a> pour plus d&#8217;informations sur les stratégies disponibles.</p>
+<p>La stratégie de fusion à choisir lors de la fusion denote dans <span class='synopsis'><code>refs/notes/</code> <em>&lt;nom&gt;</em></span>. Cela remplace le plus général <span class='synopsis'><code>notes.mergeStrategy</code></span>. Voir la section « STRATÉGIES DE FUSION DE NOTES » dans <a href='{{< relurl "docs/git-notes/fr" >}}'>git-notes[1]</a> pour plus d&#8217;informations sur les stratégies disponibles.</p>
 </dd>
 <dt class="hdlist1" id="git-config-spanclasssynopsiscodenotesdisplayRefcodespan"> <a class="anchor" href="#git-config-notesdisplayRef"></a> <a class="anchor" href="#git-config-spanclasssynopsiscodenotesdisplayRefcodespan"></a><span class='synopsis'><code>notes.displayRef</code></span> </dt>
 <dd>

--- a/external/docs/content/docs/git-log/fr.html
+++ b/external/docs/content/docs/git-log/fr.html
@@ -2894,7 +2894,7 @@ surcharger cette option avec <span class='synopsis'><code>--no-abbrev-commit</co
 </dd>
 <dt class="hdlist1" id="git-log-spanclasssynopsiscodenotescodeemltnomgtemcodemergeStrategycodespan"> <a class="anchor" href="#git-log-notesnommergeStrategy"></a> <a class="anchor" href="#git-log-spanclasssynopsiscodenotescodeemltnomgtemcodemergeStrategycodespan"></a><span class='synopsis'><code>notes.</code><em>&lt;nom&gt;</em><code>.mergeStrategy</code></span> </dt>
 <dd>
-<p>La stratégie de fusion à choisir lors de la fusion denote dans <span class='synopsis'><code>refs/notes/</code> <em>&lt;nom&gt;</em></span>. Cela remplace le plus général <span class='synopsis'><code>notes.mergeStrategy</code></span>. Voir la section « STRATÉGIES DE FUSION DE NITES » dans <a href='{{< relurl "docs/git-notes/fr" >}}'>git-notes[1]</a> pour plus d&#8217;informations sur les stratégies disponibles.</p>
+<p>La stratégie de fusion à choisir lors de la fusion denote dans <span class='synopsis'><code>refs/notes/</code> <em>&lt;nom&gt;</em></span>. Cela remplace le plus général <span class='synopsis'><code>notes.mergeStrategy</code></span>. Voir la section « STRATÉGIES DE FUSION DE NOTES » dans <a href='{{< relurl "docs/git-notes/fr" >}}'>git-notes[1]</a> pour plus d&#8217;informations sur les stratégies disponibles.</p>
 </dd>
 <dt class="hdlist1" id="git-log-spanclasssynopsiscodenotesdisplayRefcodespan"> <a class="anchor" href="#git-log-notesdisplayRef"></a> <a class="anchor" href="#git-log-spanclasssynopsiscodenotesdisplayRefcodespan"></a><span class='synopsis'><code>notes.displayRef</code></span> </dt>
 <dd>

--- a/external/docs/content/docs/git-notes/fr.html
+++ b/external/docs/content/docs/git-notes/fr.html
@@ -360,7 +360,7 @@ $ git notes --ref=built add --allow-empty -C "$blob" HEAD</pre>
 </dd>
 <dt class="hdlist1" id="git-notes-spanclasssynopsiscodenotescodeemltnomgtemcodemergeStrategycodespan"> <a class="anchor" href="#git-notes-notesnommergeStrategy"></a> <a class="anchor" href="#git-notes-spanclasssynopsiscodenotescodeemltnomgtemcodemergeStrategycodespan"></a><span class='synopsis'><code>notes.</code><em>&lt;nom&gt;</em><code>.mergeStrategy</code></span> </dt>
 <dd>
-<p>La stratégie de fusion à choisir lors de la fusion denote dans <span class='synopsis'><code>refs/notes/</code> <em>&lt;nom&gt;</em></span>. Cela remplace le plus général <span class='synopsis'><code>notes.mergeStrategy</code></span>. Voir la section « STRATÉGIES DE FUSION DE NITES » dans <a href='{{< relurl "docs/git-notes/fr" >}}'>git-notes[1]</a> pour plus d&#8217;informations sur les stratégies disponibles.</p>
+<p>La stratégie de fusion à choisir lors de la fusion denote dans <span class='synopsis'><code>refs/notes/</code> <em>&lt;nom&gt;</em></span>. Cela remplace le plus général <span class='synopsis'><code>notes.mergeStrategy</code></span>. Voir la section « STRATÉGIES DE FUSION DE NOTES » dans <a href='{{< relurl "docs/git-notes/fr" >}}'>git-notes[1]</a> pour plus d&#8217;informations sur les stratégies disponibles.</p>
 </dd>
 <dt class="hdlist1" id="git-notes-spanclasssynopsiscodenotesdisplayRefcodespan"> <a class="anchor" href="#git-notes-notesdisplayRef"></a> <a class="anchor" href="#git-notes-spanclasssynopsiscodenotesdisplayRefcodespan"></a><span class='synopsis'><code>notes.displayRef</code></span> </dt>
 <dd>


### PR DESCRIPTION
## Summary

- Fix a typo in the French translation: "STRATÉGIES DE FUSION DE **NITES**" → "STRATÉGIES DE FUSION DE **NOTES**" across 6 files (3 HTML docs for git-notes, git-log, git-config + 3 asciidoc sources).

## Test plan

- [x] Verified all 6 occurrences have been corrected
- [ ] Visual check on rendered French documentation pages

Assisted-by: Claude:claude-opus-4-6