### PR TITLE
asciidoctor-extensions: fix synopsis parser dropping leading single quotes

### DIFF
--- a/script/asciidoctor-extensions.rb
+++ b/script/asciidoctor-extensions.rb
@@ -21,7 +21,7 @@ module Git
       rule(:opt_or_alt) { match('[\[\] |()]') >> space? }
       rule(:ellipsis) { str('...') >> match('\]|$').present? }
       rule(:grammar) { opt_or_alt | ellipsis }
-      rule(:ignore) { match('[\'`]') }
+      rule(:ignore) { str('`') }
 
       rule(:token) do
         grammar.as(:grammar) | placeholder.as(:placeholder) | space.as(:space) |


### PR DESCRIPTION
## Changes

<!-- List the changes this PR makes. -->

- asciidoctor-extensions: fix synopsis parser dropping leading single quotes

## Context

<!-- Explain why you're making these changes. -->

The `ignore` rule in AdocSynopsisQuote strips both backticks and single quotes, but the `keyword` rule treats single quotes as part of keywords. Therefore, the parser drops leading single quotes that appear first in a token, and preserves those at the end of a token, which is not intended nor consistent. This results in missing single quotes in some places, including but not limited to:
- https://git-scm.com/docs/git#Documentation/git.txt-GITLITERALPATHSPECS
- https://git-scm.com/docs/git-branch#Documentation/git-branch.txt--l
- https://git-scm.com/docs/git-config#Documentation/git-config.txt-corealternateRefsCommand

Single quotes are legitimate shell-quoting characters, so only backticks should be ignored. With this change, since single quotes are already in the keyword character class, they now pass through correctly as part of keyword tokens.

Fixes missing leading single quotes in various documentation pages, including the following and their versioned counterparts:

    external/docs/content/docs/CodingGuidelines.html              | 2 +-
    external/docs/content/docs/api-parse-options.html             | 2 +-
    external/docs/content/docs/git-branch.html                    | 2 +-
    external/docs/content/docs/git-cat-file.html                  | 2 +-
    external/docs/content/docs/git-config.html                    | 2 +-
    external/docs/content/docs/git-diff-tree.html                 | 4 ++--
    external/docs/content/docs/git-format-patch.html              | 2 +-
    external/docs/content/docs/git-grep.html                      | 2 +-
    external/docs/content/docs/git-log.html                       | 6 +++---
    external/docs/content/docs/git-ls-tree.html                   | 2 +-
    external/docs/content/docs/git-push.html                      | 2 +-
    external/docs/content/docs/git-rev-list.html                  | 6 +++---
    external/docs/content/docs/git-rm.html                        | 2 +-
    external/docs/content/docs/git-show.html                      | 4 ++--
    external/docs/content/docs/git-tag.html                       | 2 +-
    external/docs/content/docs/git.html                           | 2 +-
    external/docs/content/docs/pretty-formats.html                | 4 ++--
    external/docs/content/docs/reftable.html                      | 6 +++---

CC @jnavila (author of https://github.com/git/git-scm.com/pull/1921)