### PR TITLE
Move pt-br book translation to Full translations

### DIFF
--- a/layouts/partials/translations.html
+++ b/layouts/partials/translations.html
@@ -20,6 +20,7 @@ This book is available in
     <tr><td><a href="{{ partial "translated-chapter.html" (dict "ctx" . "lang" "ja") }}">日本語</a>,</td></tr>
     <tr><td><a href="{{ partial "translated-chapter.html" (dict "ctx" . "lang" "ko") }}">한국어</a>,</td></tr>
     <tr><td><a href="{{ partial "translated-chapter.html" (dict "ctx" . "lang" "nl") }}">Nederlands</a>,</td></tr>
+    <tr><td><a href="{{ partial "translated-chapter.html" (dict "ctx" . "lang" "pt-br") }}">Português (Brasil)</a>,</td></tr>
     <tr><td><a href="{{ partial "translated-chapter.html" (dict "ctx" . "lang" "ru") }}">Русский</a>,</td></tr>
     <tr><td><a href="{{ partial "translated-chapter.html" (dict "ctx" . "lang" "sl") }}">Slovenščina</a>,</td></tr>
     <tr><td><a href="{{ partial "translated-chapter.html" (dict "ctx" . "lang" "sr") }}">Српски</a>,</td></tr>
@@ -36,7 +37,6 @@ This book is available in
     <tr><td><a href="{{ partial "translated-chapter.html" (dict "ctx" . "lang" "cs") }}">Čeština</a>,</td></tr>
     <tr><td><a href="{{ partial "translated-chapter.html" (dict "ctx" . "lang" "mk") }}">Македонски</a>,</td></tr>
     <tr><td><a href="{{ partial "translated-chapter.html" (dict "ctx" . "lang" "pl") }}">Polski</a>,</td></tr>
-    <tr><td><a href="{{ partial "translated-chapter.html" (dict "ctx" . "lang" "pt-br") }}">Português (Brasil)</a>,</td></tr>
     <tr><td><a href="{{ partial "translated-chapter.html" (dict "ctx" . "lang" "uz") }}">Ўзбекча</a>,</td></tr>
     <tr><td><a href="{{ partial "translated-chapter.html" (dict "ctx" . "lang" "zh-tw") }}">繁體中文</a>,</td></tr>
   </table>


### PR DESCRIPTION
This PR moves the `pt-br` (Brazilian Portuguese) language from the "Partial translations" list to the "Full translation" list on the website's sidebar.

The translation of the book has been successfully completed. For reference and evidence of the completion, please see the recently merged PR in the translation repository: https://github.com/progit/progit2-pt-br/pull/145.

Additionally, as someone who has been actively involved in finishing this translation effort, I want to mention that I'll be around to help keep the Brazilian Portuguese version up to date and assist with any future maintenance, reviews, or issues that arise in the `progit2-pt-br` repository (related discussion: https://github.com/progit/progit2-pt-br/issues/130).

Thank you for your time and for maintaining this project!