### PR TITLE
Fix squash command in cheat sheet (HEAD~6 → HEAD~5)

### DIFF
--- a/content/cheat-sheet/_index.html
+++ b/content/cheat-sheet/_index.html
@@ -244,7 +244,7 @@ headings:
     </div>
     <div class="item">
       <h3>Squash the last 5 commits into one:</h3>
-      <code>git rebase -i HEAD~6</code>
+      <code>git rebase -i HEAD~5</code>
       <p>Then change "pick" to "fixup" for any commit you want to combine with the previous one</p>
     </div>
     <div class="item">


### PR DESCRIPTION
## Changes

- Fixed the squash example in the cheat sheet: `git rebase -i HEAD~6` → `git rebase -i HEAD~5`

## Context

Hi there, I'm learning Git and found this while playing around in my terminal.

The heading says "Squash the last 5 commits into one," but the command used `git rebase -i HEAD~6`, which lists 6 commits instead of 5. In a repo with only 6 total commits, this actually throws `fatal: invalid upstream 'HEAD~6'`, since there's no commit further back than the root.

Changed it to `HEAD~5` to match the heading and the actual number of commits being squashed.