### PR TITLE
Fix mobile overflow on install tabs

### DIFF
--- a/assets/sass/install.scss
+++ b/assets/sass/install.scss
@@ -41,10 +41,15 @@
   }
 
   @media (max-width: $mobile-m) {
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+
     a[role="tab"] {
+      flex: 0 0 auto;
       padding: .5rem;
       line-height: 1.2em;
       display: flex;
+      white-space: nowrap;
 
       span {
         margin: auto;


### PR DESCRIPTION
## Summary
- allow the install tab bar to scroll horizontally on small screens
- prevent individual tabs from shrinking into clipped widths on mobile

## Why
Fixes #2106. The install tabs are rendered as a single flex row, but the mobile styles did not provide overflow handling for the long "Build from Source" label.

## Validation
- `git diff --check`
- inspected the generated diff for the install tabs stylesheet

## Notes
- I did not run a local Hugo render in this environment because the required `hugo` extended binary was not installed.