### PR TITLE
script: also prune stale `data.json` language entries when removing orphans

### DIFF
--- a/script/update-docs.rb
+++ b/script/update-docs.rb
@@ -385,10 +385,11 @@ def index_l10n_doc(filter_tags, doc_list, get_content)
     end
   end
 
-  # Clean up orphaned translated outputs whose upstream source has gone away.
-  # Skipped entirely when no source was iterated (e.g. when the early `next if
-  # !rerun && l10n["committed"] >= ts` short-circuits the whole tag loop) so
-  # that an "everything is up to date" run never deletes anything.
+  # Clean up orphan translated outputs and the matching `data.json` entries
+  # whose upstream source has gone away. Skipped entirely when no source was
+  # iterated (e.g. when the early `next if !rerun && l10n["committed"] >= ts`
+  # short-circuits the whole tag loop) so that an "everything is up to date"
+  # run never deletes anything.
   unless seen_translations.empty?
     Dir.glob("#{SITE_ROOT}external/docs/content/docs/*/*.html").each do |output_path|
       m = output_path.match(%r{/external/docs/content/docs/([^/]+)/([^/]+)\.html\z})
@@ -406,6 +407,22 @@ def index_l10n_doc(filter_tags, doc_list, get_content)
       next if File.read(output_path, 256).include?("\nredirect_to:")
       puts "Removing orphan translation #{output_path}"
       File.delete(output_path)
+    end
+
+    # `layouts/partials/ref/languages.html` iterates
+    # `data.pages.<docname>.languages` on every English manual page to build
+    # the per-page language picker, so a stale entry here generates a dead
+    # link from every variant of every English page (including each
+    # versioned `/docs/<docname>/<version>.html` slice). Prune symmetrically
+    # with the file-deletion loop above.
+    data["pages"].each do |docname, page_data|
+      next unless page_data.is_a?(Hash)
+      langs = page_data["languages"]
+      next unless langs.is_a?(Hash)
+      langs.keys.reject { |lang| seen_translations.include?([docname, lang]) }.each do |lang|
+        puts "Removing orphan language entry data.pages.#{docname}.languages.#{lang}"
+        langs.delete(lang)
+      end
     end
   end
 


### PR DESCRIPTION
Follow-up to #2165. That PR removed orphaned translated manual page files and applied a matching cleanup of `external/docs/data/docs.json` by hand. This commit teaches `script/update-docs.rb` to do the same pruning automatically going forward, so the next time upstream `jnavila/git-html-l10n` drops a translated source, the next regeneration run will also remove the matching `data.pages.<docname>.languages.<lang>` entry instead of leaving it behind to feed the per-page language picker in `layouts/partials/ref/languages.html` with dead links.

Verified locally by seeding a fake orphan output file plus two stale `data.json` entries (one on a fake docname, one as an `xx_FAKE` extra language on the real `git-clone` page), running `RERUN=true bundle exec ruby script/update-docs.rb <git-html-l10n-clone> l10n`, and confirming the script logged

```
Removing orphan translation .../git-thisdocdoesnotexist/de.html
Removing orphan language entry data.pages.git-clone.languages.xx_FAKE
Removing orphan language entry data.pages.git-thisdocdoesnotexist.languages.de
```

while leaving all 768 pre-existing redirect-stub files and the real `git-clone` translations (es, fr, ru, sv, uk, zh_HANS-CN) untouched.