### PR TITLE
book deploy: retry the flaky redirect check, and upload the Playwright report on failure

### DIFF
--- a/.github/actions/deploy-to-github-pages/action.yml
+++ b/.github/actions/deploy-to-github-pages/action.yml
@@ -298,7 +298,9 @@ runs:
         PLAYWRIGHT_TEST_URL: ${{ env.base_url }}
         # avoid test failures when HTTPS is enforced half-way through
         PLAYWRIGHT_EXTERNAL_HTTPS: ${{ inputs.external-https }}
-      run: npx playwright test --project=chrome
+      run: |
+        echo "result=$PLAYWRIGHT_TEST_URL" >>$GITHUB_OUTPUT &&
+        npx playwright test --project=chrome
     - uses: actions/upload-artifact@v7
       if: always() && steps.playwright.outputs.result != ''
       with:

--- a/tests/git-scm.spec.js
+++ b/tests/git-scm.spec.js
@@ -23,6 +23,23 @@ test.afterEach(async ({ page }, testInfo) => {
 
 if (process.platform === 'win32') test.setTimeout(60_000) // give it some time
 
+// Navigating to a page that immediately redirects elsewhere via
+// `<meta http-equiv="refresh" content="0; url=...">` occasionally races with
+// Chrome's navigation handling: the in-flight load is aborted and the page is
+// left stranded on the internal error page `chrome-error://chromewebdata/`.
+// As that is a committed navigation, merely polling for the target URL cannot
+// recover from it, the navigation has to be re-triggered. This is a known,
+// transient Playwright/Chromium issue (see e.g.
+// https://github.com/microsoft/playwright/issues/19161), so retry the whole
+// navigate-and-assert dance until the expected URL is reached.
+async function gotoAndExpectRedirect(page, gotoURL, expectedURL) {
+  await expect(async () => {
+    await page.goto(gotoURL)
+    await expect(page).toHaveURL(expectedURL)
+    // Retry every second for up to 15 seconds in total
+  }).toPass({ intervals: [1_000], timeout: 15_000 });
+}
+
 test('generator is Hugo', async ({page}) => {
   await page.goto(url)
   await expect(page.locator('meta[name="generator"]')).toHaveAttribute('content', /^Hugo /)
@@ -189,11 +206,9 @@ test('anchor links in manual pages', async ({ page }) => {
 })
 
 test('book', async ({ page }) => {
-  await page.goto(`${url}book/`)
-  await expect(page).toHaveURL(`${url}book/en/v2`)
+  await gotoAndExpectRedirect(page, `${url}book/`, `${url}book/en/v2`)
 
-  await page.goto(`${url}book`)
-  await expect(page).toHaveURL(`${url}book/en/v2`)
+  await gotoAndExpectRedirect(page, `${url}book`, `${url}book/en/v2`)
 
   // the repository URL is correct
   await expect(page.getByRole('link', { name: 'hosted on GitHub' }))


### PR DESCRIPTION
The scheduled `update-book.yml` workflow rebuilds the ProGit book and, in its `push-updates` job, deploys to GitHub Pages through the `deploy-to-github-pages` composite Action, which runs the Playwright smoke tests against the freshly deployed site. A [recent scheduled run](https://github.com/git/git-scm.com/actions/runs/28149818103) failed there, and the failure was needlessly hard to diagnose because, unlike the pull-request workflow in `ci.yml`, the deploy Action never uploaded the Playwright report that embeds the failure screenshots.

The first commit closes that observability gap. The report's `upload-artifact` step is guarded by `if: always() && steps.playwright.outputs.result != ''`, but the Playwright step in the Action never wrote anything to `$GITHUB_OUTPUT`, so the guard was always false and the report was silently dropped. The PR workflow avoids this by writing `result=$PLAYWRIGHT_TEST_URL` before running the tests; this mirrors that, so the deploy job now leaves the report behind on failure.

The second commit fixes the failure itself. The `book` test navigates to `/book/` and expects to land on `/book/en/v2`, but that redirect is purely client-side: Hugo emits `/book/index.html` as a stub whose only content is `<meta http-equiv="refresh" content="0; url=../book/en/v2">`. When that zero-delay refresh fires, Chrome occasionally aborts the load that `page.goto()` started and strands the page on its internal error page, `chrome-error://chromewebdata/`. Because that is a committed navigation, the existing `expect(page).toHaveURL(...)`, which only polls the URL, can never recover. This is a [known transient Playwright/Chromium issue](https://github.com/microsoft/playwright/issues/19161). The fix wraps the navigate-and-assert in `expect(async () => { ... }).toPass()`, which re-triggers the navigation until the expected URL is reached.

In the interest of full disclosure: the `chrome-error` is a live-network race that does not reproduce against a local `localhost` build, so I could not exercise it directly. The refactor was verified only to not regress the normal pass, by running the full suite against a local Hugo build before and after the change with identical results.
